### PR TITLE
Standardize object keys across locales

### DIFF
--- a/utils/data/import/generate-json.js
+++ b/utils/data/import/generate-json.js
@@ -82,12 +82,14 @@ function generateJSONFiles(data, englishHeader) {
         const termKey = englishTerm.toLowerCase().replace(/\s+/g, '-');
         localeData.terms[termKey] = {
           "term": translatedTerm,
-          "phonetic": "",
           "partOfSpeech": "",
-          "definition": "",
           "termCategory": "",
-          "source": "",
-          "datefirstseen": ""
+          "phonetic": "",
+          "definition": "",
+          "extended": "",
+          "termSource": "",
+          "dateFirstRecorded": "",
+          "commentary": "",
         };
       } else {
         console.warn(`Warning: Found an undefined term in row: ${JSON.stringify(row)}`);


### PR DESCRIPTION
The script that is used to generate the `./locales/*` directories, aka the files that list all the terms and their associated info, is `./utils/data/import/generate-json.js`. 

This PR:

- Updates the list, and order, of the "fields", aka "key value pairs", associated with each term object, so that they're the same across all locales, and are an attempt at building the groundwork for future features, e.g. community discussions and API functionality:

```javascript
    // Process each row in the CSV
    data.forEach(row => {
      const englishTerm = row[englishHeader]; // English term is the key in the JSON structure
      const translatedTerm = row[locale] || englishTerm; // Use translation if available, otherwise use the English term

      if (englishTerm) {
        const termKey = englishTerm.toLowerCase().replace(/\s+/g, '-');
        localeData.terms[termKey] = {
          "term": translatedTerm,
          "partOfSpeech": "",
          "termCategory": "",
          "phonetic": "",
          "definition": "",
          "extended": "",
          "termSource": "",
          "dateFirstRecorded": "",
          "commentary": "",
        };
      } else {
        console.warn(`Warning: Found an undefined term in row: ${JSON.stringify(row)}`);
      }
    });
``` 

I also corrected a few terms in NL and RU, which had `/` in their names; this results in a page not being made for those terms, as that's not a valid path in this setup. That will re-occur until we sanitize the underlying .CSVs, but I just wanted to do it. :shrug: 