### PR TITLE
README: align some information from old version, move lots of detail elsewhere

### DIFF
--- a/.github/ISSUE_TEMPLATE/term_request.md
+++ b/.github/ISSUE_TEMPLATE/term_request.md
@@ -1,5 +1,5 @@
 ---
-name: 1. Term Addition/Modification
+name: 1. Term addition or modification
 about: Suggest a new term or modify an existing one
 title: '[TERM] - '
 labels: content

--- a/.github/legacy/template-backup.md
+++ b/.github/legacy/template-backup.md
@@ -1,0 +1,45 @@
+---
+name: 'Add or modify a term '
+about: 'Make a suggestion to add or improve a term''s entry '
+title: "[SUBMISSION]"
+labels: ''
+assignees: ''
+
+---
+
+You can make your suggestion in writing, ie "narrative" form here, like: 
+
+"We should add the term 'stonks' because everybody in Discord says it. The definition should be "A meme meaning the value of something is good. Or bad."
+
+Or you can submit an entry using the JSON format in which each term record is saved: 
+
+```
+    "0x-api": {
+      "term": "0x API",
+      "partOfSpeech": "noun",
+      "termCategory": "",
+      "phonetic": "/ˌzɪroʊ ˈɛks ˈeɪ.pi.aɪ/",
+      "definition": "The 0x API is the liquidity and data endpoint for DeFi. It lets you access aggregated liquidity from tens of on-chain and off-chain decentralized exchange networks, across multiple blockchains. It comes with many parameters to customize your requests for your application and your users.",
+      "definitionSource": "",
+      "sampleSentence": "",
+      "extended": "",
+      "termSource": "",
+      "dateFirstRecorded": "",
+      "commentary": ""
+    },
+
+```
+
+    "0x-api": { `this is a sanitized version of the term, that will appear as a URL`
+      "term": "0x API", `this is the term itself`
+      "partOfSpeech": "noun", `what grammatical category is it?`
+      "termCategory": "", `is it web3? Web2? Memes?`
+      "phonetic": "/ˌzɪroʊ ˈɛks ˈeɪ.pi.aɪ/", `an IPA pronunciation`
+      "definition": "The 0x API is the liquidity and data endpoint for DeFi. It lets you access aggregated liquidity from tens of on-chain and off-chain decentralized exchange networks, across multiple blockchains. It comes with many parameters to customize your requests for your application and your users.", `The definition of the term. This should be one to two sentences, and don't use the term in its own definition.`
+      "definitionSource": "", `Who wrote this definition?`
+      "sampleSentence": "", `Can you use it in a sentence?`
+      "extended": "", `Is there more to say? Back story? Multiple uses? Debate?`
+      "termSource": "", `Know who coined the term? Did it come from a specific website or account?`
+      "dateFirstRecorded": "", `Date of submission here`
+      "commentary": "" `If there is active debate, room for doubt, a topic under development, this is the place for explanations!`
+    },

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,57 @@
+name: Deploy to GH Pages
+
+on:
+  push:
+    branches:
+      - main # Replace with your branch name if different
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    # Step 1: Checkout the repository
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    # Step 2: Set up Node.js
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: 21
+
+    # Step 3: Install dependencies and build the project
+    - name: Install dependencies and buildg
+      run: |
+        npm ci
+        npm run build
+
+    # upload as artifact
+    - name: Upload static files as artifact
+      id: deployment
+      uses: actions/upload-pages-artifact@v3 # or specific "vX.X.X" version tag for this action
+      with:
+        path: ./build
+
+
+  # Deploy job
+  deploy:
+    # Add a dependency to the build job
+    needs: build
+
+    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
+    permissions:
+      pages: write      # to deploy to Pages
+      id-token: write   # to verify the deployment originates from an appropriate source
+
+    # Deploy to the github-pages environment
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    # Specify runner + deployment step
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4 # or specific "vX.X.X" version tag for this action

--- a/README.md
+++ b/README.md
@@ -7,10 +7,15 @@ A multilingual glossary for web3, crypto, and decentralized web terminology, dep
 
 > If the canonical URL isn't working, try the [IPNS hash](https://ipfs.io/ipns/k51qzi5uqu5dik032y8x6pgcprlg8t42dy521tnnqiomgxauyt3u2z6j5x60r1/english-us/index.html).
 
+## Overview
+
+wordsofweb3 is a collaborative project by [Education DAO](https://educationdao.xyz/) that aims to create a credibly neutral, living record of web3 and decentralized web tech terminology. 
+
+The project supports multiple languages and provides an intertextual experience where terms link to related concepts.
+
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-- [Overview](#overview)
 - [Design Philosophy](#design-philosophy)
 - [Features](#features)
 - [Supported Languages](#supported-languages)
@@ -37,12 +42,6 @@ A multilingual glossary for web3, crypto, and decentralized web terminology, dep
 - [Contact](#contact)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
-
-## Overview
-
-wordsofweb3 is a collaborative project by [Education DAO](https://educationdao.xyz/) that aims to create a credibly neutral, living record of web3 and decentralized web tech terminology. 
-
-The project supports multiple languages and provides an intertextual experience where terms link to related concepts.
 
 ## Design Philosophy
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,12 @@ This app is meant to be _for the ages_. We follow these core principles:
 - Português Brasileiro (Brazilian Portuguese)
 - Limba Română (Romanian)
 - Русские (Russian)
-- 
+- Español de América Latina (Latin American Spanish)
+- Tagalog (Filipino)
+- ไทย (Thai)
+- Türkçe (Turkish)
+- Українська (Ukrainian)
+- Tiếng-việt (Vietnamese)
 
 </details>
 
@@ -106,6 +111,13 @@ This app is meant to be _for the ages_. We follow these core principles:
 bash
 git clone https://github.com/mapachurro/wordsofweb3.git
 cd wordsofweb3
+nvm use
+```
+If necessary, based on console output, run `nvm install`
+
+Once the correct version of node is installed, run:
+
+```bash
 npm install
 ```
 
@@ -113,7 +125,7 @@ npm install
 
 1. **Module System**
    - Use ES Module syntax throughout
-   - No CommonJS `require()` statements
+    - No CommonJS `require()` statements
 
 2. **Error Handling**
    - Include graceful failures
@@ -123,6 +135,8 @@ npm install
 3. **Custom Solutions**
    - Prefer custom scripts over npm packages
    - Maintain minimal dependencies
+
+**Note**: *Currently, this project does not bundle any JS into the client side. It outputs static JS files for specific pages only.*
 
 ## Project Architecture
 
@@ -152,6 +166,8 @@ npm install
 3. Intertextual links created
 4. Search indices built
 
+See [the build script](./utils/build.js) for more detail.
+
 ## Search Functionality
 
 The search system provides:
@@ -160,6 +176,9 @@ The search system provides:
 - Definition matches
 - Partial matches
 - Language-specific search indices
+
+The search results are drawn from indices made during the build process.
+They will be located in each locale's built directory, under the file name `directoryContents.json`.
 
 ## Visual Identity
 
@@ -191,7 +210,6 @@ We welcome contributions! See our [Contributing Guide](CONTRIBUTING.md) for:
 npm run build
 ```
 
-
 This will:
 1. Generate homepages
 2. Build term pages
@@ -199,20 +217,34 @@ This will:
 4. Generate search indices
 5. Copy static assets
 
+For a detailed, if not always up to date, walkthrough of data importation and site build processes, see [the build README](./utils/BUILD-README.md).
+
 ### Testing
 
 Before deployment:
 
-1. Test on local server
+1. [Test on local server](#test-on-local-server)
 2. Verify language switching
 3. Check search functionality
 4. Validate intertextual links
 
+#### Test on local server
+
+Once you've installed this project, you can simply run:
+
+```bash
+- npm run build
+- npm run start
+```
+and you will have the site running locally at `localhost:8080`.
+
 ## Deployment
 
-- Primary: IPFS via Fleek.xyz
-- ENS: wordsofweb3.eth
-- Access: wordsofweb3.eth.limo
+The site is currently deployed using a combination of two web3 technologies:
+
+- Site builds uploaded to IPFS, and domain routed to that content hash, via [Fleek](https://fleek.xyz)
+- [ENS](https://ens.domains) is used to create  the `wordsofweb3.eth` name
+- ENS' 'limo' routing service integrates with Fleek to allow the site to **be accessible at [wordsofweb3.eth.limo](https://wordsofweb3.eth.limo)**.
 
 ## Future Plans
 

--- a/README.md
+++ b/README.md
@@ -7,27 +7,59 @@ A multilingual glossary for web3, crypto, and decentralized web terminology, dep
 
 > If the canonical URL isn't working, try the [IPNS hash](https://ipfs.io/ipns/k51qzi5uqu5dik032y8x6pgcprlg8t42dy521tnnqiomgxauyt3u2z6j5x60r1/english-us/index.html).
 
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [Overview](#overview)
+- [Design Philosophy](#design-philosophy)
+- [Features](#features)
+- [Supported Languages](#supported-languages)
+- [Getting Started](#getting-started)
+  - [Prerequisites](#prerequisites)
+  - [Installation](#installation)
+  - [Technical Conventions](#technical-conventions)
+- [Project Architecture](#project-architecture)
+  - [Directory Structure](#directory-structure)
+  - [Data Management](#data-management)
+    - [CSV Files](#csv-files)
+    - [Build Process](#build-process)
+- [Search Functionality](#search-functionality)
+- [Visual Identity](#visual-identity)
+  - [Color Palette](#color-palette)
+- [Contributing](#contributing)
+- [Development](#development)
+  - [Building the Project](#building-the-project)
+  - [Testing](#testing)
+- [Deployment](#deployment)
+- [Future Plans](#future-plans)
+- [License](#license)
+- [Contact](#contact)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 ## Overview
 
-wordsofweb3 is a collaborative project by [Education DAO](https://educationdao.xyz/) that aims to create a credibly neutral, living record of web3 terminology. The project supports multiple languages and provides an intertextual experience where terms link to related concepts.
+wordsofweb3 is a collaborative project by [Education DAO](https://educationdao.xyz/) that aims to create a credibly neutral, living record of web3 and decentralized web tech terminology. 
+
+The project supports multiple languages and provides an intertextual experience where terms link to related concepts.
 
 ## Design Philosophy
 
 This app is meant to be _for the ages_. We follow these core principles:
 
-- **Longevity**: Built to sometimes break(but never fail, like every other durable thing out there), using the simplest possible solutions
+- **Longevity**: Built to sometimes break (but never fail, like every other durable thing out there), using the simplest possible solutions
 - **Accessibility**: Available to the widest possible audience
 - **Decentralization**: Deployed on [IPFS](https://ipfs.tech/) for permanent availability
 - **Simplicity**: Minimal dependencies, custom solutions over external packages
-- **Language Neutrality**: Working towards a language-agnostic approach
+- **Language neutrality**: Working towards a human language-agnostic design.
 
 ## Features
 
-- **Multilingual Support**: Available in 28+ languages
-- **Intertextual Experience**: Terms link to related concepts within definitions
-- **Search Functionality**: Easy term lookup across all supported languages
-- **Static Generation**: All pages built at compile time for reliability
-- **Decentralized Storage**: Deployed on IPFS via [Fleek]((https://fleek.xyz/))
+- **Multilingual support**: Available in 28+ languages
+- **Intertextual experience**: Terms link to related concepts within definitions
+- **Search functionality**: Easy term lookup across all supported languages
+- **Static generation**: All pages built at compile time for reliability
+- **Decentralized storage**: Deployed on IPFS via [Fleek]((https://fleek.xyz/)); working towards multiple fallbacks, e.g. Arweave, GH Pages, etc.
 
 ## Supported Languages
 
@@ -42,11 +74,22 @@ This app is meant to be _for the ages_. We follow these core principles:
 - Français (French)
 - Deutsch (German)
 - Eλληνικά (Greek)
+- Hausa
 - हिन्दी (Hindi)
 - 日本語 (Japanese)
 - 한국어 (Korean)
-- Español (Latin America)
-- And many more...
+- Español de (Latin America)
+- Magyar (Hungarian)
+- Bahasa Indonesia (Indonesian)
+- Italiano (Italian)
+- فارسی (Persian)
+- Bahasa Melayu (Malaysian)
+- Pidgin (Nigerian Pidgin)
+- Polski (Polish)
+- Português Brasileiro (Brazilian Portuguese)
+- Limba Română (Romanian)
+- Русские (Russian)
+- 
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ A multilingual glossary for web3, crypto, and decentralized web terminology, dep
 - [Development](#development)
   - [Building the Project](#building-the-project)
   - [Testing](#testing)
+    - [Test on local server](#test-on-local-server)
 - [Deployment](#deployment)
 - [Future Plans](#future-plans)
 - [License](#license)

--- a/compreadme.md
+++ b/compreadme.md
@@ -1,0 +1,442 @@
+# Welcome!
+
+This repo is the backend for [the `wordsofweb3.eth` glossary](https://wordsofweb3.eth.limo), from [Education DAO](https://educationdao.xyz/).
+
+If the canonical URL isn't working, at `wordsofweb3.eth.limo`, try loading this IPNS hash: [https://ipfs.io/ipns/k51qzi5uqu5dik032y8x6pgcprlg8t42dy521tnnqiomgxauyt3u2z6j5x60r1/english-us/index.html](https://ipfs.io/ipns/k51qzi5uqu5dik032y8x6pgcprlg8t42dy521tnnqiomgxauyt3u2z6j5x60r1/english-us/index.html)
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+**Table of Contents** _generated with [DocToc](https://github.com/thlorenz/doctoc)_
+
+- [wordsofweb3](#wordsofweb3)
+- [wordsofweb3: Architecture](#wordsofweb3-architecture)
+  - [Design principles](#design-principles)
+  - [Implementation implications](#implementation-implications)
+    - [Creating the homepages](#creating-the-homepages)
+      - [The Navbar and language switching](#the-navbar-and-language-switching)
+    - [Creating the glossary entries](#creating-the-glossary-entries)
+      - [`ext-sync-terms.csv`:](#ext-sync-termscsv)
+    - [`app-side-glossary.csv`](#app-side-glossarycsv)
+    - [Moving the information from .json to HTML](#moving-the-information-from-json-to-html)
+    - [Paths and slugs](#paths-and-slugs)
+  - [Creating the connections between the `definitions`](#creating-the-connections-between-the-definitions)
+    - [Matching](#matching)
+- [Overall site / `build` directory structure](#overall-site--build-directory-structure)
+  - [Navbar / top-level link structure](#navbar--top-level-link-structure)
+- [Search](#search)
+- [Build](#build)
+  - [`build.js`](#buildjs)
+- [Deployment](#deployment)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+# Contributions
+
+wordsofweb3 is meant to be a place where we all, collectively, can create a `credibly neutral`, living record of _what words mean_. The hope is that if we can agree on some definitions, we can begin to agree on reality a little bit more.
+
+**Would you like to contribute**? Is a word's definition wrong? Should the term be in camel case? Have we failed to document a very important concept??
+
+CORRECTIONS ARE THE WAY WE MAKE THIS GOOD.
+
+## For the moment, please feel free to [create an issue in this repo](https://github.com/mapachurro/wordsofweb3/issues).
+
+We are working on creating an attestation-based contribution flow / frontend for the app. Stay tuned!
+
+# wordsofweb3: Architecture
+
+wordsofweb3 is a multilingual glossary app encompassing terms and explanations about crypto, web3, and decentralized web, in general, terms, concepts, and entities.
+
+It is meant to be an intertextual experience for the reader: in every `term`'s definition, whenever there is a term or phrase that is _also_ a `term` in the glossary in that language, there will be a hyperlink to that term.
+Ideally, there will be a `breadcrumbs` element at the top of each entry page, tracking the user's journey through the interwoven terminology of this space.
+
+## Design principles
+
+This app is meant to be _for the ages_. The idea is that it _will never break_. It is designed to be deployed on decentralized storage networks, such as IPFS, which sometimes experience high latency; additionally, this technology should be accessible by the widest possible audience.
+
+For these reasons, at every point at which we can choose "how to do X", we should choose the dumbest, most low-tech way possible.
+
+This means that if you're installing an npm package, or importing a CDN, you might be doing it wrong.
+
+### Conventions
+
+We use ES Module syntax in wordsofweb3, so make sure any functionality uses this design paradigm. Additionally, please add graceful failures and error handling, and console logging, in any scripts you build or modify!
+
+## Implementation implications
+
+Yes, this means custom scripting; but anyone that tells you that an npm package or open source project will require _less_ maintenance than custom scripts that do what you want, well, wish them the best of luck with that.
+
+## Languages
+
+Currently, we have definitions in the following languages:
+
+```txt
+العربية
+中文-简体(简体)
+中文-繁體(繁體)
+nederlands
+français
+deutsch
+eλληνικά
+english-us (United States)
+hausa
+हिन्दी
+magyar
+bahasa-indonesia
+italiano
+日本語
+한국어
+فارسی
+bahasa-melayu
+pidgin
+polski
+português-brasil
+românăână
+русский
+español-latinoamérica
+tagaloga
+ไทย
+türkçe
+українська
+tiếng-việt
+```
+
+# Components of the site: data processing and build
+
+## Homepages
+
+As a fully internationalized app, the site will actually have multiple potential versions of its homepage.
+
+This means there is an `index.html` page in the root directory `./`, as well as an index.html page in each of the locale directories, e.g. `./nederlands/index.html`.
+
+The root index file, upon load, _should_ detect the user's browser locale, and direct them to the correct `./<locale>/index.html` file.
+If there doesn't seem to be an appropriate locale for the user, the root index file should show a welcome message, display all available locales and allow the user to choose one.
+
+*Note: the above functionality probably has a bad impact on SEO, and we should consider disabling it.*
+
+These homepages are created by `build-homepages.js`, which runs during the build process.
+This script ingests `index-template.html`, and applies UI translation strings found in `./locales<four-letter-dash-locale-code>/translation.json` to the elements that need to contain human-readable information.
+
+### The Navbar and language switching
+
+The language dropdown selector on this site is much dumber than many that are out there.
+
+Currently, **it only does one thing: takes you to the homepage of whatever language you select.**
+
+Ideally, it would also switch between languages for the term page you're on.
+
+## Creating the glossary entries
+
+Similarly to the "template" format of the homepage, each `term`'s `entry page` will be generated **on the build side of the app; nothing will be created "generatively" on the reader's side.**
+
+We currently are bringing new terms into the glossary though a kind of rough pipeline, housed in [./utils/data/import](./utils/data/import), using CSV files, which are more human-readable, to manage and update the content, then process into .json formatted for the rest of the site generation pipeline.
+
+There are two CSV files we use in particular, `all-terms.csv`, and `english-terms.csv`. `all-terms` is the **canonical source of truth for what terms are in the glossary, and what their equivalents are across languages**.
+
+To emphasize the importance of this: **The .json files that are created from this spreadsheet use the English term as the "object key" for that term in each additional language. This allows for functionality such as establishing equivalents across languages, obviously crucial for the project. *the structure of the .json created from this spreadsheet, therefore, must be the same across all languages*, and is a common source of issues, e.g. "why are there no terms loading in X language"**
+
+`english-terms.csv` is imported because the author(s) of this glossary primarily work in English, and are updating definitions in English. 
+
+**This process, overall, should be changed to be language-agnostic.**
+
+**An alternate "term key" system which does not place English as the canonical "source of truth" would be in line with the spirit of this project. Currently, that is a "nice to have". If it becomes a "must do", that's a good problem to have, because it will mean this project is very successful.
+
+More details about these files: 
+
+### `all-terms.csv`:
+
+This .csv file is something that will be imported, from time to time, with new or updated terms in one or more languages.
+It currently houses a large number of locales; here is a sample of its structure and content:
+
+```CSV
+Term [en-US],Term [ar],Term [zh-CN],Term [zh-TW],Term [nl-NL],Term [fr],Term [de-DE],Term [el-GR],Term [ha-NG],Term [hi-IN],Term [hu-HU],Term [id-ID],Term [it-IT],Term [ja-JP],Term [ko-KR],Term [fa-AF],Term [ms-MY],Term [pcm],Term [pl-PL],Term [pt-BR],Term [ro-RO],Term [ru-RU],Term [es-419],Term [tl],Term [th-TH],Term [tr-TR],Term [uk-UA],Term [vi-VN],Term [en-GB]
+0x API,0x API,0x API,0x API,0x API,0x API,0x API,0x API,0x API,0x API,0x API,0x API,0x API,0x API,0x API,0x API,0x API,0x API,0x API,0x API,0x API,0x API,0x API,0x API,0x API,0x API,0x API,0x API,0x API
+1inch,1inch,1inch,1inch,1inch,1inch,1inch,1inch,1inch,1inch,1inch,1inch,1inch,1inch,1inch,1inch,1inch,1inch,1inch,1inch,1inch,1inch,1inch,1inch,1inch,1inch,1inch,1inch,1inch
+2FA,المصادقة الثنائية (2FA),双因素验证（2FA）,雙重要素驗證 (2FA),verificatie in twee stappen,Authentification double,2FA,Επαλήθευση δύο παραγόντων,Tabbatarwa ta Biyu,टू-फैक्टर ऑथेंटिकेशन,Kétlépcsős hitelesítés,2FA,Autenticazione a due fattori,2FA,2단계 인증,2FA,2FA,Double verification for security,2FA,2FA,2FA,двухфакторная аутентификация,autenticación de dos factores,2FA,การพิสูจน์ตัวจริงสองปัจจัย,İki Faktörlü Kimlik Doğrulaması,Двофакторна аутентифікація,2FA,2FA
+3Box Labs,3Box Labs,3Box Labs,3Box Labs,3Box Labs,3Box Labs,3Box Labs,3Box Labs,3Box Labs,3Box Labs,3Box Labs,3Box Labs,3Box Labs,3Box Labs,3Box Labs,3Box Labs,3Box Labs,3Box Labs,3Box Labs,3Box Labs,3Box Labs,3Box Labs,3Box Labs,3Box Labs,3Box Labs,3Box Labs,3Box Labs,3Box Labs,3Box Labs
+51% attack,هجوم 51٪,51%攻击,51%攻擊,51%-aanval,attaque des 51 %,51 % attacke,επίθεση του 51%,tsarin 51%,51% अटैक,51%-os támadás,51% attack,attacco del 51%,51%攻撃,51% 공격,حمله ۵۱٪,serangan 51%,Chop oga network wey pass 50%,atak 51%,ataque de 51%,atac 51%,атака 51%,ataque de 51 %,51% pag-atake,การโจมตี 51%,%51 saldırısı,aтака 51%,tấn công 51%,51% attack
+Aave,Aave,Aave,Aave,Aave,Aave,Aave,Aave,AAVE,Aave,Aave,Aave,Aave,Aave,Aave,Aave,Aave,Aave,Aave,Aave,Aave,Aave,Aave,Aave,Aave,Aave,Aave,Aave,Aave
+account,حساب,账户,帳戶,account,compte,konto,λογαριασμός,asusu,अकाउंट,fiók,akun,account,アカウント,계정,حساب,akaun,akaunt,konto,conta,cont,счет,cuenta,account,บัญชี,hesap,oбліковий запис,tài khoản,account
+
+```
+
+This .csv will be processed by a script, [generate-json.js](./utils/generate-json.js). For each locale, this script:
+
+- Iterates through `./locales/<locale-code>` directories
+  - In each directory, it looks for a file, `./locales/<locale-code>/<locale-code>.json`
+    - If that file exists, it iterates through the rows of `ext-sync-terms.csv`, ensuring that:
+      - There is a `term` object for each row of that locale (each word in that language), and that
+      - There are no duplicate terms, such that building an HTML file from it would result in multiple HTML files located at the same URL path / slug.
+      - Additionally, when this script creates a new term, it uses the following structure:
+
+```json
+    "Ethereum": {
+      "term": "Ethereum",
+      "phonetic": "/ɪˈθiːriəm/",
+      "partOfSpeech": "noun",
+      "definition": "A public blockchain network and decentralized software platform upon which developers build and run applications. As it is a proper noun, it should always be capitalized.",
+      "termCategory": "project or product",
+      "source": "",
+      "datefirstseen": ""
+    },
+```
+
+This script will, essentially, only be updating the `term` field of each object.
+The name of each overarching object will be the term from the `en_US` column, whereas the `term` key's value will be populated from the corresponding locale.
+The `partOfSpeech` value has not been filled out for most terms in most languages, but should mirror that of the `en_US` locale, unless grammatically incorrect in that language.
+The `termCategory` value should also mirror `en_US`, unless subsequently changed.
+If there is no data to fill in a given value (e.g., "source"), it should be left blank at this point (`source: "",`).
+
+For example:
+
+```json
+    "Ethereum": {
+      "term": "حساب",
+      "phonetic": "",
+      "partOfSpeech": "noun",
+      "definition": "",
+      "termCategory": "project or product",
+      "source": "",
+      "datefirstseen": ""
+    },
+```
+
+### `english-terms.csv`
+
+This file, like `all-terms`, will be imported from time to time, and will include updated English terms and their definitions.
+
+
+
+## Exporting term data to CSV
+
+We need a way to export this information, and manage it, in .csv format, for less-technical people who don't want to handle .json files.
+
+The script at [`./utils/data/export/export-json.js`](./utils/data/export/export-json.js) does just this. In order to export a given language's
+data to a .CSV file, change the path to the langauge you're interested in, and run the script using nodejs, `node export-json.js`. It should
+output `glossary.csv` in that directory, which you can use as you see fit.
+
+There is a placeholder script, in [`./utils/data/export/TODO.js`](./utils/data/export/TODO.js), with aspirations for a script that does
+all languages at once. That's a TODO, for sure.
+
+
+Here is a sample of how [the current CSV file](./utils/data/import/all-terms.csv) looks:
+
+```CSV
+
+"key","term","partOfSpeech","termCategory","phonetic","definition","definitionSource","sampleSentence","extended","termSource","dateFirstRecorded","commentary"
+"51%-attack","51% attack","noun","","/ˈfɪfti wʌn pərˈsɛnt əˈtæk/","An attack, often discussed in purely theoretical terms, performed against a distributed ledger or blockchain network.   The mechanism of the attack consists of gaining control of at least half – more than 50% – of the 'nodes' or 'peers' that participate in the network's consensus mechanism, i.e., sync the current state of the ledger. By gaining control of 51% of the network, the attacker could, in theory, maliciously rewrite the ledger for their own purposes.","","","Solving for this attack vector is one of the key design decisions in the Bitcoin protocol, as well as Ethereum, and others. In the case of Bitcoin, this was solved through the Proof of Work consensus mechanism, wherein the difficulty involved in mining new blocks effectively prevents any one actor from gaining this sort of control.","Consensys Software Inc., Blockchain Glossary for Beginners","",""
+"account","account","noun","","/əˈkaʊnt/","An account, in web1 and web2 terms, refers to some sort of identity on some sort of digital platform. It is usually tied to an authentication method, e.g., username and password, which is granted, managed, and secured by the platform or service in question.   By contrast, a web3 or crypto account consists of what is known as a public-private key pair; the public half is generally safe to be shared publicly, and in the case of Ethereum, is further processed to create what is known as the 'public address' of the account, always beginning with '0x'. The private half, meanwhile, gives total control over the account; *total*.","","","These public-private key pairs can be generated one at a time, or they can be *derived* from what is known as a **seed phrase** or **secret recovery phrase**; for more on this, see HD wallet.","Many","",""
+"address","address","noun","","/ˈæd.rɛs/ ""ˈpʌblɪk ˈæd.rɛs""","On a distributed ledger or public blockchain network, an 'address', or 'public address', is an identifier that can be used to variously locate, identify, send or receive tokens to and from, different entities.","James Beck, Education DAO - mapachurro","","For example, on some networks, particularly EVM-style, every account will have an address, to which tokens could be sent. Smart contracts on those networks also have addresses, so that other contracts or protocols can interact with them. In Ethereum, the address begins with 0x; For example: 0x06A85356DCb5b307096726FB86A78c59D38e08ee","Consensys Software Inc., Blockchain Glossary for Beginners","",""
+"aggregator","aggregator","noun","","/ˈæɡrɪˌɡeɪtər/","A platform or protocol that combines real-time or quasi-real-time information regarding the availability, liquidity, price, etc., of tokens, pools, and other decentralized finance (DeFi) instruments from multiple decentralized exchanges (DEXs), or other sources, ideally to provide the best prices and the most efficient execution for their trades or other actions.","","","","","",""
+
+```
+
+## Building the term pages
+
+Once this information is in its .json files in corresponding locale folders, we can proceed to generate the site's content from it.
+
+`./utils/build-pages.js` does the following:
+
+- Ingests `template.html`
+- Looks up the list of terms in each language, in `./locales/<four-letter-dash-locale-code>/<four-letter-dash-locale-code>.json`
+  - Iterates through that .json file, and for each `term` object,
+    - Creates an .HTML file, filling in the placeholders in the HTML template with the values found in the object.
+
+The script then should save that HTML file (e.g. `cuenta.html`) in a directory which it will create (and overwrite the contents of if it already exists, to ensure the most up to date build / version) if it doesn't already exist.
+
+The script should save these **static HTML files** to:
+
+`./static/<language-slug>/<term-in-that-language>.html`
+
+There is a cross-locale mapping function present in this script, which should link a term entry in one language to its equivalent in every other in which it exists, by using the `object key` from the .json file, which should be the same for every term across all languages. It produces something like this:
+
+```markdown
+### Read this entry in:
+
+[Spanish](./path-to-entry-in-Spanish.html)
+[English](./path-to-entry-in-English.html)
+```
+
+## Paths and slugs
+
+wordsofweb3 should always prioritize human-readability over concessions to the conventions of machines, even when that sucks for technical reasons.
+
+An example of this: we do not have paths like `/es-419/cuenta.html`; no, we have `/nederlands/ethereum.html`. This does mean that, at times, we have to leverage functions available in the `l10n.js` script to convert between different formats of language codes. This script leverages a .json file which contains several different formats, at `./public/assets/language-codes.json`:
+
+```json
+{
+  "ar-001": {
+      "name": "العربية",
+      "slug": "العربية",
+      "fourLetterDash": "ar-001",
+      "fourLetterUnderscore": "ar_001",
+      "twoLetter": "ar",
+      "threeLetter": "ara",
+      "notes": "As of 2024, we have limited Arabic dialectical differentiation, so preference is to use generic code"
+  },
+  "zh-CN": {
+      "name": "中文-(简体)",
+      "slug": "中文-简体",
+      "fourLetterDash": "zh-CN",
+      "fourLetterUnderscore": "zh_CN",
+      "twoLetter": "zh",
+      "threeLetter": "zho",
+      "notes": "The alternative is to use zh-Hans and zh-Hant - which would delineate Simplified vs. Traditional without any regional association. I think for now we can stick with zh-CN and zh-TW, and perhaps expand to zh-HK if we need to."
+     
+  },
+```
+
+...and so on.
+
+## Creating the connections between the `definitions`
+
+Subsequent to the creation of the entry pages in `build-pages.js`, a second script is run (when invoked using `npm run build` and the `build.js` script): `./utils/intertextual.js` does the following:
+
+- Ingest the corresponding `./locales/<four-letter-dash-locale-code>/<four-letter-dash-locale-code>.json` file
+- Iterate over the built files for that locale in `./static/<locale-slug>/*`
+- In each HTML file within that directory, locate the `<p id="description">` tag which will have been created by `build-pages.js`
+- Search for terms or phrases which [match](#matching) a `term` key in the .json file
+- For each match, create a hyperlink to that term, following the pattern `./<term-key>.html`. Given that all the .html files will be in the same directory, this should provide for easy resolution. **terms will not be indexed across languages**.
+
+This script should have robust console logging and graceful error handling, given the number of edge cases it will present.
+It should save this output to file at `./utils/intertextual-output-<number>.txt`, increasing the number each time so that subsequent versions of the log can be checked.
+
+### Matching
+
+There is a difficult implementation detail here: `stop words`, `stems`, and `plurals`.
+
+A quality contextual search will use detailed information about the morphology of a given language to find a _good_ match, not just something that happens to match a pattern.
+One option is to leverage [lunr-languages](https://github.com/MihaiValentin/lunr-languages), which has a decent and open source (MPL) collection of such files.
+
+# Overall site / `build` directory structure
+
+```bash
+./build (once build.js has been run (npm run build))
+    index.html
+    ./js
+        search.js
+        navbar.js
+        index.js
+        l10n.js
+        explore.js
+    ./assets
+        <locale-code>-index.json` x number of locales
+    ./css
+        styles.css
+    ./images
+        `any images needed by the app`
+    favicon.ico
+    ./en-US
+        directoryContents.json
+        51%-attack.html
+        account.html
+            etc.
+    ./es-ES
+        directoryContents.json
+        ataque-del-51%.html
+        cuenta.html
+        ...etc
+```
+
+## Navbar / top-level link structure
+
+As stated, upon changing the language using the dropdown selector (or the URL bar), you go to the corresponding index.html page.
+
+This should also change _the search index used for any searches made_, such that if I have selected Nigerian Pidgin, I am searching the index of Nigerian Pidgin terms.
+
+# Search
+
+The search will be key functionality in this site.
+
+The current implementation leverages the directoryContents.json files, which are generated during build. It currently matches any terms which have the search query term in them. Ideally, we have something like this in the future:
+
+```markdown
+
+# Additional pages
+
+The first additional page, outside the core Glossary, is the `Resources` page. 
+
+This is a static page, mostly of links. It will have two sections, to begin with: 
+
+1. Web3, Decentralized Web, and Crypto Glossaries and Explainers
+
+This section simply lists glossaries and **conceptual explainers** in this technological area. It does **not** list *educational resources*, such as courses or bootcamps.
+
+2. High-Value Source Materials
+
+This section lists websites, forums, GitHub repositories, etc., where reliable information about terminology can be sourced. This includes places like the Ethereum Cat Herders and Magicians' sites, the Bitcoin Wiki, ethereum.org, etc. 
+
+**For the time being, if you'd like to add something to this list, open an issue or a PR on this repo!**
+
+`TODO :`
+- When the submission flow is created, allow users to submit suggestions here
+
+## Term matches
+
+- Terms that have the search query in them
+
+## Definition matches
+
+- Terms that have the search query in their `description` field
+
+## Partial matches
+
+- Terms that partially match the search query
+```
+
+In this way, the reader will be presented with the most relevant searches first.
+
+# Front end, imagery, colors, and overall `vibes`
+
+## Hex codes for Education DAO palette, in order from left to right in this screenshot:
+
+![color-palette](./backend-images/palette.png)
+
+- #a49ceb
+- #1c1c1c
+- #5c5481 
+- #484366
+- #54547c 
+- #5c5c8c
+- #343446
+- #3c344c
+- #2e2c3d
+- #2c2934
+
+# Build
+
+There is a distinction made in this repo between the JS files in `./src/js`, and `./utils`:
+
+./src/js: client-facing javascript, ie, things that run "in the site", such as the Search function that happens when you click the "search" button
+
+vs
+
+./utils: javascript intended for the build process, ie, things that run "to build the site", such as `build-search-indices.js`, which creates the static search index files.
+
+For this reason, `build.js` is located in `utils`, and should only ever copy over to `./build/js/*` the JS files in `./src.js`.
+
+## `build.js`
+
+This script is invoked by `npm run build`, and will, in turn:
+
+- Build the homepages, with `build-homepages.js`
+- Build the individual entry pages, with `build-pages.js`
+- Run `intertextual.js`
+- Create the `directoryContents.json` files
+- Copy over the following directories and files:
+
+```txt
+./l10n  (recursively) to ./build/l10n
+./public/assets/css to ./build/css
+./public/assets/<files at this level> to ./build/assets
+./public/assets/search-indices (recursively) to ./build/search-indices
+./static/<languageName directories>/* to ./build/* (so, all files within ./static/deutsche, and all its contents, should be copied to ./build/deutsche)
+index.html to ./build/index.html
+index.js to ./build/index.js
+```
+
+# Deployment
+
+This site is deployed on IPFS, for starters, using Fleek.xyz. It can and probably should be deployed on other decentralized storage networks.
+
+The intention is to route the ENS name `wordsofweb3.eth` to an IPNS hash using Fleek.xyz, such that it could be accessed at `wordsofweb3.eth.limo`, etc.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,10 +11,10 @@
       "dependencies": {
         "bootstrap": "^5.3.3",
         "csv-parser": "^3.0.0",
-        "doctoc": "^2.2.1",
         "json2csv": "^6.0.0-alpha.2"
       },
       "devDependencies": {
+        "doctoc": "^2.2.1",
         "http-server": "^14.1.1"
       }
     },
@@ -36,12 +36,14 @@
     "node_modules/@textlint/ast-node-types": {
       "version": "12.6.1",
       "resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-12.6.1.tgz",
-      "integrity": "sha512-uzlJ+ZsCAyJm+lBi7j0UeBbj+Oy6w/VWoGJ3iHRHE5eZ8Z4iK66mq+PG/spupmbllLtz77OJbY89BYqgFyjXmA=="
+      "integrity": "sha512-uzlJ+ZsCAyJm+lBi7j0UeBbj+Oy6w/VWoGJ3iHRHE5eZ8Z4iK66mq+PG/spupmbllLtz77OJbY89BYqgFyjXmA==",
+      "dev": true
     },
     "node_modules/@textlint/markdown-to-ast": {
       "version": "12.6.1",
       "resolved": "https://registry.npmjs.org/@textlint/markdown-to-ast/-/markdown-to-ast-12.6.1.tgz",
       "integrity": "sha512-T0HO+VrU9VbLRiEx/kH4+gwGMHNMIGkp0Pok+p0I33saOOLyhfGvwOKQgvt2qkxzQEV2L5MtGB8EnW4r5d3CqQ==",
+      "dev": true,
       "dependencies": {
         "@textlint/ast-node-types": "^12.6.1",
         "debug": "^4.3.4",
@@ -58,6 +60,7 @@
       "version": "3.0.15",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.15.tgz",
       "integrity": "sha512-LnwD+mUEfxWMa1QpDraczIn6k0Ee3SMicuYSSzS6ZYl2gKS09EClnJYGd8Du6rfc5r/GZEk5o1mRb8TaTj03sQ==",
+      "dev": true,
       "dependencies": {
         "@types/unist": "^2"
       }
@@ -65,12 +68,14 @@
     "node_modules/@types/unist": {
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
-      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "dev": true
     },
     "node_modules/anchor-markdown-header": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/anchor-markdown-header/-/anchor-markdown-header-0.6.0.tgz",
       "integrity": "sha512-v7HJMtE1X7wTpNFseRhxsY/pivP4uAJbidVhPT+yhz4i/vV1+qx371IXuV9V7bN6KjFtheLJxqaSm0Y/8neJTA==",
+      "dev": true,
       "dependencies": {
         "emoji-regex": "~10.1.0"
       }
@@ -94,6 +99,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.1.tgz",
       "integrity": "sha512-ahC5W1xgou+KTXix4sAO8Ki12Q+jf4i0+tmk3sC+zgcynshkHxzpXdImBehiUYKKKDwvfFiJl1tZt6ewscS1Mg==",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.5",
         "is-array-buffer": "^3.0.4"
@@ -109,6 +115,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.3.tgz",
       "integrity": "sha512-bMxMKAjg13EBSVscxTaYA4mRc5t1UAXa2kXiGTNfZ079HIWXEkKmkgFrh/nJqamaLSrXO5H4WFFkPEaLJWbs3A==",
+      "dev": true,
       "dependencies": {
         "array-buffer-byte-length": "^1.0.1",
         "call-bind": "^1.0.5",
@@ -139,6 +146,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
       "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "dev": true,
       "dependencies": {
         "possible-typed-array-names": "^1.0.0"
       },
@@ -153,6 +161,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.5.tgz",
       "integrity": "sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ==",
+      "dev": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -192,6 +201,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
       "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
+      "dev": true,
       "dependencies": {
         "es-define-property": "^1.0.0",
         "es-errors": "^1.3.0",
@@ -210,6 +220,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.1.0.tgz",
       "integrity": "sha512-vlNK021QdI7PNeiUh/lKkC/mNHHfV0m/Ad5JoI0TYtlBnJAslM/JIkm/tGC88bkLIwO6OQ5uV6ztS6kVAtCDlg==",
+      "dev": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -235,6 +246,7 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.4.tgz",
       "integrity": "sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==",
+      "dev": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -244,6 +256,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz",
       "integrity": "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==",
+      "dev": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -253,6 +266,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz",
       "integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==",
+      "dev": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -311,6 +325,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.1.tgz",
       "integrity": "sha512-0lht7OugA5x3iJLOWFhWK/5ehONdprk0ISXqVFn/NFrDu+cuc8iADFrGQz5BnRK7LLU3JmkbXSxaqX+/mXYtUA==",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.6",
         "es-errors": "^1.3.0",
@@ -327,6 +342,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.1.tgz",
       "integrity": "sha512-4J7wRJD3ABAzr8wP+OcIcqq2dlUKp4DVflx++hs5h5ZKydWMI6/D/fAot+yh6g2tHh8fLFTvNOaVN357NvSrOQ==",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.7",
         "es-errors": "^1.3.0",
@@ -343,6 +359,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.0.tgz",
       "integrity": "sha512-t/Ygsytq+R995EJ5PZlD4Cu56sWa8InXySaViRzw9apusqsOO2bQP+SbYzAhR0pFKoB+43lYy8rWban9JSuXnA==",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.6",
         "es-errors": "^1.3.0",
@@ -359,6 +376,7 @@
       "version": "4.3.7",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
       "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "dev": true,
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -375,6 +393,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
       "dependencies": {
         "es-define-property": "^1.0.0",
         "es-errors": "^1.3.0",
@@ -391,6 +410,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
       "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
       "dependencies": {
         "define-data-property": "^1.0.1",
         "has-property-descriptors": "^1.0.0",
@@ -407,6 +427,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/doctoc/-/doctoc-2.2.1.tgz",
       "integrity": "sha512-qNJ1gsuo7hH40vlXTVVrADm6pdg30bns/Mo7Nv1SxuXSM1bwF9b4xQ40a6EFT/L1cI+Yylbyi8MPI4G4y7XJzQ==",
+      "dev": true,
       "dependencies": {
         "@textlint/markdown-to-ast": "^12.1.1",
         "anchor-markdown-header": "^0.6.0",
@@ -423,6 +444,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
       "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
+      "dev": true,
       "dependencies": {
         "domelementtype": "^2.0.1",
         "domhandler": "^4.2.0",
@@ -436,6 +458,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
       "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+      "dev": true,
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
@@ -444,6 +467,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
       "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -455,6 +479,7 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
       "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
+      "dev": true,
       "dependencies": {
         "domelementtype": "^2.2.0"
       },
@@ -469,6 +494,7 @@
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
       "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
+      "dev": true,
       "dependencies": {
         "dom-serializer": "^1.0.1",
         "domelementtype": "^2.2.0",
@@ -481,12 +507,14 @@
     "node_modules/emoji-regex": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.1.0.tgz",
-      "integrity": "sha512-xAEnNCT3w2Tg6MA7ly6QqYJvEoY1tm9iIjJ3yMKK9JPlWuRHAMoe5iETwQnx3M9TVbFMfsrBgWKR+IsmswwNjg=="
+      "integrity": "sha512-xAEnNCT3w2Tg6MA7ly6QqYJvEoY1tm9iIjJ3yMKK9JPlWuRHAMoe5iETwQnx3M9TVbFMfsrBgWKR+IsmswwNjg==",
+      "dev": true
     },
     "node_modules/entities": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
       "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
+      "dev": true,
       "engines": {
         "node": ">=0.12"
       },
@@ -498,6 +526,7 @@
       "version": "1.23.3",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.3.tgz",
       "integrity": "sha512-e+HfNH61Bj1X9/jLc5v1owaLYuHdeHHSQlkhCBiTK8rBvKaULl/beGMxwrMXjpYrv4pz22BlY570vVePA2ho4A==",
+      "dev": true,
       "dependencies": {
         "array-buffer-byte-length": "^1.0.1",
         "arraybuffer.prototype.slice": "^1.0.3",
@@ -557,6 +586,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
       "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
+      "dev": true,
       "dependencies": {
         "get-intrinsic": "^1.2.4"
       },
@@ -568,6 +598,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -576,6 +607,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
       "integrity": "sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==",
+      "dev": true,
       "dependencies": {
         "es-errors": "^1.3.0"
       },
@@ -587,6 +619,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.3.tgz",
       "integrity": "sha512-3T8uNMC3OQTHkFUsFq8r/BwAXLHvU/9O9mE0fBc/MY5iq/8H7ncvO947LmYA6ldWw9Uh8Yhf25zu6n7nML5QWQ==",
+      "dev": true,
       "dependencies": {
         "get-intrinsic": "^1.2.4",
         "has-tostringtag": "^1.0.2",
@@ -600,6 +633,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
       "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+      "dev": true,
       "dependencies": {
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
@@ -616,6 +650,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -632,12 +667,14 @@
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true
     },
     "node_modules/fault": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/fault/-/fault-1.0.4.tgz",
       "integrity": "sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==",
+      "dev": true,
       "dependencies": {
         "format": "^0.2.0"
       },
@@ -670,6 +707,7 @@
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
       "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "dev": true,
       "dependencies": {
         "is-callable": "^1.1.3"
       }
@@ -678,6 +716,7 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
       "integrity": "sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==",
+      "dev": true,
       "engines": {
         "node": ">=0.4.x"
       }
@@ -686,6 +725,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -694,6 +734,7 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.6.tgz",
       "integrity": "sha512-Z5kx79swU5P27WEayXM1tBi5Ze/lbIyiNgU3qyXUOf9b2rgXYyF9Dy9Cx+IQv/Lc8WCG6L82zwUPpSS9hGehIg==",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.2.0",
@@ -711,6 +752,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
       "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -719,6 +761,7 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
       "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
+      "dev": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2",
@@ -737,6 +780,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.2.tgz",
       "integrity": "sha512-g0QYk1dZBxGwk+Ngc+ltRH2IBp2f7zBkBMBJZCDerh6EhlhSR6+9irMCuT/09zD6qkarHUSn529sK/yL4S27mg==",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.5",
         "es-errors": "^1.3.0",
@@ -753,6 +797,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
       "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "dev": true,
       "dependencies": {
         "define-properties": "^1.2.1",
         "gopd": "^1.0.1"
@@ -768,6 +813,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
       "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "dev": true,
       "dependencies": {
         "get-intrinsic": "^1.1.3"
       },
@@ -779,6 +825,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
       "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
+      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -796,6 +843,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
       "dependencies": {
         "es-define-property": "^1.0.0"
       },
@@ -807,6 +855,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
       "integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -818,6 +867,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
       "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -829,6 +879,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
       "dependencies": {
         "has-symbols": "^1.0.3"
       },
@@ -843,6 +894,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -875,6 +927,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-7.2.0.tgz",
       "integrity": "sha512-H7MImA4MS6cw7nbyURtLPO1Tms7C5H602LRETv95z1MxO/7CP7rDVROehUYeYBUYEON94NXXDEPmZuq+hX4sog==",
+      "dev": true,
       "funding": [
         "https://github.com/fb55/htmlparser2?sponsor=1",
         {
@@ -946,6 +999,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.7.tgz",
       "integrity": "sha512-NGnrKwXzSms2qUUih/ILZ5JBqNTSa1+ZmP6flaIp6KmSElgE9qdndzS3cqjrDovwFdmwsGsLdeFgB6suw+1e9g==",
+      "dev": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "hasown": "^2.0.0",
@@ -959,6 +1013,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.4.tgz",
       "integrity": "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==",
+      "dev": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -968,6 +1023,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.4.tgz",
       "integrity": "sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==",
+      "dev": true,
       "dependencies": {
         "is-alphabetical": "^1.0.0",
         "is-decimal": "^1.0.0"
@@ -981,6 +1037,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.4.tgz",
       "integrity": "sha512-wcjaerHw0ydZwfhiKbXJWLDY8A7yV7KhjQOpb83hGgGfId/aQa4TOvwyzn2PuswW2gPCYEL/nEAiSVpdOj1lXw==",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "get-intrinsic": "^1.2.1"
@@ -996,6 +1053,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
       "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
+      "dev": true,
       "dependencies": {
         "has-bigints": "^1.0.1"
       },
@@ -1007,6 +1065,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
       "integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
@@ -1022,6 +1081,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
       "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1044,6 +1104,7 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
       "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -1055,6 +1116,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.1.tgz",
       "integrity": "sha512-AHkaJrsUVW6wq6JS8y3JnM/GJF/9cf+k20+iDzlSaJrinEo5+7vRiteOSwBhHRiAyQATN1AmY4hwzxJKPmYf+w==",
+      "dev": true,
       "dependencies": {
         "is-typed-array": "^1.1.13"
       },
@@ -1069,6 +1131,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
       "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
+      "dev": true,
       "dependencies": {
         "has-tostringtag": "^1.0.0"
       },
@@ -1083,6 +1146,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.4.tgz",
       "integrity": "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==",
+      "dev": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -1092,6 +1156,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz",
       "integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==",
+      "dev": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -1101,6 +1166,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
       "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -1112,6 +1178,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
       "integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
+      "dev": true,
       "dependencies": {
         "has-tostringtag": "^1.0.0"
       },
@@ -1126,6 +1193,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
       "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -1134,6 +1202,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
       "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
@@ -1149,6 +1218,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.3.tgz",
       "integrity": "sha512-nA2hv5XIhLR3uVzDDfCIknerhx8XUKnstuOERPNNIinXG7v9u+ohXF67vxm4TPTEPU6lm61ZkwP3c9PCB97rhg==",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.7"
       },
@@ -1163,6 +1233,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
       "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+      "dev": true,
       "dependencies": {
         "has-tostringtag": "^1.0.0"
       },
@@ -1177,6 +1248,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
       "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
+      "dev": true,
       "dependencies": {
         "has-symbols": "^1.0.2"
       },
@@ -1191,6 +1263,7 @@
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.13.tgz",
       "integrity": "sha512-uZ25/bUAlUY5fR4OKT4rZQEBrzQWYV9ZJYGGsUmEJ6thodVJ1HX64ePQ6Z0qPWP+m+Uq6e9UugrE38jeYsDSMw==",
+      "dev": true,
       "dependencies": {
         "which-typed-array": "^1.1.14"
       },
@@ -1205,6 +1278,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
       "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2"
       },
@@ -1215,7 +1289,8 @@
     "node_modules/isarray": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true
     },
     "node_modules/json2csv": {
       "version": "6.0.0-alpha.2",
@@ -1250,6 +1325,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-2.0.4.tgz",
       "integrity": "sha512-vM6rUVCVUJJt33bnmHiZEvr7wPT78ztX7rojL+LW51bHtLh6HTjx84LA5W4+oa6aKEJA7jJu5LR6vQRBpA5DVg==",
+      "dev": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -1259,6 +1335,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-2.0.0.tgz",
       "integrity": "sha512-Ezda85ToJUBhM6WGaG6veasyym+Tbs3cMAw/ZhOPqXiYsr0jgocBV3j3nx+4lk47plLlIqjwuTm/ywVI+zjJ/A==",
+      "dev": true,
       "dependencies": {
         "repeat-string": "^1.0.0"
       },
@@ -1271,6 +1348,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-1.1.1.tgz",
       "integrity": "sha512-9cKl33Y21lyckGzpSmEQnIDjEfeeWelN5s1kUW1LwdB0Fkuq2u+4GdqcGEygYxJE8GVqCl0741bYXHgamfWAZA==",
+      "dev": true,
       "dependencies": {
         "escape-string-regexp": "^4.0.0",
         "unist-util-is": "^4.0.0",
@@ -1285,6 +1363,7 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/mdast-util-footnote/-/mdast-util-footnote-0.1.7.tgz",
       "integrity": "sha512-QxNdO8qSxqbO2e3m09KwDKfWiLgqyCurdWTQ198NpbZ2hxntdc+VKS4fDJCmNWbAroUdYnSthu+XbZ8ovh8C3w==",
+      "dev": true,
       "dependencies": {
         "mdast-util-to-markdown": "^0.6.0",
         "micromark": "~2.11.0"
@@ -1298,6 +1377,7 @@
       "version": "0.8.5",
       "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-0.8.5.tgz",
       "integrity": "sha512-2hkTXtYYnr+NubD/g6KGBS/0mFmBcifAsI0yIWRiRo0PjVs6SSOSOdtzbp6kSGnShDN6G5aWZpKQ2lWRy27mWQ==",
+      "dev": true,
       "dependencies": {
         "@types/mdast": "^3.0.0",
         "mdast-util-to-string": "^2.0.0",
@@ -1314,6 +1394,7 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/mdast-util-frontmatter/-/mdast-util-frontmatter-0.2.0.tgz",
       "integrity": "sha512-FHKL4w4S5fdt1KjJCwB0178WJ0evnyyQr5kXTM3wrOVpytD0hrkvd+AOOjU9Td8onOejCkmZ+HQRT3CZ3coHHQ==",
+      "dev": true,
       "dependencies": {
         "micromark-extension-frontmatter": "^0.2.0"
       },
@@ -1326,6 +1407,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-0.1.2.tgz",
       "integrity": "sha512-NNkhDx/qYcuOWB7xHUGWZYVXvjPFFd6afg6/e2g+SV4r9q5XUcCbV4Wfa3DLYIiD+xAEZc6K4MGaE/m0KDcPwQ==",
+      "dev": true,
       "dependencies": {
         "mdast-util-gfm-autolink-literal": "^0.1.0",
         "mdast-util-gfm-strikethrough": "^0.2.0",
@@ -1342,6 +1424,7 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-0.1.3.tgz",
       "integrity": "sha512-GjmLjWrXg1wqMIO9+ZsRik/s7PLwTaeCHVB7vRxUwLntZc8mzmTsLVr6HW1yLokcnhfURsn5zmSVdi3/xWWu1A==",
+      "dev": true,
       "dependencies": {
         "ccount": "^1.0.0",
         "mdast-util-find-and-replace": "^1.1.0",
@@ -1356,6 +1439,7 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-0.2.3.tgz",
       "integrity": "sha512-5OQLXpt6qdbttcDG/UxYY7Yjj3e8P7X16LzvpX8pIQPYJ/C2Z1qFGMmcw+1PZMUM3Z8wt8NRfYTvCni93mgsgA==",
+      "dev": true,
       "dependencies": {
         "mdast-util-to-markdown": "^0.6.0"
       },
@@ -1368,6 +1452,7 @@
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-0.1.6.tgz",
       "integrity": "sha512-j4yDxQ66AJSBwGkbpFEp9uG/LS1tZV3P33fN1gkyRB2LoRL+RR3f76m0HPHaby6F4Z5xr9Fv1URmATlRRUIpRQ==",
+      "dev": true,
       "dependencies": {
         "markdown-table": "^2.0.0",
         "mdast-util-to-markdown": "~0.6.0"
@@ -1381,6 +1466,7 @@
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-0.1.6.tgz",
       "integrity": "sha512-/d51FFIfPsSmCIRNp7E6pozM9z1GYPIkSy1urQ8s/o4TC22BZ7DqfHFWiqBD23bc7J3vV1Fc9O4QIHBlfuit8A==",
+      "dev": true,
       "dependencies": {
         "mdast-util-to-markdown": "~0.6.0"
       },
@@ -1393,6 +1479,7 @@
       "version": "0.6.5",
       "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-0.6.5.tgz",
       "integrity": "sha512-XeV9sDE7ZlOQvs45C9UKMtfTcctcaj/pGwH8YLbMHoMOXNNCn2LsqVQOqrF1+/NU8lKDAqozme9SCXWyo9oAcQ==",
+      "dev": true,
       "dependencies": {
         "@types/unist": "^2.0.0",
         "longest-streak": "^2.0.0",
@@ -1410,6 +1497,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-2.0.0.tgz",
       "integrity": "sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w==",
+      "dev": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
@@ -1419,6 +1507,7 @@
       "version": "2.11.4",
       "resolved": "https://registry.npmjs.org/micromark/-/micromark-2.11.4.tgz",
       "integrity": "sha512-+WoovN/ppKolQOFIAajxi7Lu9kInbPxFuTBVEavFcL8eAfVstoc5MocPmqBeAdBOJV00uaVjegzH4+MA0DN/uA==",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -1438,6 +1527,7 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/micromark-extension-footnote/-/micromark-extension-footnote-0.3.2.tgz",
       "integrity": "sha512-gr/BeIxbIWQoUm02cIfK7mdMZ/fbroRpLsck4kvFtjbzP4yi+OPVbnukTc/zy0i7spC2xYE/dbX1Sur8BEDJsQ==",
+      "dev": true,
       "dependencies": {
         "micromark": "~2.11.0"
       },
@@ -1450,6 +1540,7 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/micromark-extension-frontmatter/-/micromark-extension-frontmatter-0.2.2.tgz",
       "integrity": "sha512-q6nPLFCMTLtfsctAuS0Xh4vaolxSFUWUWR6PZSrXXiRy+SANGllpcqdXFv2z07l0Xz/6Hl40hK0ffNCJPH2n1A==",
+      "dev": true,
       "dependencies": {
         "fault": "^1.0.0"
       },
@@ -1462,6 +1553,7 @@
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-0.3.3.tgz",
       "integrity": "sha512-oVN4zv5/tAIA+l3GbMi7lWeYpJ14oQyJ3uEim20ktYFAcfX1x3LNlFGGlmrZHt7u9YlKExmyJdDGaTt6cMSR/A==",
+      "dev": true,
       "dependencies": {
         "micromark": "~2.11.0",
         "micromark-extension-gfm-autolink-literal": "~0.5.0",
@@ -1479,6 +1571,7 @@
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-0.5.7.tgz",
       "integrity": "sha512-ePiDGH0/lhcngCe8FtH4ARFoxKTUelMp4L7Gg2pujYD5CSMb9PbblnyL+AAMud/SNMyusbS2XDSiPIRcQoNFAw==",
+      "dev": true,
       "dependencies": {
         "micromark": "~2.11.3"
       },
@@ -1491,6 +1584,7 @@
       "version": "0.6.5",
       "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-0.6.5.tgz",
       "integrity": "sha512-PpOKlgokpQRwUesRwWEp+fHjGGkZEejj83k9gU5iXCbDG+XBA92BqnRKYJdfqfkrRcZRgGuPuXb7DaK/DmxOhw==",
+      "dev": true,
       "dependencies": {
         "micromark": "~2.11.0"
       },
@@ -1503,6 +1597,7 @@
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-0.4.3.tgz",
       "integrity": "sha512-hVGvESPq0fk6ALWtomcwmgLvH8ZSVpcPjzi0AjPclB9FsVRgMtGZkUcpE0zgjOCFAznKepF4z3hX8z6e3HODdA==",
+      "dev": true,
       "dependencies": {
         "micromark": "~2.11.0"
       },
@@ -1515,6 +1610,7 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-0.3.0.tgz",
       "integrity": "sha512-9GU0xBatryXifL//FJH+tAZ6i240xQuFrSL7mYi8f4oZSbc+NvXjkrHemeYP0+L4ZUT+Ptz3b95zhUZnMtoi/Q==",
+      "dev": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
@@ -1524,6 +1620,7 @@
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-0.3.3.tgz",
       "integrity": "sha512-0zvM5iSLKrc/NQl84pZSjGo66aTGd57C1idmlWmE87lkMcXrTxg1uXa/nXomxJytoje9trP0NDLvw4bZ/Z/XCQ==",
+      "dev": true,
       "dependencies": {
         "micromark": "~2.11.0"
       },
@@ -1567,12 +1664,14 @@
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
     },
     "node_modules/object-inspect": {
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.2.tgz",
       "integrity": "sha512-IRZSRuzJiynemAXPYtPe5BoI/RESNYR7TYm50MC5Mqbd3Jmw5y790sErYw3V6SryFJD64b74qQQs9wn5Bg/k3g==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -1584,6 +1683,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -1592,6 +1692,7 @@
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.5.tgz",
       "integrity": "sha512-byy+U7gp+FVwmyzKPYhW2h5l3crpmGsxl7X2s8y43IgxvG4g3QZ6CffDtsNQy1WsmZpQbO+ybo0AlW7TY6DcBQ==",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.5",
         "define-properties": "^1.2.1",
@@ -1618,6 +1719,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-2.0.0.tgz",
       "integrity": "sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==",
+      "dev": true,
       "dependencies": {
         "character-entities": "^1.0.0",
         "character-entities-legacy": "^1.0.0",
@@ -1658,6 +1760,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
       "integrity": "sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -1681,6 +1784,7 @@
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.2.tgz",
       "integrity": "sha512-NcDiDkTLuPR+++OCKB0nWafEmhg/Da8aUPLPMQbK+bxKKCm1/S5he+AqYa4PlMCVBalb4/yxIRub6qkEx5yJbw==",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.6",
         "define-properties": "^1.2.1",
@@ -1698,6 +1802,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/remark-footnotes/-/remark-footnotes-3.0.0.tgz",
       "integrity": "sha512-ZssAvH9FjGYlJ/PBVKdSmfyPc3Cz4rTWgZLI4iE/SX8Nt5l3o3oEjv3wwG5VD7xOjktzdwp5coac+kJV9l4jgg==",
+      "dev": true,
       "dependencies": {
         "mdast-util-footnote": "^0.1.0",
         "micromark-extension-footnote": "^0.3.0"
@@ -1711,6 +1816,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/remark-frontmatter/-/remark-frontmatter-3.0.0.tgz",
       "integrity": "sha512-mSuDd3svCHs+2PyO29h7iijIZx4plX0fheacJcAoYAASfgzgVIcXGYSq9GFyYocFLftQs8IOmmkgtOovs6d4oA==",
+      "dev": true,
       "dependencies": {
         "mdast-util-frontmatter": "^0.2.0",
         "micromark-extension-frontmatter": "^0.2.0"
@@ -1724,6 +1830,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-1.0.0.tgz",
       "integrity": "sha512-KfexHJCiqvrdBZVbQ6RopMZGwaXz6wFJEfByIuEwGf0arvITHjiKKZ1dpXujjH9KZdm1//XJQwgfnJ3lmXaDPA==",
+      "dev": true,
       "dependencies": {
         "mdast-util-gfm": "^0.1.0",
         "micromark-extension-gfm": "^0.3.0"
@@ -1737,6 +1844,7 @@
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-9.0.0.tgz",
       "integrity": "sha512-geKatMwSzEXKHuzBNU1z676sGcDcFoChMK38TgdHJNAYfFtsfHDQG7MoJAjs6sgYMqyLduCYWDIWZIxiPeafEw==",
+      "dev": true,
       "dependencies": {
         "mdast-util-from-markdown": "^0.8.0"
       },
@@ -1749,6 +1857,7 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
+      "dev": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -1763,6 +1872,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.2.tgz",
       "integrity": "sha512-vj6RsCsWBCf19jIeHEfkRMw8DPiBb+DMXklQ/1SGDHOMlHdPUkZXFQ2YdplS23zESTijAcurb1aSgJA3AgMu1Q==",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.7",
         "get-intrinsic": "^1.2.4",
@@ -1786,6 +1896,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.3.tgz",
       "integrity": "sha512-CdASjNJPvRa7roO6Ra/gLYBTzYzzPyyBXxIMdGW3USQLyjWEls2RgW5UBTXaQVp+OrpeCK3bLem8smtmheoRuw==",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.6",
         "es-errors": "^1.3.0",
@@ -1814,6 +1925,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
       "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
       "dependencies": {
         "define-data-property": "^1.1.4",
         "es-errors": "^1.3.0",
@@ -1830,6 +1942,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
       "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+      "dev": true,
       "dependencies": {
         "define-data-property": "^1.1.4",
         "es-errors": "^1.3.0",
@@ -1844,6 +1957,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
       "integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.7",
         "es-errors": "^1.3.0",
@@ -1861,6 +1975,7 @@
       "version": "1.2.9",
       "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.9.tgz",
       "integrity": "sha512-klHuCNxiMZ8MlsOihJhJEBJAiMVqU3Z2nEXWfWnIqjN0gEFS9J9+IxKozWWtQGcgoa1WUZzLjKPTr4ZHNFTFxw==",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.7",
         "define-properties": "^1.2.1",
@@ -1878,6 +1993,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.8.tgz",
       "integrity": "sha512-p73uL5VCHCO2BZZ6krwwQE3kCzM7NKmis8S//xEC6fQonchbum4eP6kR4DLEjQFO3Wnj3Fuo8NM0kOSjVdHjZQ==",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.7",
         "define-properties": "^1.2.1",
@@ -1891,6 +2007,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
       "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.7",
         "define-properties": "^1.2.1",
@@ -1919,6 +2036,7 @@
       "version": "0.6.10",
       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.10.tgz",
       "integrity": "sha512-hN4uFRxbK+PX56DxYiGHsTn2dME3TVr9vbNqlQGcGcPhJAn+tdP126iA+TArMpI4YSgnTkMWyoLl5bf81Hi5TA==",
+      "dev": true,
       "dependencies": {
         "gopd": "^1.0.1",
         "typedarray.prototype.slice": "^1.0.3",
@@ -1935,6 +2053,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz",
       "integrity": "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==",
+      "dev": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -1944,6 +2063,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.2.tgz",
       "integrity": "sha512-gEymJYKZtKXzzBzM4jqa9w6Q1Jjm7x2d+sh19AdsD4wqnMPDYyvwpsIc2Q/835kHuo3BEQ7CjelGhfTsoBb2MQ==",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.7",
         "es-errors": "^1.3.0",
@@ -1957,6 +2077,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.1.tgz",
       "integrity": "sha512-3iMJ9q0ao7WE9tWcaYKIptkNBuOIcZCCT0d4MRvuuH88fEoEH62IuQe0OtraD3ebQEoTRk8XCBoknUNc1Y67pw==",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.7",
         "for-each": "^0.3.3",
@@ -1975,6 +2096,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.2.tgz",
       "integrity": "sha512-Ous0vodHa56FviZucS2E63zkgtgrACj7omjwd/8lTEMEPFFyjfixMZ1ZXenpgCFBBt4EC1J2XsyVS2gkG0eTFA==",
+      "dev": true,
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
         "call-bind": "^1.0.7",
@@ -1994,6 +2116,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.6.tgz",
       "integrity": "sha512-/OxDN6OtAk5KBpGb28T+HZc2M+ADtvRxXrKKbUwtsLgdoxgX13hyy7ek6bFRl5+aBs2yZzB0c4CnQfAtVypW/g==",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.7",
         "for-each": "^0.3.3",
@@ -2013,6 +2136,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/typedarray.prototype.slice/-/typedarray.prototype.slice-1.0.3.tgz",
       "integrity": "sha512-8WbVAQAUlENo1q3c3zZYuy5k9VzBQvp8AX9WOtbvyWlLM1v5JaSRmjubLjzHF4JFtptjH/5c/i95yaElvcjC0A==",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.7",
         "define-properties": "^1.2.1",
@@ -2032,6 +2156,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
       "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "has-bigints": "^1.0.2",
@@ -2045,12 +2170,14 @@
     "node_modules/underscore": {
       "version": "1.13.7",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.7.tgz",
-      "integrity": "sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g=="
+      "integrity": "sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==",
+      "dev": true
     },
     "node_modules/unified": {
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/unified/-/unified-9.2.2.tgz",
       "integrity": "sha512-Sg7j110mtefBD+qunSLO1lqOEKdrwBFBrR6Qd8f4uwkhWNlbkaqwHse6e7QvD3AP/MNoJdEDLaf8OxYyoWgorQ==",
+      "dev": true,
       "dependencies": {
         "bail": "^1.0.0",
         "extend": "^3.0.0",
@@ -2080,6 +2207,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.1.0.tgz",
       "integrity": "sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg==",
+      "dev": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
@@ -2089,6 +2217,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.3.tgz",
       "integrity": "sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==",
+      "dev": true,
       "dependencies": {
         "@types/unist": "^2.0.2"
       },
@@ -2101,6 +2230,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-3.1.1.tgz",
       "integrity": "sha512-1KROIZWo6bcMrZEwiH2UrXDyalAa0uqzWCxCJj6lPOvTve2WkfgCytoDTPaMnodXh1WrXOq0haVYHj99ynJlsg==",
+      "dev": true,
       "dependencies": {
         "@types/unist": "^2.0.0",
         "unist-util-is": "^4.0.0"
@@ -2113,7 +2243,8 @@
     "node_modules/update-section": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/update-section/-/update-section-0.3.3.tgz",
-      "integrity": "sha512-BpRZMZpgXLuTiKeiu7kK0nIPwGdyrqrs6EDSaXtjD/aQ2T+qVo9a5hRC3HN3iJjCMxNT/VxoLGQ7E/OzE5ucnw=="
+      "integrity": "sha512-BpRZMZpgXLuTiKeiu7kK0nIPwGdyrqrs6EDSaXtjD/aQ2T+qVo9a5hRC3HN3iJjCMxNT/VxoLGQ7E/OzE5ucnw==",
+      "dev": true
     },
     "node_modules/url-join": {
       "version": "4.0.1",
@@ -2125,6 +2256,7 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/vfile/-/vfile-4.2.1.tgz",
       "integrity": "sha512-O6AE4OskCG5S1emQ/4gl8zK586RqA3srz3nfK/Viy0UPToBc5Trp9BVFb1u0CjsKrAWwnpr4ifM/KBXPWwJbCA==",
+      "dev": true,
       "dependencies": {
         "@types/unist": "^2.0.0",
         "is-buffer": "^2.0.0",
@@ -2140,6 +2272,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-2.0.4.tgz",
       "integrity": "sha512-DjssxRGkMvifUOJre00juHoP9DPWuzjxKuMDrhNbk2TdaYYBNMStsNhEOt3idrtI12VQYM/1+iM0KOzXi4pxwQ==",
+      "dev": true,
       "dependencies": {
         "@types/unist": "^2.0.0",
         "unist-util-stringify-position": "^2.0.0"
@@ -2165,6 +2298,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
       "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+      "dev": true,
       "dependencies": {
         "is-bigint": "^1.0.1",
         "is-boolean-object": "^1.1.0",
@@ -2180,6 +2314,7 @@
       "version": "1.1.15",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.15.tgz",
       "integrity": "sha512-oV0jmFtUky6CXfkqehVvBP/LSWJ2sy4vWMioiENyJLePrBO/yKyV9OyJySfAKosh+RYkIl5zJCNZ8/4JncrpdA==",
+      "dev": true,
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
         "call-bind": "^1.0.7",
@@ -2198,6 +2333,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-1.0.5.tgz",
       "integrity": "sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw==",
+      "dev": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"

--- a/package.json
+++ b/package.json
@@ -16,10 +16,10 @@
   "dependencies": {
     "bootstrap": "^5.3.3",
     "csv-parser": "^3.0.0",
-    "doctoc": "^2.2.1",
     "json2csv": "^6.0.0-alpha.2"
   },
   "devDependencies": {
+    "doctoc": "^2.2.1",
     "http-server": "^14.1.1"
   }
 }


### PR DESCRIPTION
The updates to README.md made by @resourcefulmind were absolutely the right way to go. There was too much detail there.

- I moved most of it to `./utils/BUILD-README.md`, linked to that.
- While the bullet points were good, parts of it felt a little too GPT, to me, so I made it:
    - feel a little more human
    - added some links 
    - updated the TOC
    - ensured all the locales were listed, and 
    - added a _bit_ more explanation in a few places.