### PR TITLE
Proofreading en-US.json to look for capital letters and incorrect attributions

### DIFF
--- a/locales/ar-001/ar-001.json
+++ b/locales/ar-001/ar-001.json
@@ -6146,8 +6146,8 @@
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
     },
-    "mesh": {
-      "term": "Mesh",
+    "consensys-mesh": {
+      "term": "Consensys Mesh",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",

--- a/locales/ar-001/ar-001.json
+++ b/locales/ar-001/ar-001.json
@@ -5222,7 +5222,7 @@
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
     },
-    "interplanetary-file-system-(ipfs)": {
+    "interplanetary-file-system": {
       "term": "نظام الملفات إنتربلانتري (IPFS)",
       "partOfSpeech": "",
       "termCategory": "",
@@ -5237,7 +5237,7 @@
       "commentary": ""
     },
     "interplanetary-file-system-ipfs": {
-      "term": "InterPlanetary File System (IPFS)",
+      "term": "InterPlanetary File System",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",

--- a/locales/ar-001/ar-001.json
+++ b/locales/ar-001/ar-001.json
@@ -8064,7 +8064,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "rollups": {
+    "rollup": {
       "term": "تجميعات",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/ar-001/directoryContents.json
+++ b/locales/ar-001/directoryContents.json
@@ -1756,7 +1756,7 @@
     "link": "merkle.html"
   },
   {
-    "name": "Mesh",
+    "name": "Consensys Mesh",
     "link": "mesh.html"
   },
   {

--- a/locales/ar-001/directoryContents.json
+++ b/locales/ar-001/directoryContents.json
@@ -1496,7 +1496,7 @@
     "link": "ipfs.html"
   },
   {
-    "name": "InterPlanetary File System (IPFS)",
+    "name": "InterPlanetary File System",
     "link": "interplanetary-file-system-ipfs.html"
   },
   {

--- a/locales/de-DE/de-DE.json
+++ b/locales/de-DE/de-DE.json
@@ -3234,8 +3234,8 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "mesh": {
-      "term": "Mesh",
+    "consensys-mesh": {
+      "term": "Consensys Mesh",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",

--- a/locales/de-DE/de-DE.json
+++ b/locales/de-DE/de-DE.json
@@ -2702,8 +2702,8 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "interplanetary-file-system-(ipfs)": {
-      "term": "InterPlanetary-Dateisystem (IPFS)",
+    "interplanetary-file-system": {
+      "term": "InterPlanetary-DateiSystem",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",

--- a/locales/de-DE/de-DE.json
+++ b/locales/de-DE/de-DE.json
@@ -4312,7 +4312,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "rollups": {
+    "rollup": {
       "term": "Rollups",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/de-DE/directoryContents.json
+++ b/locales/de-DE/directoryContents.json
@@ -924,7 +924,7 @@
     "link": "merkle-patriciatrie.html"
   },
   {
-    "name": "Mesh",
+    "name": "Consensys Mesh",
     "link": "mesh.html"
   },
   {

--- a/locales/de-DE/directoryContents.json
+++ b/locales/de-DE/directoryContents.json
@@ -772,7 +772,7 @@
     "link": "interoperabilitt.html"
   },
   {
-    "name": "InterPlanetary-Dateisystem (IPFS)",
+    "name": "InterPlanetary-DateiSystem",
     "link": "interplanetarydateisystem-ipfs.html"
   },
   {

--- a/locales/el-GR/directoryContents.json
+++ b/locales/el-GR/directoryContents.json
@@ -924,7 +924,7 @@
     "link": "merkle-patricia-trie.html"
   },
   {
-    "name": "Mesh",
+    "name": "Consensys Mesh",
     "link": "mesh.html"
   },
   {

--- a/locales/el-GR/el-GR.json
+++ b/locales/el-GR/el-GR.json
@@ -3234,8 +3234,8 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "mesh": {
-      "term": "Mesh",
+    "consensys-mesh": {
+      "term": "Consensys Mesh",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",

--- a/locales/el-GR/el-GR.json
+++ b/locales/el-GR/el-GR.json
@@ -4312,7 +4312,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "rollups": {
+    "rollup": {
       "term": "κακόβουλο λογισμικό",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/el-GR/el-GR.json
+++ b/locales/el-GR/el-GR.json
@@ -2702,7 +2702,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "interplanetary-file-system-(ipfs)": {
+    "interplanetary-file-system": {
       "term": "Διαπλανητικό Σύστημα Αρχείων (IPFS)",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/en-GB/directoryContents.json
+++ b/locales/en-GB/directoryContents.json
@@ -772,7 +772,7 @@
     "link": "interoperability.html"
   },
   {
-    "name": "InterPlanetary File System (IPFS)",
+    "name": "InterPlanetary File System",
     "link": "interplanetary-file-system-ipfs.html"
   },
   {

--- a/locales/en-GB/directoryContents.json
+++ b/locales/en-GB/directoryContents.json
@@ -924,7 +924,7 @@
     "link": "merkle-patricia-trie.html"
   },
   {
-    "name": "Mesh",
+    "name": "Consensys Mesh",
     "link": "mesh.html"
   },
   {

--- a/locales/en-GB/en-GB.json
+++ b/locales/en-GB/en-GB.json
@@ -3234,8 +3234,8 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "mesh": {
-      "term": "Mesh",
+    "consensys-mesh": {
+      "term": "Consensys Mesh",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",

--- a/locales/en-GB/en-GB.json
+++ b/locales/en-GB/en-GB.json
@@ -4312,8 +4312,8 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "rollups": {
-      "term": "rollups",
+    "rollup": {
+      "term": "rollup",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",

--- a/locales/en-GB/en-GB.json
+++ b/locales/en-GB/en-GB.json
@@ -2702,8 +2702,8 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "interplanetary-file-system-(ipfs)": {
-      "term": "InterPlanetary File System (IPFS)",
+    "interplanetary-file-system": {
+      "term": "InterPlanetary File System",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",

--- a/locales/en-US/en-US.json
+++ b/locales/en-US/en-US.json
@@ -7992,7 +7992,7 @@
       "commentary": ""
     },
     "progressive-web-application": {
-      "term": "Progressive Web application (PWA)",
+      "term": "Progressive Web Application",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -8020,7 +8020,7 @@
       "commentary": ""
     },
     "proof-of-reserves-por": {
-      "term": "Proof of Reserves (PoR)",
+      "term": "proof of reserves",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -8039,7 +8039,7 @@
       "termCategory": "",
       "phonetic": "/pruf əv steɪk/",
       "definition": "A consensus mechanism in which an individual node, or “validator”, validates transactions or blocks. Validators lock up a certain amount of cryptocurrency, such as ether, into a ‘stake’, in order to be able to participate in consensus. If the node validates a block (group of transactions) correctly, then the validator receives a reward. Conversely, if the validator behaves poorly by validating incorrect transactions or by not maintaining sufficient network connectivity, the cryptocurrency they staked can be ‘slashed’, or taken from them and put out of circulation (‘burned’). PoS requires a negligible amount of computing power compared to Proof of Work consensus.",
-      "definitionSource": "https://academy.binance.com/en/glossary/proof-of-stake",
+      "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
       "alternate": [
@@ -8053,7 +8053,7 @@
       "commentary": ""
     },
     "proof-of-staked-authority-posa": {
-      "term": "Proof of Staked Authority (PoSA)",
+      "term": "Proof of Staked Authority",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -8072,7 +8072,7 @@
       "termCategory": "",
       "phonetic": "/pruf əv wɜrk/",
       "definition": "A consensus mechanism in which each block is ‘mined’ by one of the nodes, or a group of nodes, on the network. The computational process involved in committing a series of transactions into a block on the network, known as ‘hashing a block’, is technically quite simple, and therefore subject to attack. Under PoW, each miner must solve a math problem to find a set, difficult variable in order to be able to propose their block to the network as the next to be ‘mined’. In effect, the process of hashing each block becomes a competition. This addition of solving for a target increases the difficulty of successfully hashing each block, and consequently the security of the network.\n\nFor each hashed block, the overall process of hashing will have taken some time and computational effort. Thus, a hashed block is considered Proof of Work, and the miner that successfully hashes the block first receives a reward, in the form of cryptocurrency. PoW is singificantly more energy-intensive than other consensus mechanisms, such as Proof of Stake.",
-      "definitionSource": "https://academy.binance.com/en/glossary/proof-of-work",
+      "definitionSource": "Consensys Software Inc., A Blockchain Glossary for Beginners",
       "sampleSentence": "",
       "extended": "",
       "alternate": [
@@ -8086,7 +8086,7 @@
       "commentary": ""
     },
     "proposer-builder-separation-pbs": {
-      "term": "Proposer-Builder Separation (PBS)",
+      "term": "proposer-builder separation",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -8100,7 +8100,7 @@
       "commentary": ""
     },
     "proto-danksharding": {
-      "term": "Proto-Danksharding",
+      "term": "proto-danksharding",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -8128,7 +8128,7 @@
       "commentary": ""
     },
     "pseudorandom": {
-      "term": "Pseudorandom",
+      "term": "pseudorandom",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -8175,7 +8175,7 @@
       "termCategory": "",
       "phonetic": "/ˈpʌblɪk kiː/",
       "definition": "Public blockchain networks are just that: public. Their data is accessible and readable by anyone. In order to have any degree of usability when it comes to allowing users to do some things, like send transactions, but not others, like steal other peoples’ tokens, cryptographic technology is used. In particular, a design paradigm known as ‘public/private key pairs’ is employed to ensure users can interact with others on the network as they wish, while keeping their own account secure.\n\nThese key pairs consist of two long strings of alphanumeric characters. A public key can be derived mathematically from its corresponding private key, but the inverse is not true: it is mathematically impossible to derive a private key from its corresponding public key. This allows, for example, users to have a public wallet address that anyone can use to send them tokens, with the peace of mind that as long as they properly keep the corresponding private key safe, those tokens cannot be stolen. See also ‘private key’.",
-      "definitionSource": "https://academy.binance.com/en/glossary/public-key",
+      "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
       "alternate": [
@@ -8207,7 +8207,7 @@
       "commentary": ""
     },
     "pump-and-dump": {
-      "term": "Pump-and-dump",
+      "term": "pump-and-dump",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -8249,7 +8249,7 @@
       "commentary": ""
     },
     "quantitative-tightening-qt": {
-      "term": "Quantitative Tightening (QT)",
+      "term": "quantitative tightening",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -8263,7 +8263,7 @@
       "commentary": ""
     },
     "quantum-computing": {
-      "term": "Quantum Computing",
+      "term": "quantum computing",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -8291,7 +8291,7 @@
       "commentary": ""
     },
     "race-attack": {
-      "term": "Race attack",
+      "term": "race attack",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -8305,7 +8305,7 @@
       "commentary": ""
     },
     "ransomware": {
-      "term": "Ransomware",
+      "term": "ransomware",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -8333,11 +8333,11 @@
       "commentary": ""
     },
     "real-world-assets-rwas": {
-      "term": "Real World Assets (RWAs)",
+      "term": "Real World Assets",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
-      "definition": "Real World Assets refer to tangible, physical assets with intrinsic value—like real estate, commodities, or art—that are tokenized for use on the blockchain.",
+      "definition": "Real World Assets, or RWAs, refer to tangible, physical assets with intrinsic value—like real estate, commodities, or art—that are tokenized for use on the blockchain.",
       "definitionSource": "https://academy.binance.com/en/glossary/real-world-assets-rwas",
       "sampleSentence": "",
       "extended": "",
@@ -8347,7 +8347,7 @@
       "commentary": ""
     },
     "recession": {
-      "term": "Recession",
+      "term": "recession",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -8361,7 +8361,7 @@
       "commentary": ""
     },
     "recursive-inscription": {
-      "term": "Recursive Inscription",
+      "term": "recursive inscription",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -8375,9 +8375,9 @@
       "commentary": ""
     },
     "rekt": {
-      "term": "Rekt",
+      "term": "rekt",
       "partOfSpeech": "",
-      "termCategory": "",
+      "termCategory": "meme",
       "phonetic": "",
       "definition": "A slang term used to define someone or something that has been destroyed or experienced catastrophic failure and a synonym for liquidated",
       "definitionSource": "https://academy.binance.com/en/glossary/rekt",
@@ -8389,7 +8389,7 @@
       "commentary": ""
     },
     "relative-strength-index": {
-      "term": "Relative Strength Index (RSI)",
+      "term": "Relative Strength Index",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -8424,14 +8424,14 @@
       "definition": "",
       "definitionSource": "",
       "sampleSentence": "",
-      "extended": "",
+      "extended": "See also 'RPC'.",
       "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
     },
     "resistance": {
-      "term": "Resistance",
+      "term": "resistance",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -8445,21 +8445,21 @@
       "commentary": ""
     },
     "return-on-investment": {
-      "term": "Return on Investment (ROI)",
+      "term": "Return on Investment",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
       "definition": "A measure used in order to assess the efficiency of an investment. The ratio between net profit and net cost.",
       "definitionSource": "https://academy.binance.com/en/glossary/return-on-investment",
       "sampleSentence": "",
-      "extended": "",
+      "extended": "Generally referred to by its initialism, 'ROI'.",
       "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/return-on-investment",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
     "revenge-trading": {
-      "term": "Revenge Trading",
+      "term": "revenge trading",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -8477,8 +8477,8 @@
       "partOfSpeech": "noun",
       "termCategory": "",
       "phonetic": "/ˈrɪŋkəbi/",
-      "definition": "An Ethereum testnet that uses Proof of Authority consensus, available through MetaMask; Following the transition to Proof of Stake, Rinkeby scheduled its deprecation for the end of 2023.",
-      "definitionSource": "",
+      "definition": "An Ethereum testnet that used Proof of Authority consensus, available through MetaMask; Following the transition to Proof of Stake, Rinkeby scheduled its deprecation for the end of 2023.",
+      "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
       "alternate": [],
@@ -8487,7 +8487,7 @@
       "commentary": ""
     },
     "risk-premium": {
-      "term": "Risk Premium",
+      "term": "risk premium",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -8506,7 +8506,7 @@
       "termCategory": "",
       "phonetic": "/ˈroʊdmæp/",
       "definition": "A planning technique which lays out the short and long term goals of a particular project within a flexible estimated timeline.",
-      "definitionSource": "https://academy.binance.com/en/glossary/roadmap",
+      "definitionSource": "Consensys Software Inc., A Blockchain Glossary for Beginners",
       "sampleSentence": "",
       "extended": "",
       "alternate": [
@@ -8533,8 +8533,8 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "rollups": {
-      "term": "rollups",
+    "rollup": {
+      "term": "rollup",
       "partOfSpeech": "noun",
       "termCategory": "",
       "phonetic": "/ˈrɒlʌps/",

--- a/locales/en-US/en-US.json
+++ b/locales/en-US/en-US.json
@@ -5402,20 +5402,6 @@
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
-    "initial-public-offering": {
-      "term": "Initial Public Offering",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "Refers to the moment a private company starts offering its shares to the public for the first time.",
-      "definitionSource": "https://academy.binance.com/en/glossary/initial-public-offering",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "https://academy.binance.com/en/glossary/initial-public-offering",
-      "dateFirstRecorded": "2025-01-31",
-      "commentary": ""
-    },
     "inscription": {
       "term": "inscription",
       "partOfSpeech": "",
@@ -5505,8 +5491,8 @@
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
-    "interplanetary-file-system-(ipfs)": {
-      "term": "InterPlanetary File System (IPFS)",
+    "interplanetary-file-system": {
+      "term": "InterPlanetary File System",
       "partOfSpeech": "noun",
       "termCategory": "",
       "phonetic": "/ˌɪntərˈplænəˌtɛri faɪl ˈsɪstəm/",
@@ -5517,7 +5503,7 @@
       "alternate": [
         {
           "definition": "An open-source project building a protocol for distributed content storage and access.",
-          "source": "https://academy.binance.com/en/glossary/interplanetary-file-system-ipfs",
+          "source": "https://academy.binance.com/en/glossary/interplanetary-file-system-ipfs"
         }
       ],
       "termSource": "",
@@ -5575,7 +5561,12 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "Refers to the moment a private company starts offering its shares to the public for the first time.",
+          "source": "https://academy.binance.com/en/glossary/initial-public-offering",
+        }
+      ],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""

--- a/locales/en-US/en-US.json
+++ b/locales/en-US/en-US.json
@@ -3397,7 +3397,7 @@
       "commentary": ""
     },
     "efficient-market-hypothesis-emh": {
-      "term": "Efficient Market Hypothesis (EMH)",
+      "term": "efficient market hypothesis (EMH)",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -3421,20 +3421,6 @@
       "extended": "",
       "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/eigenlayer",
-      "dateFirstRecorded": "2025-01-31",
-      "commentary": ""
-    },
-    "eip": {
-      "term": "EIP",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "EIP stands for Ethereum Improvement Proposal. It’s a way for the Ethereum community to suggest upgrades or new ideas for the blockchain.",
-      "definitionSource": "https://academy.binance.com/en/glossary/eip",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "https://academy.binance.com/en/glossary/eip",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -3807,8 +3793,13 @@
       "definition": "",
       "definitionSource": "",
       "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
+      "extended": "There are many EIP-related entries in this glossary. See also ERC.",
+      "alternate": [
+        {
+          "definition": "EIP stands for Ethereum Improvement Proposal. It’s a way for the Ethereum community to suggest upgrades or new ideas for the blockchain.",
+          "source": "https://academy.binance.com/en/glossary/eip"
+        }
+      ],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""

--- a/locales/en-US/en-US.json
+++ b/locales/en-US/en-US.json
@@ -1338,9 +1338,9 @@
       "commentary": ""
     },
     "blue-chip-token": {
-      "term": "Blue-Chip Token",
-      "partOfSpeech": "",
-      "termCategory": "",
+      "term": "blue-chip token",
+      "partOfSpeech": "noun phrase",
+      "termCategory": "DeFi",
       "phonetic": "",
       "definition": "Blue-chip cryptos are coins that have withstood the test of time. These assets are established and reliably valuable.",
       "definitionSource": "https://academy.binance.com/en/glossary/blue-chip-token",
@@ -1394,7 +1394,7 @@
       "commentary": ""
     },
     "bollinger-bands": {
-      "term": "Bollinger Bands",
+      "term": "Bollinger bands",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -1408,9 +1408,9 @@
       "commentary": ""
     },
     "bond": {
-      "term": "Bond",
-      "partOfSpeech": "",
-      "termCategory": "",
+      "term": "bond",
+      "partOfSpeech": "noun",
+      "termCategory": "finance",
       "phonetic": "",
       "definition": "Bonds are a type of fixed-income investment that represents a loan made by an investor to a borrower, typically a business or government.",
       "definitionSource": "https://academy.binance.com/en/glossary/bond",
@@ -1427,7 +1427,7 @@
       "termCategory": "",
       "phonetic": "/ˈbaʊnti/ /bʌɡ ˈbaʊnti/",
       "definition": "A reward offered for exposing vulnerabilities and issues in computer code. For this reason, often referred to as a 'bug bounty'.",
-      "definitionSource": "https://academy.binance.com/en/glossary/bounty",
+      "definitionSource": "Consensys Software Inc., Blockchain Glossary for Beginners, Education DAO",
       "sampleSentence": "",
       "extended": "",
       "alternate": [
@@ -1469,7 +1469,7 @@
       "commentary": ""
     },
     "brc-20-tokens": {
-      "term": "BRC-20 Tokens",
+      "term": "BRC-20 tokens",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -1483,9 +1483,9 @@
       "commentary": ""
     },
     "break-even-point": {
-      "term": "Break-Even Point (BEP)",
+      "term": "break-even point",
       "partOfSpeech": "",
-      "termCategory": "",
+      "termCategory": "finance",
       "phonetic": "",
       "definition": "The point where the total costs of an operation is equivalent to its current value or revenue.",
       "definitionSource": "https://academy.binance.com/en/glossary/break-even-point",
@@ -1497,7 +1497,7 @@
       "commentary": ""
     },
     "breakeven-multiple": {
-      "term": "Breakeven Multiple",
+      "term": "breakeven multiple",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -1511,7 +1511,7 @@
       "commentary": ""
     },
     "breakout": {
-      "term": "Breakout",
+      "term": "breakout",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -1567,7 +1567,7 @@
       "commentary": ""
     },
     "btc-wallet-address": {
-      "term": "BTC Wallet Address",
+      "term": "BTC wallet address",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -1600,7 +1600,7 @@
       "commentary": ""
     },
     "bull-market": {
-      "term": "Bull Market",
+      "term": "bull market",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -1614,9 +1614,9 @@
       "commentary": ""
     },
     "burner-wallet": {
-      "term": "Burner Wallet",
-      "partOfSpeech": "",
-      "termCategory": "",
+      "term": "burner wallet",
+      "partOfSpeech": "noun phrase",
+      "termCategory": "web3",
       "phonetic": "",
       "definition": "Explore burner wallets, temporary cryptocurrency wallets that users can use to safely interact with potentially dangerous blockchain applications.",
       "definitionSource": "https://academy.binance.com/en/glossary/burner-wallet",
@@ -1628,7 +1628,7 @@
       "commentary": ""
     },
     "buy-wall": {
-      "term": "Buy Wall",
+      "term": "buy wall",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -1684,7 +1684,7 @@
       "commentary": ""
     },
     "candidate-block": {
-      "term": "Candidate Block",
+      "term": "candidate block",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -1698,21 +1698,21 @@
       "commentary": ""
     },
     "candlestick": {
-      "term": "Candlestick",
+      "term": "candlestick",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
       "definition": "A graph representation of price action that displays the open, close, high, and low points within a certain period.",
       "definitionSource": "https://academy.binance.com/en/glossary/candlestick",
-      "sampleSentence": "",
-      "extended": "",
+      "sampleSentence": "Did you see that green candlestick on $POO this morning? Someone bought big.",
+      "extended": "Often shortened to simply 'candle'.",
       "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/candlestick",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
     "capitulation": {
-      "term": "Capitulation",
+      "term": "capitulation",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -1740,21 +1740,21 @@
       "commentary": ""
     },
     "censorship-resistance": {
-      "term": "Censorship-resistance",
-      "partOfSpeech": "",
-      "termCategory": "",
+      "term": "censorship resistance",
+      "partOfSpeech": "noun phrase",
+      "termCategory": "decentralized tech",
       "phonetic": "",
       "definition": "The property of a cryptocurrency network that prevents any entity from altering transactions on it.",
       "definitionSource": "https://academy.binance.com/en/glossary/censorship-resistance",
       "sampleSentence": "",
-      "extended": "",
+      "extended": "While this is the noun phrase, you will often see a protocol or network described as 'censorship resistant'.",
       "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/censorship-resistance",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
     "central-bank": {
-      "term": "Central Bank",
+      "term": "central bank",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -1796,8 +1796,8 @@
       "commentary": ""
     },
     "centralized": {
-      "term": "Centralized",
-      "partOfSpeech": "",
+      "term": "centralized",
+      "partOfSpeech": "adjective",
       "termCategory": "",
       "phonetic": "",
       "definition": "When the planning and decision-making mechanisms are concentrated in a particular point within a system.",
@@ -1885,8 +1885,8 @@
       "commentary": ""
     },
     "cipher": {
-      "term": "Cipher",
-      "partOfSpeech": "",
+      "term": "cipher",
+      "partOfSpeech": "noun",
       "termCategory": "",
       "phonetic": "",
       "definition": "A method for encrypting and decrypting messages. Ciphers can be divided into symmetric or asymmetric, according to their key model.",
@@ -1899,7 +1899,7 @@
       "commentary": ""
     },
     "circulating-supply": {
-      "term": "Circulating Supply",
+      "term": "circulating supply",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -1932,7 +1932,7 @@
       "commentary": ""
     },
     "cloud": {
-      "term": "Cloud",
+      "term": "cloud",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -2040,7 +2040,7 @@
       "commentary": ""
     },
     "collateral": {
-      "term": "Collateral",
+      "term": "collateral",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -2054,7 +2054,7 @@
       "commentary": ""
     },
     "colocation": {
-      "term": "Colocation",
+      "term": "colocation",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -2065,7 +2065,7 @@
       "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/colocation",
       "dateFirstRecorded": "2025-01-31",
-      "commentary": ""
+      "commentary": "Not to be confused with 'collocation', referring to common placement of phrases or words together."
     },
     "commodity-futures-trading-commission": {
       "term": "Commodity Futures Trading Commission (CFTC)",
@@ -2110,7 +2110,7 @@
       "commentary": ""
     },
     "compound-interest": {
-      "term": "Compound Interest",
+      "term": "compound interest",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -2138,7 +2138,7 @@
       "commentary": ""
     },
     "confirmation-time": {
-      "term": "Confirmation Time",
+      "term": "confirmation time",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -2157,7 +2157,7 @@
       "commentary": ""
     },
     "confluence": {
-      "term": "Confluence",
+      "term": "confluence",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -2168,7 +2168,7 @@
       "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/confluence",
       "dateFirstRecorded": "2025-01-31",
-      "commentary": ""
+      "commentary": "Confluence is also the name of a workplace productivity tool, made by software company Atlassian."
     },
     "consensus": {
       "term": "consensus",
@@ -2185,7 +2185,7 @@
       "commentary": ""
     },
     "consensus-algorithm": {
-      "term": "Consensus Algorithm",
+      "term": "consensus algorithm",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -2283,7 +2283,7 @@
       "commentary": ""
     },
     "contango-and-backwardation": {
-      "term": "Contango and Backwardation",
+      "term": "contango and backwardation",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -2339,7 +2339,7 @@
       "commentary": ""
     },
     "copy-trading": {
-      "term": "Copy Trading",
+      "term": "copy trading",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -2353,7 +2353,7 @@
       "commentary": ""
     },
     "counterparty-risk": {
-      "term": "Counterparty Risk",
+      "term": "counterparty risk",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -2367,7 +2367,7 @@
       "commentary": ""
     },
     "credentials": {
-      "term": "Credentials",
+      "term": "credentials",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -2381,7 +2381,7 @@
       "commentary": ""
     },
     "cross-chain-bridges": {
-      "term": "Cross-Chain Bridges",
+      "term": "cross-chain bridge",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -2392,7 +2392,7 @@
       "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/cross-chain-bridges",
       "dateFirstRecorded": "2025-01-31",
-      "commentary": ""
+      "commentary": "This phrasing, as used by Binance, is perhaps redundant. A bridge between blockchains is, by definition, cross-chain."
     },
     "crypto-": {
       "term": "crypto-",
@@ -2451,7 +2451,7 @@
       "commentary": ""
     },
     "crypto-etfs": {
-      "term": "Crypto ETFs",
+      "term": "crypto ETF",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -2493,7 +2493,7 @@
       "commentary": ""
     },
     "crypto-protocol": {
-      "term": "Crypto Protocol",
+      "term": "crypto protocol",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -2504,7 +2504,7 @@
       "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/crypto-protocol",
       "dateFirstRecorded": "2025-01-31",
-      "commentary": ""
+      "commentary": "This phrasing, as used by Binance, is perhaps implying a differentiation where one does not exist. A protocol is a protocol, regardless of whether it is employed in a crypto context or otherwise."
     },
     "crypto-wallet": {
       "term": "crypto wallet",
@@ -2521,7 +2521,7 @@
       "commentary": ""
     },
     "crypto-winter": {
-      "term": "Crypto Winter",
+      "term": "crypto Winter",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -2648,9 +2648,9 @@
       "commentary": ""
     },
     "daemon": {
-      "term": "Daemon",
-      "partOfSpeech": "",
-      "termCategory": "",
+      "term": "daemon",
+      "partOfSpeech": "noun",
+      "termCategory": "Computer science",
       "phonetic": "",
       "definition": "A process operating in the background waiting for a specific event or condition in order to be activated.",
       "definitionSource": "https://academy.binance.com/en/glossary/daemon",
@@ -2732,7 +2732,7 @@
       "commentary": ""
     },
     "dead-cat-bounce": {
-      "term": "Dead Cat Bounce",
+      "term": "dead cat bounce",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -2746,7 +2746,7 @@
       "commentary": ""
     },
     "death-cross": {
-      "term": "Death Cross",
+      "term": "death cross",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -2779,7 +2779,7 @@
       "termCategory": "",
       "phonetic": "/ˌdiːsɛntrəlaɪzd ˌæplɪˈkeɪʃən/",
       "definition": "An open-source software application with backend (not user-facing) code running on a decentralized peer-to-peer network, rather than a centralized server. You may see alternate spellings: dApps, DApps, Dapps, and Đapps.",
-      "definitionSource": "https://academy.binance.com/en/glossary/decentralized-application",
+      "definitionSource": "Consensys Software Inc., Blockchain Glossary for Beginners, Education DAO",
       "sampleSentence": "",
       "extended": "",
       "alternate": [
@@ -2804,7 +2804,7 @@
       "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/decentralized-autonomous-cooperative",
       "dateFirstRecorded": "2025-01-31",
-      "commentary": ""
+      "commentary": "Arguably, a DAO is, or often ends up being, simply 'an online cooperative with some smart contracts, maybe'."
     },
     "decentralized-autonomous-organization": {
       "term": "Decentralized Autonomous Organization",
@@ -2812,7 +2812,7 @@
       "termCategory": "",
       "phonetic": "/ˌdiːsɛntrəlaɪzd ɔːˈtɒnəməs ˌɔrɡənaɪˈzeɪʃən/, /daʊ/",
       "definition": "A Decentralized Autonomous Organization (DAO, pronounced like the Chinese concept) is a powerful and very flexible organizational structure built on a blockchain.",
-      "definitionSource": "https://academy.binance.com/en/glossary/decentralized-autonomous-organization",
+      "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "Alternatively, the first known example of a DAO is referred to as The DAO. The DAO served as a form of investor-directed venture capital fund, which sought to provide enterprises with new decentralized business models. Ethereum-based, The DAO’s code was open source. The organization set the record for the most crowdfunded project in 2016. Those funds were partially stolen by hackers. The hack caused an Ethereum hard-fork which lead to the creation of Ethereum Classic.",
       "alternate": [

--- a/locales/en-US/en-US.json
+++ b/locales/en-US/en-US.json
@@ -10324,7 +10324,7 @@
       "alternate": [
         {
           "definition": "An output created in a transaction, which must be referenced in a future transaction to spend funds.",
-          "source": "https://academy.binance.com/en/glossary/unspent-transaction-output-utxo",
+          "source": "https://academy.binance.com/en/glossary/unspent-transaction-output-utxo"
         }
       ],
       "termSource": "",

--- a/locales/en-US/en-US.json
+++ b/locales/en-US/en-US.json
@@ -5564,7 +5564,7 @@
       "alternate": [
         {
           "definition": "Refers to the moment a private company starts offering its shares to the public for the first time.",
-          "source": "https://academy.binance.com/en/glossary/initial-public-offering",
+          "source": "https://academy.binance.com/en/glossary/initial-public-offering"
         }
       ],
       "termSource": "",
@@ -5572,7 +5572,7 @@
       "commentary": ""
     },
     "isolated-margin": {
-      "term": "Isolated Margin",
+      "term": "isolated margin",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -5586,7 +5586,7 @@
       "commentary": ""
     },
     "issuance": {
-      "term": "Issuance",
+      "term": "issuance",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -5628,7 +5628,7 @@
       "commentary": ""
     },
     "keccak": {
-      "term": "Keccak",
+      "term": "keccak",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -5661,7 +5661,7 @@
       "termCategory": "",
       "phonetic": "/ˈnoʊ jʊər ˈkʌstəmər/; /ˈkaɪs/",
       "definition": "A process in which a business must verify the identity and background information (address, financial details, etc.) of their customers. For example, current regulations and laws require banks and other financial institutions to keep and report customers' personal information and transactions.",
-      "definitionSource": "https://academy.binance.com/en/glossary/know-your-customer",
+      "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
       "alternate": [
@@ -5731,7 +5731,7 @@
       "commentary": ""
     },
     "laspeyres-index": {
-      "term": "Laspeyres Index",
+      "term": "Laspeyres index",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -5750,7 +5750,7 @@
       "termCategory": "",
       "phonetic": "/ˈleɪtənsi/",
       "definition": "In the context of Network latency: refers to the amount of time it takes for a computer on one network to communicate with a computer on another network. Network latency",
-      "definitionSource": "https://academy.binance.com/en/glossary/latency",
+      "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
       "alternate": [
@@ -5792,7 +5792,7 @@
       "commentary": ""
     },
     "law-of-demand": {
-      "term": "Law of Demand",
+      "term": "law of demand",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -5806,7 +5806,7 @@
       "commentary": ""
     },
     "layer-0": {
-      "term": "Layer 0",
+      "term": "layer 0",
       "partOfSpeech": "noun",
       "termCategory": "",
       "phonetic": "/ˈleɪər ˈzɪroʊ/",
@@ -5839,7 +5839,7 @@
       "termCategory": "",
       "phonetic": "/ˈleɪər ˈtuː/",
       "definition": "A Layer 2 network, or L2, is a blockchain that is built specifically to scale another network. For a full understanding of how this is achieved, see here. Some popular examples of this in the Ethereum ecosystem are Arbitrum, Optimism, and StarkNet. These chains are specifically built to handle a large number of transactions quickly by relying on Ethereum Mainnet for security functions, while optimizing for speed and scale. These networks are considered 'scaling solutions' while not being part of Ethereum's protocol-level scaling efforts. See also 'blockchain trilemma', 'modular blockchain', 'Serenity'. Contrast with 'sidechain'.",
-      "definitionSource": "https://academy.binance.com/en/glossary/layer-2",
+      "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
       "alternate": [
@@ -5858,7 +5858,7 @@
       "termCategory": "",
       "phonetic": "/ˈlɛdʒər/",
       "definition": "A physical book or a digital computer file where monetary and financial transactions are tracked and recorded.",
-      "definitionSource": "https://academy.binance.com/en/glossary/ledger",
+      "definitionSource": "Consensys Software, Inc., A Blockchain Glossary for Beginners",
       "sampleSentence": "",
       "extended": "",
       "alternate": [
@@ -5900,7 +5900,7 @@
       "commentary": ""
     },
     "leveraged-tokens": {
-      "term": "Leveraged Tokens",
+      "term": "leveraged tokens",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -5919,7 +5919,7 @@
       "termCategory": "",
       "phonetic": "/ˈlaɪbrəri/",
       "definition": "A collection of non-volatile resources used by computer programs, often for software development. These may include configuration data, documentation, help data, message templates, pre-written code and subroutines, classes, values or type specifications. Software Library",
-      "definitionSource": "https://academy.binance.com/en/glossary/library",
+      "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
       "alternate": [
@@ -5952,7 +5952,7 @@
       "termCategory": "",
       "phonetic": "/laɪt ˈklaɪənt/",
       "definition": "In computing, a 'client' is a software that runs or accesses a program made available by a remote computer. With blockchain networks, then, clients are the programs that sync blockchain data and participate in network consensus. More often and more specifically, 'Layer 2' is used as a noun, to refer to a type of network that is specifically built to handle a large number of transactions quickly by relying on Ethereum mainnet for security functions, and optimizing for speed and scale. Examples include Arbitrum and Optimism; this is different from a 'sidechain', which is a network that has its own security mechanism, yet still allows compatibility and bridging of assets between itself and Ethereum.",
-      "definitionSource": "",
+      "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
       "alternate": [
@@ -5970,8 +5970,8 @@
       "partOfSpeech": "noun",
       "termCategory": "",
       "phonetic": "/ˈlaɪtnɪŋ ˈnɛtwɜrk/",
-      "definition": "The Lightning Network is a second layer for Bitcoin that uses micropayment channels to scale the blockchain’s capability to conduct transactions more efficiently.\n\nThis layer consists of multiple payment channels between parties or Bitcoin users. A Lightning Network channel is a transaction mechanism between two parties. Using channels, the parties can make or receive payments from each other. Transactions conducted on the Lightning Network are faster, less costly, and more readily confirmed than those conducted directly on the Bitcoin blockchain.",
-      "definitionSource": "https://academy.binance.com/en/glossary/lightning-network",
+      "definition": "The Lightning Network is a second layer for Bitcoin that uses micropayment channels to scale the blockchain’s capability to conduct transactions more efficiently. This layer consists of multiple payment channels between parties or Bitcoin users. A Lightning Network channel is a transaction mechanism between two parties. Using channels, the parties can make or receive payments from each other. Transactions conducted on the Lightning Network are faster, less costly, and more readily confirmed than those conducted directly on the Bitcoin blockchain.",
+      "definitionSource": "Consensys Software, Inc., A Blockchain Glossary for Beginners",
       "sampleSentence": "",
       "extended": "",
       "alternate": [
@@ -5985,7 +5985,7 @@
       "commentary": ""
     },
     "limit-order": {
-      "term": "Limit Order",
+      "term": "limit order",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -6027,7 +6027,7 @@
       "commentary": ""
     },
     "liquid-democracy": {
-      "term": "Liquid Democracy",
+      "term": "liquid democracy",
       "partOfSpeech": "noun",
       "termCategory": "",
       "phonetic": "/ˈlɪkwɪd dɪˈmɒkrəsi/ (/ˈdɛlɪɡətɪv dɪˈmɒkrəsi/)",
@@ -6041,7 +6041,7 @@
       "commentary": ""
     },
     "liquid-staking": {
-      "term": "Liquid Staking",
+      "term": "liquid staking",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -6055,7 +6055,7 @@
       "commentary": ""
     },
     "liquid-staking-token-lst": {
-      "term": "Liquid Staking Token (LST)",
+      "term": "liquid staking token",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -6088,7 +6088,7 @@
       "termCategory": "",
       "phonetic": "/lɪˈkwɪdɪti/",
       "definition": "An asset is considered more ‘liquid’ if it can easily be converted into cash, and therefore, ‘liquidity’ refers to the availability of assets to a company or market. Conversely, the harder it is to turn an asset into cash, the more illiquid the asset. For example, stocks are considered relatively liquid assets, as they can be easily converted to cash, while real estate is considered an illiquid asset. The liquidity of an asset affects its risk potential and market price.",
-      "definitionSource": "https://academy.binance.com/en/glossary/liquidity",
+      "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
       "alternate": [
@@ -6102,7 +6102,7 @@
       "commentary": ""
     },
     "liquidity-crisis": {
-      "term": "Liquidity Crisis",
+      "term": "liquidity crisis",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -6144,7 +6144,7 @@
       "commentary": ""
     },
     "liquidity-ratios": {
-      "term": "Liquidity Ratios",
+      "term": "liquidity ratios",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -6172,7 +6172,7 @@
       "commentary": ""
     },
     "listing": {
-      "term": "Listing",
+      "term": "listing",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -6191,7 +6191,7 @@
       "termCategory": "",
       "phonetic": "/ˈmeɪnˌnɛt/",
       "definition": "The primary network where actual transactions take place on a specific distributed ledger. For example, The Ethereum Mainnet (capitalized in this case) is the public blockchain where network validation and transactions take place",
-      "definitionSource": "https://academy.binance.com/en/glossary/mainnet",
+      "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
       "alternate": [
@@ -6205,7 +6205,7 @@
       "commentary": ""
     },
     "mainnet-swap": {
-      "term": "Mainnet Swap",
+      "term": "mainnet swap",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -6219,7 +6219,7 @@
       "commentary": ""
     },
     "maker": {
-      "term": "Maker",
+      "term": "maker",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -6252,7 +6252,7 @@
       "termCategory": "",
       "phonetic": "/ˈmælwɛər/",
       "definition": "Any software intentionally designed to cause disruption to a computer, server, client, or computer network, leak private information, gain unauthorized access to information or systems, deprive access to information, or which unknowingly interferes with the user's computer security and privacy.",
-      "definitionSource": "https://academy.binance.com/en/glossary/malware",
+      "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
       "alternate": [
@@ -6266,7 +6266,7 @@
       "commentary": ""
     },
     "margin-trading": {
-      "term": "Margin Trading",
+      "term": "margin trading",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -6288,27 +6288,18 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "The total trading value of a given coin - calculated by the product of the supply of the coin by the current price.",
+          "source": "https://academy.binance.com/en/glossary/market-capitalization"
+        }
+      ],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "market-capitalization": {
-      "term": "Market Capitalization",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "The total trading value of a given coin - calculated by the product of the supply of the coin by the current price.",
-      "definitionSource": "https://academy.binance.com/en/glossary/market-capitalization",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "https://academy.binance.com/en/glossary/market-capitalization",
-      "dateFirstRecorded": "2025-01-31",
-      "commentary": ""
-    },
     "market-momentum": {
-      "term": "Market Momentum",
+      "term": "market momentum",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",

--- a/locales/en-US/en-US.json
+++ b/locales/en-US/en-US.json
@@ -6313,7 +6313,7 @@
       "commentary": ""
     },
     "market-order": {
-      "term": "Market Order",
+      "term": "market order",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -6327,7 +6327,7 @@
       "commentary": ""
     },
     "masternode": {
-      "term": "Masternode",
+      "term": "masternode",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -6341,7 +6341,7 @@
       "commentary": ""
     },
     "matching-engine": {
-      "term": "Matching Engine",
+      "term": "matching engine",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -6383,7 +6383,7 @@
       "commentary": ""
     },
     "maximum-supply": {
-      "term": "Maximum Supply",
+      "term": "maximum supply",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -6415,8 +6415,8 @@
       "partOfSpeech": "noun",
       "termCategory": "",
       "phonetic": "/ˈmɛmpuːl/",
-      "definition": "abbreviation; Memory Pool. Also commonly referred to as a 'transaction pool'.\n\nWhen a user submits a transaction to the Ethereum network–or many other networks based on Ethereum–the transaction goes into what’s known as a “transaction pool”, or “txpool” for short. This is essentially a queue of transactions that are waiting to be added to a block and recorded to the blockchain. There are mechanisms that determine which transactions are “picked up” and included in the next block, and there is currently a lot of research surrounding how this decision gets made. In Bitcoin, the transaction pool was referred to as the “memory pool”, or “mempool”, and often these terms are used interchangeably.",
-      "definitionSource": "https://academy.binance.com/en/glossary/mempool",
+      "definition": "abbreviation; Memory Pool. Also commonly referred to as a 'transaction pool'. When a user submits a transaction to the Ethereum network–or many other networks based on Ethereum–the transaction goes into what’s known as a “transaction pool”, or “txpool” for short. This is essentially a queue of transactions that are waiting to be added to a block and recorded to the blockchain. There are mechanisms that determine which transactions are “picked up” and included in the next block, and there is currently a lot of research surrounding how this decision gets made. In Bitcoin, the transaction pool was referred to as the “memory pool”, or “mempool”, and often these terms are used interchangeably.",
+      "definitionSource": "Consensys Software Inc., A Blockchain Glossary for Beginners",
       "sampleSentence": "",
       "extended": "",
       "alternate": [
@@ -6458,7 +6458,7 @@
       "commentary": ""
     },
     "merged-mining": {
-      "term": "Merged Mining",
+      "term": "merged mining",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -6472,12 +6472,12 @@
       "commentary": ""
     },
     "merkle-patricia-trie": {
-      "term": "Merkle Patricia trie",
+      "term": "Merkle PATRICIA trie",
       "partOfSpeech": "noun",
       "termCategory": "",
       "phonetic": "/ˈmɜrkl pəˈtrɪʃə traɪ/",
       "definition": "Often referred to simply as a 'Merkle trie' (pronounced 'tree'), a Merkle Patricia trie is a data structure in which a single hash code function (see 'hash') splits into smaller branches. In a similar way to a family tree, where a parent branch splits into child branches, which are then extrapolated into grandchild branches, a Merkle Patricia trie keeps a record of the filiation and history of each element. This type of data structure enables for faster verification on a blockchain network.",
-      "definitionSource": "",
+      "definitionSource": "Consensys Software Inc., A Blockchain Glossary for Beginners",
       "sampleSentence": "",
       "extended": "",
       "alternate": [],
@@ -6499,8 +6499,8 @@
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
-    "mesh": {
-      "term": "Mesh",
+    "consensys-mesh": {
+      "term": "Consensys Mesh",
       "partOfSpeech": "noun",
       "termCategory": "",
       "phonetic": "/mɛʃ/",
@@ -6519,7 +6519,7 @@
       "termCategory": "",
       "phonetic": "/ˈmɛtəˌdeɪtə/",
       "definition": "In the context of 'NFT metadata': Metadata is 'data that provides information about other data' Metadata",
-      "definitionSource": "https://academy.binance.com/en/glossary/metadata",
+      "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
       "alternate": [
@@ -6607,8 +6607,8 @@
       "partOfSpeech": "noun",
       "termCategory": "",
       "phonetic": "/ˈmɛtəˌvɜrs/",
-      "definition": "A metaverse is a digital universe that contains all the aspects of the real world, such as real-time interactions and economies. It offers a unique experience to end-users. Metaverse",
-      "definitionSource": "https://academy.binance.com/en/glossary/metaverse",
+      "definition": "A metaverse is a digital universe that contains some aspects of the real world, such as real-time interactions and economies. It offers a unique experience to end-users. Metaverse",
+      "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
       "alternate": [
@@ -6650,7 +6650,7 @@
       "commentary": ""
     },
     "microtransactions": {
-      "term": "Microtransactions",
+      "term": "microtransactions",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -6697,7 +6697,7 @@
       "termCategory": "",
       "phonetic": "/ˈmaɪnɪŋ/",
       "definition": "The process by which blocks or transactions are verified and added to a blockchain using a Proof of Work (PoW) consensus mechanism. In order to verify a block, a miner must use a computer to solve a cryptographic problem. Once the computer has solved the problem, the block is considered “mined” or verified. On Bitcoin or other PoW blockchains, the first computer to mine or verify the block receives bitcoin, or the equivalent network token, as a reward.",
-      "definitionSource": "https://academy.binance.com/en/glossary/mining",
+      "definitionSource": "Consensys Software Inc., A Blockchain Glossary for Beginners",
       "sampleSentence": "",
       "extended": "",
       "alternate": [
@@ -6711,7 +6711,7 @@
       "commentary": ""
     },
     "mining-farm": {
-      "term": "Mining Farm",
+      "term": "mining farm",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -6730,7 +6730,7 @@
       "termCategory": "",
       "phonetic": "/mɪnt/",
       "definition": "Minting refers to the act of publishing a token on the blockchain to make it transferrable and purchasable.",
-      "definitionSource": "https://academy.binance.com/en/glossary/mint",
+      "definitionSource": "Consensys Software Inc., A Blockchain Glossary for Beginners",
       "sampleSentence": "",
       "extended": "",
       "alternate": [
@@ -6786,7 +6786,7 @@
       "commentary": ""
     },
     "monetary-policy": {
-      "term": "Monetary Policy",
+      "term": "monetary policy",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",

--- a/locales/en-US/en-US.json
+++ b/locales/en-US/en-US.json
@@ -6923,7 +6923,7 @@
       "alternate": [
         {
           "definition": "Wallet which requires another party to authorize a transaction before it is broadcasted to the network.",
-          "source": "https://academy.binance.com/en/glossary/multisignature",
+          "source": "https://academy.binance.com/en/glossary/multisignature"
         }
       ],
       "termSource": "",
@@ -7147,7 +7147,7 @@
       "alternate": [
         {
           "definition": "A type of cryptographic token that represents a unique digital or real-world asset and isn't interchangeable.",
-          "source": "https://academy.binance.com/en/glossary/non-fungible-token-nft",
+          "source": "https://academy.binance.com/en/glossary/non-fungible-token-nft"
         }
       ],
       "termSource": "",
@@ -9524,7 +9524,7 @@
       "alternate": [
         {
           "definition": "A two-way communication channel between two users or nodes on a network, or between a user and a service.",
-          "source": "https://academy.binance.com/en/glossary/state-channel",
+          "source": "https://academy.binance.com/en/glossary/state-channel"
         }
       ],
       "termSource": "",
@@ -9934,7 +9934,7 @@
       "commentary": ""
     },
     "tokenization": {
-      "term": "Tokenization",
+      "term": "tokenization",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -9948,7 +9948,7 @@
       "commentary": ""
     },
     "tokenomics": {
-      "term": "Tokenomics",
+      "term": "tokenomics",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -9962,7 +9962,7 @@
       "commentary": ""
     },
     "total-supply": {
-      "term": "Total Supply",
+      "term": "total supply",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -9976,7 +9976,7 @@
       "commentary": ""
     },
     "total-value-locked-tvl": {
-      "term": "Total Value Locked (TVL)",
+      "term": "Total Value Locked",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -10009,7 +10009,7 @@
       "termCategory": "",
       "phonetic": "/trænˈzækʃən/",
       "definition": "Data committed to the Ethereum Blockchain signed by an originating account, targeting a specific address. The transaction contains metadata such as the gas limit for that transaction.",
-      "definitionSource": "",
+      "definitionSource": "Consensys Software Inc., A Blockchain Glossary for Beginners",
       "sampleSentence": "",
       "extended": "",
       "alternate": [
@@ -10056,7 +10056,7 @@
       "termCategory": "",
       "phonetic": "/trænˈzækʃən ˈaɪˈdiː/",
       "definition": "A transaction hash/ID (often abbreviated as tx hash or txn hash) is a unique identifier, similar to a receipt, that serves as proof that a transaction was validated and added to the blockchain. In many cases, a transaction hash is needed in order to locate funds.",
-      "definitionSource": "https://academy.binance.com/en/glossary/transaction-id",
+      "definitionSource": "Consensys Software Inc., A Blockchain Glossary for Beginners",
       "sampleSentence": "",
       "extended": "",
       "alternate": [
@@ -10088,15 +10088,20 @@
       "commentary": ""
     },
     "transactions-per-second-tps": {
-      "term": "Transactions Per Second (TPS)",
+      "term": "transactions per second",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
       "definition": "The number of transactions that a blockchain network is capable of processing each second.",
       "definitionSource": "https://academy.binance.com/en/glossary/transactions-per-second-tps",
       "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
+      "extended": "Generally abbreviated to 'TPS'.",
+      "alternate": [
+        {
+          "definition": "Transactions per second.",
+          "source": "https://solana.com/docs/references/terminology#tps"
+        }
+      ],
       "termSource": "https://academy.binance.com/en/glossary/transactions-per-second-tps",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -10116,7 +10121,7 @@
       "commentary": ""
     },
     "treasury-bills-t-bills": {
-      "term": "Treasury Bills (T-Bills)",
+      "term": "Treasury Bills",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -10162,7 +10167,7 @@
       "partOfSpeech": "noun",
       "termCategory": "",
       "phonetic": "/ˈtrʌfəl/",
-      "definition": "Truffle Suite is a development environment based on Ethereum Blockchain, used to develop dapps. Truffle is a one-stop solution for building dapps: compiling contracts, deploying contracts, injecting it into a web app, creating front-end for dapps and testing.\nTruffle Suite",
+      "definition": "Truffle Suite was a development environment based on Ethereum Blockchain, used to develop dapps. Truffle allowed for compiling contracts, deploying contracts, injecting them into a web app, creating front-end for dapps and testing.",
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
@@ -10177,7 +10182,7 @@
       "termCategory": "",
       "phonetic": "/ˈtrʌstlɪs/",
       "definition": "Trustless' is a term that gets used a lot in the decentralized web, and it deserves some explanation. Traditionally, to call something 'trustless' would sound like a negative thing. In the context of decentralized technology, it has a more technical meaning: since everyone has a copy of the ledger of all transactions ever executed, there is no need for a centralized entity that 'must be trusted' as the source of truth. With public blockchain networks, data isn't kept on some centralized server somewhere that could be hacked or changed arbitrarily; anyone can verify the transactions themselves. This is why the term 'trustless' was coined: there is no need for trust, although, in a way, the rules and assurances built into the blockchain provide the basis for greater trust between people, because the system is guaranteed to work the same for everyone.",
-      "definitionSource": "https://academy.binance.com/en/glossary/trustless",
+      "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
       "alternate": [
@@ -10196,7 +10201,7 @@
       "termCategory": "",
       "phonetic": "/ˈtjʊərɪŋ kəmˈpliːt/",
       "definition": "Any machine that can calculate on a level equal to a programmable computer is Turing-complete, or computationally universal. The Ethereum Virtual Machine, which processes smart contracts and transactions, is Turing-complete, despite not existing on a single physical computer.",
-      "definitionSource": "https://academy.binance.com/en/glossary/turing-complete",
+      "definitionSource": "Consensys Software Inc., A Blockchain Glossary for Beginners",
       "sampleSentence": "",
       "extended": "",
       "alternate": [
@@ -10270,8 +10275,8 @@
       "partOfSpeech": "noun",
       "termCategory": "",
       "phonetic": "/ʌnɪnˈkrɪptɪd kiː/",
-      "definition": "In MetaMask, an unencrypted private key is 64 characters long, and it is used to unlock or restore wallets. An encrypted key is also 64 letters long and is a regular private key that has gone through the process of encryption. Usually, encrypted private keys are kept within the extension or device they are encrypted by, and they remain out of sight from the user. This is meant to add another layer of security to keep a user’s wallet information safe. By way of example: if the world ‘Apple’ was your private key, then it was encrypted three letters down the alphabet, your new encrypted key would be ‘Dssoh’. Since you know the way to encrypt this key, you could derive the original private key from it by reversing the method of encryption.",
-      "definitionSource": "",
+      "definition": "In an Ethereum wallet application like MetaMask, an unencrypted private key is 64 characters long, and it is used to unlock or restore wallets. An encrypted key is also 64 letters long and is a regular private key that has gone through the process of encryption. Usually, encrypted private keys are kept within the extension or device they are encrypted by, and they remain out of sight from the user. This is meant to add another layer of security to keep a user’s wallet information safe. By way of example: if the world ‘Apple’ was your private key, then it was encrypted three letters down the alphabet, your new encrypted key would be ‘Dssoh’. Since you know the way to encrypt this key, you could derive the original private key from it by reversing the method of encryption.",
+      "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
       "alternate": [],
@@ -10316,23 +10321,14 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "An output created in a transaction, which must be referenced in a future transaction to spend funds.",
+          "source": "https://academy.binance.com/en/glossary/unspent-transaction-output-utxo",
+        }
+      ],
       "termSource": "",
       "dateFirstRecorded": "",
-      "commentary": ""
-    },
-    "unspent-transaction-output-utxo": {
-      "term": "Unspent Transaction Output (UTXO)",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "An output created in a transaction, which must be referenced in a future transaction to spend funds.",
-      "definitionSource": "https://academy.binance.com/en/glossary/unspent-transaction-output-utxo",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "https://academy.binance.com/en/glossary/unspent-transaction-output-utxo",
-      "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
     "unstake": {
@@ -10406,7 +10402,7 @@
       "commentary": ""
     },
     "utility-token": {
-      "term": "Utility Token",
+      "term": "utility token",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -10439,7 +10435,7 @@
       "termCategory": "",
       "phonetic": "/ˈvælɪˌdeɪtər/",
       "definition": "A participant in Proof of Stake (PoS) consensus. On Ethereum’s Proof of Stake network, validators need to stake 32 ETH in order to get included in the validator set. See also ‘staking’.",
-      "definitionSource": "",
+      "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
       "alternate": [
@@ -10523,7 +10519,7 @@
       "commentary": ""
     },
     "virtual-machine": {
-      "term": "Virtual Machine",
+      "term": "virtual machine",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -10551,7 +10547,7 @@
       "commentary": ""
     },
     "volatility": {
-      "term": "Volatility",
+      "term": "volatility",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -10565,7 +10561,7 @@
       "commentary": ""
     },
     "volume": {
-      "term": "Volume",
+      "term": "volume",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -10581,9 +10577,9 @@
     "wagmi": {
       "term": "WAGMI",
       "partOfSpeech": "",
-      "termCategory": "",
+      "termCategory": "meme",
       "phonetic": "",
-      "definition": "WAGMI is an acronym for \"We’re All Gonna Make It\" that encourages an optimistic attitude, particularly within the crypto community.",
+      "definition": "WAGMI is an acronym for 'We’re All Gonna Make It' that encourages an optimistic attitude, particularly within the crypto community.",
       "definitionSource": "https://academy.binance.com/en/glossary/wagmi",
       "sampleSentence": "",
       "extended": "",
@@ -10598,7 +10594,7 @@
       "termCategory": "",
       "phonetic": "/ˈwɒlɪt/",
       "definition": "In Ethereum-based blockchain technology, a 'wallet' is a something that allows you to manage private keys, your Secret Recovery Phrase, and the accounts generated from it. This could be an internet-connected 'hot wallet', like MetaMask, or an 'airgapped' hardware wallet. In more technical speak, you could say 'the wallet is the client, not the keys.' It is very common for people to use the word 'wallet' to refer to their SRP itself, or the accounts generated from it, or even to one account.",
-      "definitionSource": "https://academy.binance.com/en/glossary/wallet",
+      "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
       "alternate": [
@@ -10644,7 +10640,7 @@
       "commentary": ""
     },
     "wash-trading": {
-      "term": "Wash Trading",
+      "term": "wash trading",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -10658,7 +10654,7 @@
       "commentary": ""
     },
     "weak-hands": {
-      "term": "Weak Hands",
+      "term": "weak hands",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -10672,7 +10668,7 @@
       "commentary": ""
     },
     "weak-subjectivity": {
-      "term": "Weak Subjectivity",
+      "term": "weak subjectivity",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -10775,7 +10771,7 @@
       "termCategory": "",
       "phonetic": "/wiː/",
       "definition": "Wei is the smallest denomination of ether, the currency used to facilitate transactional operations on the Ethereum blockchain network, where 10^18 or 1,000,000,000,000,000,000 wei is equivalent to one ether.",
-      "definitionSource": "https://academy.binance.com/en/glossary/wei",
+      "definitionSource": "Consensys Software Inc., A Blockchain Glossary for Beginners",
       "sampleSentence": "",
       "extended": "",
       "alternate": [
@@ -10789,7 +10785,7 @@
       "commentary": ""
     },
     "weighted-moving-average-wma": {
-      "term": "Weighted Moving Average (WMA)",
+      "term": "weighted moving average",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -10803,7 +10799,7 @@
       "commentary": ""
     },
     "whale": {
-      "term": "Whale",
+      "term": "whale",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -10817,7 +10813,7 @@
       "commentary": ""
     },
     "whiskers": {
-      "term": "Whiskers",
+      "term": "whiskers",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -10831,7 +10827,7 @@
       "commentary": ""
     },
     "whitelist": {
-      "term": "Whitelist",
+      "term": "whitelist",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -10859,7 +10855,7 @@
       "commentary": ""
     },
     "wick": {
-      "term": "Wick",
+      "term": "wick",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -10873,7 +10869,7 @@
       "commentary": ""
     },
     "win-rate": {
-      "term": "Win Rate",
+      "term": "win rate",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -10887,7 +10883,7 @@
       "commentary": ""
     },
     "wrapped-ether": {
-      "term": "Wrapped Ether (WETH)",
+      "term": "wrapped ether (WETH)",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -10990,7 +10986,7 @@
       "termCategory": "",
       "phonetic": "/ˈjiːld ˈfɑːrmɪŋ/",
       "definition": "Yield farming is an investment practice that involves locking crypto in a dapp for token rewards. Yield farmers deposit their tokens into DeFi applications for crypto trading, lending, or borrowing.",
-      "definitionSource": "https://academy.binance.com/en/glossary/yield-farming",
+      "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
       "alternate": [
@@ -11026,23 +11022,14 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "Verify transactions are valid without revealing any information about the transactions, providing privacy.",
+          "source": "https://academy.binance.com/en/glossary/zero-knowledge-proofs"
+        }
+      ],
       "termSource": "",
       "dateFirstRecorded": "",
-      "commentary": ""
-    },
-    "zero-knowledge-proofs": {
-      "term": "Zero-Knowledge Proofs",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "Verify transactions are valid without revealing any information about the transactions, providing privacy.",
-      "definitionSource": "https://academy.binance.com/en/glossary/zero-knowledge-proofs",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "https://academy.binance.com/en/glossary/zero-knowledge-proofs",
-      "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
     "zero-knowledge-rollup": {
@@ -11054,23 +11041,14 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "Zk-rollup is a layer-2 scaling solution designed to increase the transaction throughput of blockchain networks without compromising on security.",
+          "source": "https://academy.binance.com/en/glossary/zk-rollup"
+        }
+      ],
       "termSource": "",
       "dateFirstRecorded": "",
-      "commentary": ""
-    },
-    "zk-rollup": {
-      "term": "Zk-rollup",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "Zk-rollup is a layer-2 scaling solution designed to increase the transaction throughput of blockchain networks without compromising on security.",
-      "definitionSource": "https://academy.binance.com/en/glossary/zk-rollup",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "https://academy.binance.com/en/glossary/zk-rollup",
-      "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
     "zk-snarks": {
@@ -11079,7 +11057,7 @@
       "termCategory": "",
       "phonetic": "/ˌzɛdˌkeɪˈsnɑːrks/",
       "definition": "Combination acronym-initialism; Zero-Knowledge Succinct Non-interactive ARguments of Knowledge. zk-SNARKs are an incredible technology, and vital to the scaling of blockchain technology and the decentralized web. They are mathematically complex and can be daunting; this explanation from the Ethereum Foundation is a good primer.",
-      "definitionSource": "https://academy.binance.com/en/glossary/zk-snarks",
+      "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
       "alternate": [
@@ -11681,7 +11659,7 @@
       "commentary": ""
     },
     "program-derived-account-PDA": {
-      "term": "program derived account (PDA)",
+      "term": "program derived account",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -11709,7 +11687,7 @@
       "commentary": ""
     },
     "proof-of-history-PoH": {
-      "term": "proof of history (PoH)",
+      "term": "proof of history",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -12002,22 +11980,8 @@
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
     },
-    "tps": {
-      "term": "tps",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "Transactions per second.",
-      "definitionSource": "https://solana.com/docs/references/terminology#tps",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "Solana Glossary",
-      "dateFirstRecorded": "2025-02-14",
-      "commentary": ""
-    },
     "tpu": {
-      "term": "tpu",
+      "term": "TPU",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -12059,7 +12023,7 @@
       "commentary": ""
     },
     "TVU": {
-      "term": "tvu",
+      "term": "TVU",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -12087,7 +12051,7 @@
       "commentary": ""
     },
     "verifiable-delay-function": {
-      "term": "verifiable delay function (VDF)",
+      "term": "verifiable delay function",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",

--- a/locales/en-US/en-US.json
+++ b/locales/en-US/en-US.json
@@ -6800,7 +6800,7 @@
       "commentary": ""
     },
     "money-markets": {
-      "term": "Money Markets",
+      "term": "money markets",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -6814,7 +6814,7 @@
       "commentary": ""
     },
     "monitoring-tag": {
-      "term": "Monitoring Tag",
+      "term": "monitoring tag",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -6828,9 +6828,9 @@
       "commentary": ""
     },
     "moon": {
-      "term": "Moon",
-      "partOfSpeech": "",
-      "termCategory": "",
+      "term": "moon",
+      "partOfSpeech": "verb",
+      "termCategory": "meme",
       "phonetic": "",
       "definition": "A colloquial expression used to describe a cryptocurrency or other asset that is experiencing a strong upward market trend.",
       "definitionSource": "https://academy.binance.com/en/glossary/moon",
@@ -6856,7 +6856,7 @@
       "commentary": ""
     },
     "moving-average-envelopes": {
-      "term": "Moving Average Envelopes",
+      "term": "moving average envelopes",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -6870,7 +6870,7 @@
       "commentary": ""
     },
     "moving-average-ribbon": {
-      "term": "Moving Average Ribbon",
+      "term": "moving average ribbon",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -6920,23 +6920,14 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "Wallet which requires another party to authorize a transaction before it is broadcasted to the network.",
+          "source": "https://academy.binance.com/en/glossary/multisignature",
+        }
+      ],
       "termSource": "",
       "dateFirstRecorded": "",
-      "commentary": ""
-    },
-    "multisignature": {
-      "term": "Multisignature",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "Wallet which requires another party to authorize a transaction before it is broadcasted to the network.",
-      "definitionSource": "https://academy.binance.com/en/glossary/multisignature",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "https://academy.binance.com/en/glossary/multisignature",
-      "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
     "nakamoto-consensus": {

--- a/locales/en-US/en-US.json
+++ b/locales/en-US/en-US.json
@@ -6959,7 +6959,7 @@
       "commentary": ""
     },
     "net-asset-value-nav": {
-      "term": "Net Asset Value (NAV)",
+      "term": "net asset value",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -7057,7 +7057,7 @@
       "commentary": ""
     },
     "nft-floor-prices": {
-      "term": "NFT Floor Prices",
+      "term": "NFT floor price",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -7071,7 +7071,7 @@
       "commentary": ""
     },
     "nft-mystery-boxes": {
-      "term": "NFT Mystery Boxes",
+      "term": "NFT mystery box",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -7087,7 +7087,7 @@
     "ngmi": {
       "term": "NGMI",
       "partOfSpeech": "",
-      "termCategory": "",
+      "termCategory": "meme",
       "phonetic": "",
       "definition": "NGMI is an acronym for \"Not Gonna Make It,” used to convey a sense of pessimism in achieving success or overcoming a challenge.",
       "definitionSource": "https://academy.binance.com/en/glossary/ngmi",
@@ -7118,7 +7118,7 @@
       "termCategory": "",
       "phonetic": "/noʊd/",
       "definition": "Public blockchains consist of a network of computers which sync the network's data, coordinate transaction requests, and participate in consensus regarding the validity of those transactions; each one of these computers is called a 'node'. A full node is a computer that can fully validate transactions and download the entire data of a specific blockchain. In contrast, a “lightweight” or “light” node does not download all pieces of a blockchain’s data, and uses a different validation process.",
-      "definitionSource": "https://academy.binance.com/en/glossary/node",
+      "definitionSource": "Consensys Software Inc., A Blockchain Glossary for Beginners",
       "sampleSentence": "",
       "extended": "",
       "alternate": [
@@ -7144,23 +7144,14 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "A type of cryptographic token that represents a unique digital or real-world asset and isn't interchangeable.",
+          "source": "https://academy.binance.com/en/glossary/non-fungible-token-nft",
+        }
+      ],
       "termSource": "",
       "dateFirstRecorded": "",
-      "commentary": ""
-    },
-    "non-fungible-token-nft": {
-      "term": "Non-Fungible Token (NFT)",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "A type of cryptographic token that represents a unique digital or real-world asset and isn't interchangeable.",
-      "definitionSource": "https://academy.binance.com/en/glossary/non-fungible-token-nft",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "https://academy.binance.com/en/glossary/non-fungible-token-nft",
-      "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
     "nonce": {
@@ -7169,7 +7160,7 @@
       "termCategory": "",
       "phonetic": "/nɒns/",
       "definition": "The word ‘nonce’ has a few different meanings, and in different contexts, it ends up getting used a lot of different ways. Originally formed from a contraction of a phrase meaning “not more than once”, on the Ethereum Mainnet, “nonce” refers to a unique transaction identification number that increases in value with each successive transaction in order to ensure various safety features (such as preventing a double-spend). Note that due to its broader use in cryptography, you may encounter ‘nonce’ being used differently on other sidechains or decentralized projects.",
-      "definitionSource": "https://academy.binance.com/en/glossary/nonce",
+      "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
       "alternate": [
@@ -7183,7 +7174,7 @@
       "commentary": ""
     },
     "oco-order": {
-      "term": "OCO Order",
+      "term": "one cancels the other order",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -7198,11 +7189,11 @@
     },
     "off-chain": {
       "term": "off-chain",
-      "partOfSpeech": "adjective",
+      "partOfSpeech": "adjective phrase",
       "termCategory": "",
       "phonetic": "/ˌɒfˈtʃeɪn/",
       "definition": "A transaction that is processed outside the blockchain network with an increased speed and reduced cost. There are two different transactions that occur on the blockchain:\nOn-chain transactions are those reflected on the distributed ledger and are visible to all the network users. On the other hand, off-chain transactions occur outside the blockchain network. Such a transaction doesn’t need the services of miners because no ledger verification is conducted.\nUnlike on-chain transactions, off-chain transactions can be made instantly. This method entails lower fees, happens instantly, and offers more anonymity.",
-      "definitionSource": "https://academy.binance.com/en/glossary/off-chain",
+      "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
       "alternate": [
@@ -7230,7 +7221,7 @@
       "commentary": ""
     },
     "offline-signing-orchestrator-oso": {
-      "term": "Offline Signing Orchestrator (OSO)",
+      "term": "offline signing orchestrator",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -7244,7 +7235,7 @@
       "commentary": ""
     },
     "offshore-account": {
-      "term": "Offshore account",
+      "term": "offshore account",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -7277,7 +7268,7 @@
       "termCategory": "",
       "phonetic": "/ˌɒnˈtʃeɪn/",
       "definition": "On-chain, as the name implies, refers to blockchain transactions that exist on and have been verified to the blockchain by miners or validators. On-Chain also means that transactions have been recorded to the blockchain",
-      "definitionSource": "https://academy.binance.com/en/glossary/on-chain",
+      "definitionSource": "Consensys Software Inc., A Blockchain Glossary for Beginners",
       "sampleSentence": "",
       "extended": "",
       "alternate": [
@@ -7333,7 +7324,7 @@
       "commentary": ""
     },
     "open-source-software-oss": {
-      "term": "Open-Source Software (OSS)",
+      "term": "Open-Source Software",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -7375,7 +7366,7 @@
       "commentary": ""
     },
     "opportunity-cost": {
-      "term": "Opportunity Cost",
+      "term": "opportunity cost",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -7393,7 +7384,7 @@
       "partOfSpeech": "noun",
       "termCategory": "",
       "phonetic": "/ɒpˈtɪmɪzəm/",
-      "definition": "Optimism is a layer-2 scaling solution for Ethereum, which is a blockchain-based platform for decentralized applications. It is designed to reduce the cost and increase the speed of transactions on the Ethereum network. Optimism works by using a technique called optimistic rollups, which allows it to process a large number of transactions off-chain, while still maintaining the security and decentralization of the Ethereum network.\n\nIn optimistic rollups, transactions are initially processed off-chain, and a summary of these transactions is then submitted to the Ethereum network for verification. This verification process ensures that the transactions are valid and that no fraud has occurred. Once the transactions are verified, they are added to the Ethereum blockchain, allowing users to interact with the decentralized applications built on the platform.",
+      "definition": "Optimism is a layer-2 scaling solution for Ethereum, which s://academy.binance.com/en/glossary/on-chainis a blockchain-based platform for decentralized applications. It is designed to reduce the cost and increase the speed of transactions on the Ethereum network. Optimism works by using a technique called optimistic rollups, which allows it to process a large number of transactions off-chain, while still maintaining the security and decentralization of the Ethereum network.\n\nIn optimistic rollups, transactions are initially processed off-chain, and a summary of these transactions is then submitted to the Ethereum network for verification. This verification process ensures that the transactions are valid and that no fraud has occurred. Once the transactions are verified, they are added to the Ethereum blockchain, allowing users to interact with the decentralized applications built on the platform.",
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
@@ -7422,7 +7413,7 @@
       "termCategory": "",
       "phonetic": "/ˈɔrəkəl/",
       "definition": "Typically, an oracle is any entity or person that is relied on to report the outcome of an event. In a blockchain network an oracle (human or machine) helps communicate data to a smart contract, which can then be used to verify an event or specific outcome.",
-      "definitionSource": "https://academy.binance.com/en/glossary/oracle",
+      "definitionSource": "Consensys Software Inc., A Blockchain Glossary for Beginners",
       "sampleSentence": "",
       "extended": "",
       "alternate": [
@@ -7450,7 +7441,7 @@
       "commentary": ""
     },
     "order-book": {
-      "term": "Order Book",
+      "term": "order book",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -7464,7 +7455,7 @@
       "commentary": ""
     },
     "ordinals": {
-      "term": "Ordinals",
+      "term": "ordinals",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -7478,7 +7469,7 @@
       "commentary": ""
     },
     "orphan-block": {
-      "term": "Orphan Block",
+      "term": "orphan block",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -7534,7 +7525,7 @@
       "commentary": ""
     },
     "paper-wallet": {
-      "term": "Paper Wallet",
+      "term": "paper wallet",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -7548,7 +7539,7 @@
       "commentary": ""
     },
     "parallelization": {
-      "term": "Parallelization",
+      "term": "parallelization",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -7590,7 +7581,7 @@
       "commentary": ""
     },
     "passive-management": {
-      "term": "Passive Management",
+      "term": "passive management",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -7608,7 +7599,7 @@
       "partOfSpeech": "noun",
       "termCategory": "",
       "phonetic": "/ˈpæsˌfreɪz/",
-      "definition": "See 'Secret Recovery Phrase'",
+      "definition": "See 'password'.",
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
@@ -7667,14 +7658,14 @@
       "definition": "When two or more computers are connected and share workload or resources without relying on a centralized server.",
       "definitionSource": "https://academy.binance.com/en/glossary/peer-to-peer",
       "sampleSentence": "",
-      "extended": "",
+      "extended": "See also, P2P.",
       "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/peer-to-peer",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
     "pegged-currency": {
-      "term": "Pegged Currency",
+      "term": "pegged currency",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -7716,7 +7707,7 @@
       "commentary": ""
     },
     "permissionless-blockchain": {
-      "term": "Permissionless Blockchain",
+      "term": "permissionless blockchain",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -7735,7 +7726,7 @@
       "termCategory": "",
       "phonetic": "/ˈfɪʃɪŋ/",
       "definition": "Phishing is a form of social engineering where attackers deceive people into revealing sensitive information or installing malware such as ransomware.",
-      "definitionSource": "https://academy.binance.com/en/glossary/phishing",
+      "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
       "alternate": [
@@ -7768,7 +7759,7 @@
       "termCategory": "",
       "phonetic": "/ˈplæzmə/",
       "definition": "Plasma' is a term that is used to refer to one of the solutions being built and deployed in order to securely scale the Ethereum network. A Plasma network functions similarly to an optimistic rollup, inasmuch as it relies on Ethereum Mainnet to maintain the record of transactions, and as the source for arbitration or fraud resolution. However, a Plasma network differs in other important technical ways from rollups, and is currently limited to simple operations, such as swaps and token transfers. More technical information is available here.",
-      "definitionSource": "https://academy.binance.com/en/glossary/plasma",
+      "definitionSource": "Consensys Software Inc., A Blockchain Glossary for Beginners",
       "sampleSentence": "",
       "extended": "",
       "alternate": [
@@ -7796,7 +7787,7 @@
       "commentary": ""
     },
     "polkadot-crowdloan": {
-      "term": "Polkadot Crowdloan",
+      "term": "Polkadot crowdloan",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -7824,7 +7815,7 @@
       "commentary": ""
     },
     "ponzi-scheme": {
-      "term": "Ponzi Scheme",
+      "term": "Ponzi scheme",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -7842,10 +7833,10 @@
       "partOfSpeech": "noun",
       "termCategory": "",
       "phonetic": "/ˈpɔrtfoʊlioʊ/",
-      "definition": "The Portfolio Dapp enables you to view all your MetaMask accounts and their assets in one place. It aggregates values from across your accounts and shows your total holdings, making it easier than ever to get an at-a-glance summary of their value in your chosen currency.\nGetting started with MetaMask Portfolio",
-      "definitionSource": "",
+      "definition": "A portfolio is a collection of assets. This term is broadly used in traditional financial fields. Often, web3 projects make 'dashboard-like' dapps that allow their users to view their tokens according to different criteria. ",
+      "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
-      "extended": "",
+      "extended": "Not to be confused with 'wallet'.",
       "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
@@ -7880,7 +7871,7 @@
       "commentary": ""
     },
     "premining": {
-      "term": "Premining",
+      "term": "premining",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -7894,7 +7885,7 @@
       "commentary": ""
     },
     "price-action": {
-      "term": "Price Action",
+      "term": "price action",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -7968,8 +7959,8 @@
       "partOfSpeech": "noun",
       "termCategory": "",
       "phonetic": "/ˈpraɪvɪt kiː/",
-      "definition": "A private key is an alphanumeric string of data that, in MetaMask, corresponds to a single specific account in a wallet. Private keys can be thought of as a password that enables an individual to control a specific crypto account. Never reveal your private key to anyone, as whoever controls the private key controls the account funds. If you lose your private key, then you lose access to, and control over, that account.",
-      "definitionSource": "https://academy.binance.com/en/glossary/private-key",
+      "definition": "A private key is an alphanumeric string of characters that, when imported into a wallet, gives total control over a given account. Private keys can be thought of as a password that enables an individual to control a specific crypto account. Never reveal your private key to anyone, as whoever controls the private key controls the account funds. If you lose your private key, then you lose access to, and control over, that account.",
+      "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
       "alternate": [
@@ -7987,7 +7978,7 @@
       "commentary": ""
     },
     "private-sale": {
-      "term": "Private Sale",
+      "term": "private sale",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",

--- a/locales/en-US/en-US.json
+++ b/locales/en-US/en-US.json
@@ -8562,7 +8562,7 @@
       "commentary": ""
     },
     "routing-attack": {
-      "term": "Routing Attack",
+      "term": "routing attack",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -8591,11 +8591,11 @@
     },
     "rug-pull": {
       "term": "rug pull",
-      "partOfSpeech": "verb",
+      "partOfSpeech": "noun",
       "termCategory": "",
       "phonetic": "/rʌɡ pʊl/",
       "definition": "Similar to the traditional financial scam of a pyramid scheme, a 'rug pull' is a cryptocurrency or crypto-token based scam in which the creators of the token create hype, through injecting liquidity into their token, airdropping, and other schemes, and once investors pile in and boost the price of the token up to a certain point, the creators liquidate their (generally majority) share of the tokens, leaving their investors with next to nothing.",
-      "definitionSource": "https://academy.binance.com/en/glossary/rug-pull",
+      "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
       "alternate": [
@@ -8665,7 +8665,7 @@
       "commentary": ""
     },
     "sandwich-trading": {
-      "term": "Sandwich Trading",
+      "term": "sandwich trading",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -8712,7 +8712,7 @@
       "termCategory": "",
       "phonetic": "/ˈsətoʊʃi nəˈkoʊtoʊmi/",
       "definition": "A pseudonymous individual or entity who created the Bitcoin protocol, solving the digital currency issue of the “double spend.” Nakamoto first published their white paper describing the project in 2008, and the first Bitcoin software was released one year later.",
-      "definitionSource": "https://academy.binance.com/en/glossary/satoshi-nakamoto",
+      "definitionSource": "Consensys Software Inc., A Blockchain Glossary for Beginners",
       "sampleSentence": "",
       "extended": "",
       "alternate": [
@@ -8838,7 +8838,7 @@
       "commentary": ""
     },
     "securities-and-exchange-commission": {
-      "term": "Securities and Exchange Commission (SEC)",
+      "term": "Securities and Exchange Commission",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -8852,7 +8852,7 @@
       "commentary": ""
     },
     "security-audit": {
-      "term": "Security Audit",
+      "term": "security audit",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -8866,7 +8866,7 @@
       "commentary": ""
     },
     "security-token": {
-      "term": "Security Token",
+      "term": "security token",
       "partOfSpeech": "noun",
       "termCategory": "",
       "phonetic": "/ˈsɪkjʊrɪti toʊkən/",
@@ -8884,27 +8884,18 @@
       "partOfSpeech": "noun",
       "termCategory": "",
       "phonetic": "/sɪˈkjʊrɪti ˈtoʊkən ˈɔfərɪŋ/",
-      "definition": "",
+      "definition": "See 'security token'.",
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "Unravel Security Token Offering (STO), a method of raising capital by issuing security tokens. Explore some of the benefits they offer to investors.",
+          "source": "https://academy.binance.com/en/glossary/security-token-offering-sto"
+        }
+      ],
       "termSource": "",
       "dateFirstRecorded": "",
-      "commentary": ""
-    },
-    "security-token-offering-sto": {
-      "term": "Security Token Offering (STO)",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "Unravel Security Token Offering (STO), a method of raising capital by issuing security tokens. Explore some of the benefits they offer to investors.",
-      "definitionSource": "https://academy.binance.com/en/glossary/security-token-offering-sto",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "https://academy.binance.com/en/glossary/security-token-offering-sto",
-      "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
     "seed-phrase": {
@@ -8913,7 +8904,7 @@
       "termCategory": "",
       "phonetic": "/siːd freɪz/",
       "definition": "Another term for Secret Recovery Phrase",
-      "definitionSource": "https://academy.binance.com/en/glossary/seed-phrase",
+      "definitionSource": "Consensys Software Inc., A Blockchain Glossary for Beginners",
       "sampleSentence": "",
       "extended": "",
       "alternate": [
@@ -8927,7 +8918,7 @@
       "commentary": ""
     },
     "seed-tag": {
-      "term": "Seed Tag",
+      "term": "seed tag",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -8941,7 +8932,7 @@
       "commentary": ""
     },
     "segregated-witness": {
-      "term": "Segregated Witness (SegWit)",
+      "term": "Segregated Witness",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -8983,7 +8974,7 @@
       "commentary": ""
     },
     "selfish-mining": {
-      "term": "Selfish Mining",
+      "term": "selfish mining",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -9011,7 +9002,7 @@
       "commentary": ""
     },
     "sentiment": {
-      "term": "Sentiment",
+      "term": "sentiment",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -9086,7 +9077,7 @@
       "termCategory": "",
       "phonetic": "/ˈʃɑːrdɪŋ/",
       "definition": "Sharding, in public blockchains, refers to splitting an entire network into multiple portions, called “shards.” Each shard would contain its own independent state, meaning a unique set of account balances and smart contracts. Sharding is currently being investigated and developed as one of the set of tools and solutions for scaling Ethereum.",
-      "definitionSource": "https://academy.binance.com/en/glossary/sharding",
+      "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
       "alternate": [
@@ -9136,23 +9127,14 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "Sidechains are independent blockchains linked to a parent blockchain, designed to enhance scalability and facilitate digital asset transfers between networks.",
+          "source": "https://academy.binance.com/en/glossary/sidechains"
+        }
+      ],
       "termSource": "",
       "dateFirstRecorded": "",
-      "commentary": ""
-    },
-    "sidechains": {
-      "term": "Sidechains",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "Sidechains are independent blockchains linked to a parent blockchain, designed to enhance scalability and facilitate digital asset transfers between networks.",
-      "definitionSource": "https://academy.binance.com/en/glossary/sidechains",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "https://academy.binance.com/en/glossary/sidechains",
-      "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
     "signature": {
@@ -9175,7 +9157,7 @@
       "commentary": ""
     },
     "simple-moving-average-sma": {
-      "term": "Simple Moving Average (SMA)",
+      "term": "simple moving average",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -9189,7 +9171,7 @@
       "commentary": ""
     },
     "slashing": {
-      "term": "Slashing",
+      "term": "slashing",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -9222,7 +9204,7 @@
       "termCategory": "",
       "phonetic": "/ˈslɪpɪdʒ/",
       "definition": "Slippage is the expected percentage difference between a quoted and an executed price.",
-      "definitionSource": "https://academy.binance.com/en/glossary/slippage",
+      "definitionSource": "Consensys Software Inc., A Blockchain Glossary for Beginners",
       "sampleSentence": "",
       "extended": "",
       "alternate": [
@@ -9241,7 +9223,7 @@
       "termCategory": "",
       "phonetic": "/slɒt/",
       "definition": "In Proof of Stake consensus in Ethereum, a 'slot' is a period of time equivalent to 12 seconds; 32 slots make up an 'epoch'. Slots are significant in that for each slot, a different validator node is randomly chosen to propose blocks to the network, and a different committee of validators are chosen to vote on whether each block is valid",
-      "definitionSource": "",
+      "definitionSource": "Consensys Software Inc., A Blockchain Glossary for Beginners",
       "sampleSentence": "",
       "extended": "",
       "alternate": [
@@ -9260,7 +9242,7 @@
       "termCategory": "",
       "phonetic": "/smɑːrt ˈkɒntrækt/",
       "definition": "Smart contracts are programs that have been published on a public blockchain, and can be used by anyone. While they often contain agreements or sets of actions between parties that emulate a traditional legal contract, they are not, in and of themselves, legal documents. Smart contracts are automated actions that can be coded and executed once a set of conditions is met, and are the dominant form of programming on the Ethereum Virtual Machine.",
-      "definitionSource": "https://academy.binance.com/en/glossary/smart-contract",
+      "definitionSource": "Consensys Software Inc., A Blockchain Glossary for Beginners",
       "sampleSentence": "",
       "extended": "",
       "alternate": [
@@ -9278,7 +9260,7 @@
       "commentary": ""
     },
     "smart-contract-wallet": {
-      "term": "Smart Contract Wallet",
+      "term": "smart contract wallet",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -9292,8 +9274,8 @@
       "commentary": ""
     },
     "snapshot": {
-      "term": "Snapshot",
-      "partOfSpeech": "",
+      "term": "snapshot",
+      "partOfSpeech": "verb, noun",
       "termCategory": "",
       "phonetic": "",
       "definition": "The ability to record the state of a blockchain ledger, storage device, or computer system at a specific point in time.",
@@ -9306,7 +9288,7 @@
       "commentary": ""
     },
     "social-recovery-wallet": {
-      "term": "Social Recovery Wallet",
+      "term": "social recovery wallet",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -9320,7 +9302,7 @@
       "commentary": ""
     },
     "social-trading": {
-      "term": "Social Trading",
+      "term": "social trading",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -9362,9 +9344,9 @@
       "commentary": ""
     },
     "soft-landing": {
-      "term": "Soft Landing",
-      "partOfSpeech": "",
-      "termCategory": "",
+      "term": "soft landing",
+      "partOfSpeech": "noun phrase",
+      "termCategory": "economics",
       "phonetic": "",
       "definition": "Soft landing refers to a situation in which the economy slows down gradually after a period of rapid growth while simultaneously avoiding a recession.",
       "definitionSource": "https://academy.binance.com/en/glossary/soft-landing",
@@ -9381,7 +9363,7 @@
       "termCategory": "",
       "phonetic": "/ˈsɒlɪdɪti/",
       "definition": "The programming language developers use to write smart contracts on the Ethereum network. See also ‘smart contract’. Solidity",
-      "definitionSource": "https://academy.binance.com/en/glossary/solidity",
+      "definitionSource": "Consensys Software Inc., A Blockchain Glossary for Beginners",
       "sampleSentence": "",
       "extended": "",
       "alternate": [
@@ -9395,7 +9377,7 @@
       "commentary": ""
     },
     "source-code": {
-      "term": "Source Code",
+      "term": "source code",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -9442,7 +9424,7 @@
       "termCategory": "",
       "phonetic": "/ˈsteɪblˌkɔɪn/",
       "definition": "A cryptocurrency whose value has been ‘pegged’ to that of something considered a ‘stable’ asset, like fiat currency or gold. It theoretically remains stable in price, as it is measured against a known amount of an asset which should be less subject to fluctuation. Always spelled as one word. User Guide: Tokens",
-      "definitionSource": "https://academy.binance.com/en/glossary/stablecoin",
+      "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
       "alternate": [
@@ -9456,7 +9438,7 @@
       "commentary": ""
     },
     "stagflation": {
-      "term": "Stagflation",
+      "term": "stagflation",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -9475,7 +9457,7 @@
       "termCategory": "",
       "phonetic": "/steɪk/",
       "definition": "Staking is the act of depositing ETH to activate new validators on the Ethereum protocol. Validators help keep Ethereum secure and operational by validating transactions and adding new blocks to the blockchain.",
-      "definitionSource": "",
+      "definitionSource": "Consensys Software Inc., A Blockchain Glossary for Beginners",
       "sampleSentence": "",
       "extended": "",
       "alternate": [
@@ -9494,7 +9476,7 @@
       "termCategory": "",
       "phonetic": "/ˈsteɪkɪŋ/",
       "definition": "On the Ethereum Proof of Stake network, those wishing to participate in consensus must first lock up, or ‘stake’, 32 ETH into a smart contract; this ETH may be ‘slashed’ (taken from them and ‘burned’, put out of circulation) in the event that their validator behaves maliciously or does not meet performance requirements. Similar Proof of Stake mechanisms are in operation on other networks, as well.\n\nAlthough this is the canonical meaning of the word, similar actions taken at the level of a decentralized exchange (DEX) or another dapp are often called ‘staking’, though it would probably be more accurate and descriptive to just call this ‘locking up tokens’.",
-      "definitionSource": "",
+      "definitionSource": "Consensys Software Inc., A Blockchain Glossary for Beginners",
       "sampleSentence": "",
       "extended": "",
       "alternate": [],
@@ -9530,30 +9512,21 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "state-channel": {
-      "term": "State Channel",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "A two-way communication channel between two users or nodes on a network, or between a user and a service.",
-      "definitionSource": "https://academy.binance.com/en/glossary/state-channel",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "https://academy.binance.com/en/glossary/state-channel",
-      "dateFirstRecorded": "2025-01-31",
-      "commentary": ""
-    },
     "state-channels": {
       "term": "state channels",
       "partOfSpeech": "noun",
       "termCategory": "",
       "phonetic": "/steɪt ˈtʃænəlz/",
       "definition": "State channels are part of the set of tools and platforms involved in scaling Ethereum. While a complex topic, state channels are essentially methods through which the current 'state' of the blockchain can be exported, and then based on that, any given number of transactions can take place off-chain, and then be moved back onto the main Ethereum chain.",
-      "definitionSource": "",
+      "definitionSource": "Consensys Software Inc., A Blockchain Glossary for Beginners",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "A two-way communication channel between two users or nodes on a network, or between a user and a service.",
+          "source": "https://academy.binance.com/en/glossary/state-channel",
+        }
+      ],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9587,7 +9560,7 @@
       "commentary": ""
     },
     "stock-variable": {
-      "term": "Stock Variable",
+      "term": "stock variable",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -9601,7 +9574,7 @@
       "commentary": ""
     },
     "store-of-value": {
-      "term": "Store of Value",
+      "term": "store of value",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -9629,7 +9602,7 @@
       "commentary": ""
     },
     "supercomputer": {
-      "term": "Supercomputer",
+      "term": "supercomputer",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -9643,7 +9616,7 @@
       "commentary": ""
     },
     "supply-chain": {
-      "term": "Supply Chain",
+      "term": "supply chain",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -9657,7 +9630,7 @@
       "commentary": ""
     },
     "support": {
-      "term": "Support",
+      "term": "support",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -9685,7 +9658,7 @@
       "commentary": ""
     },
     "sybil-attack": {
-      "term": "Sybil Attack",
+      "term": "Sybil attack",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -9713,7 +9686,7 @@
       "commentary": ""
     },
     "taker": {
-      "term": "Taker",
+      "term": "taker",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -9727,7 +9700,7 @@
       "commentary": ""
     },
     "tank": {
-      "term": "Tank",
+      "term": "tank",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -9774,7 +9747,7 @@
       "termCategory": "",
       "phonetic": "/ˈtɛstˌnɛt/",
       "definition": "A testnet is a blockchain network that mirrors, as closely as possible, the current conditions of a corresponding ‘main’ network. Testnets are used by developers to verify that their smart contracts and other functionality work as intended, before permanently recording their code to a live blockchain network (and often spending significant gas fees in the process!).\n\nTokens minted on testnets are not transferrable for their equivalent value on mainnets.",
-      "definitionSource": "https://academy.binance.com/en/glossary/testnet",
+      "definitionSource": "Consensys Software Inc., A Blockchain Glossary for Beginners",
       "sampleSentence": "",
       "extended": "",
       "alternate": [
@@ -9830,7 +9803,7 @@
       "commentary": ""
     },
     "ticker": {
-      "term": "Ticker",
+      "term": "ticker",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -9844,7 +9817,7 @@
       "commentary": ""
     },
     "ticker-symbol": {
-      "term": "Ticker Symbol",
+      "term": "ticker symbol",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -9863,7 +9836,7 @@
       "termCategory": "",
       "phonetic": "/ˈtoʊkən/",
       "definition": "A token represents an asset issued on an existing blockchain; the transfer of tokens and the addresses that currently hold them are the subject of the network’s consensus activities. There are many types of tokens; see also ‘ERC-20’ and ‘ERC-721’ entries.",
-      "definitionSource": "https://academy.binance.com/en/glossary/token",
+      "definitionSource": "Consensys Software Inc., A Blockchain Glossary for Beginners",
       "sampleSentence": "",
       "extended": "",
       "alternate": [
@@ -9881,7 +9854,7 @@
       "commentary": ""
     },
     "token-generation-event-tge": {
-      "term": "Token Generation Event (TGE)",
+      "term": "Token Generation Event",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -9900,7 +9873,7 @@
       "termCategory": "",
       "phonetic": "/ˈtoʊkən ˈlɒkʌp/",
       "definition": "A token lock-up refers to a mechanism where certain tokens or cryptocurrency holdings are locked up or frozen for a specified period of time to restrict their transfer or sale. This is often used in the context of initial coin offerings (ICOs), where token issuers may require investors to commit to holding onto their tokens for a certain period, typically to ensure that investors are committed to the project's long-term success.\n\nToken lock-up periods can vary in duration and can be predetermined or set according to certain conditions, such as reaching a certain milestone, liquidity event or network upgrade. During the lock-up period, the tokens cannot be transferred or sold, although in some cases, they may be staked or used to participate in certain network activities. Once the lock-up period is over, the tokens can be freely traded or sold.",
-      "definitionSource": "https://academy.binance.com/en/glossary/token-lockup",
+      "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
       "alternate": [
@@ -9914,7 +9887,7 @@
       "commentary": ""
     },
     "token-merge": {
-      "term": "Token Merge",
+      "term": "token merge",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -9928,7 +9901,7 @@
       "commentary": ""
     },
     "token-sale": {
-      "term": "Token Sale",
+      "term": "token sale",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -9950,23 +9923,14 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "Learn about ERC-20, ERC-721, BEP-20, and TRC-20 token standards in blockchain networks. Understand their role in cryptocurrency transactions and decentralized applications.",
+          "source": "https://academy.binance.com/en/glossary/token-standards"
+        }
+      ],
       "termSource": "",
       "dateFirstRecorded": "",
-      "commentary": ""
-    },
-    "token-standards": {
-      "term": "Token Standards",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "Learn about ERC-20, ERC-721, BEP-20, and TRC-20 token standards in blockchain networks. Understand their role in cryptocurrency transactions and decentralized applications.",
-      "definitionSource": "https://academy.binance.com/en/glossary/token-standards",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "https://academy.binance.com/en/glossary/token-standards",
-      "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
     "tokenization": {

--- a/locales/en-US/en-US.json
+++ b/locales/en-US/en-US.json
@@ -2887,7 +2887,7 @@
       "commentary": ""
     },
     "decryption": {
-      "term": "Decryption",
+      "term": "decryption",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -2901,7 +2901,7 @@
       "commentary": ""
     },
     "deep-web": {
-      "term": "Deep Web",
+      "term": "deep web",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -2943,7 +2943,7 @@
       "commentary": ""
     },
     "delisting": {
-      "term": "Delisting",
+      "term": "delisting",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -2971,7 +2971,7 @@
       "commentary": ""
     },
     "depeg": {
-      "term": "Depeg",
+      "term": "depeg",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -2999,7 +2999,7 @@
       "commentary": ""
     },
     "depression": {
-      "term": "Depression",
+      "term": "depression",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -3027,7 +3027,7 @@
       "commentary": ""
     },
     "design-flaw-attack": {
-      "term": "Design Flaw Attack",
+      "term": "design flaw attack",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -3097,7 +3097,7 @@
       "commentary": ""
     },
     "diamond-hands": {
-      "term": "Diamond Hands",
+      "term": "diamond hands",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -3116,7 +3116,7 @@
       "termCategory": "",
       "phonetic": "/ˈdɪfɪkəlti/",
       "definition": "The concept outlining how hard it is to verify blocks in a blockchain network during Proof of Work mining. In the Bitcoin network, the difficulty of mining adjusts every 2016 blocks. This is to keep block verification time at ten minutes.",
-      "definitionSource": "https://academy.binance.com/en/glossary/difficulty",
+      "definitionSource": "Consensys Software Inc., A Blockchain Glossary for Beginners",
       "sampleSentence": "",
       "extended": "",
       "alternate": [
@@ -3135,7 +3135,7 @@
       "termCategory": "",
       "phonetic": "/ˈdɪfɪkəlti bɒm/",
       "definition": "The difficulty bomb, along with the Beacon Chain and others, was a key element of Ethereum's upgrade to Ethereum 2.0 and a Proof of Stake (PoS) consensus mechanism. As the name indicates, the difficulty bomb was a software mechanism that increased block verification difficulty, making it more expensive and difficult–eventually, prohibitively so–to mine a new block. Through economic incentive, and later, the raw limitations of computing power, this forced the shift to PoS consensus. See also 'Proof of Stake', 'the Merge'.",
-      "definitionSource": "https://academy.binance.com/en/glossary/difficulty-bomb",
+      "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
       "alternate": [
@@ -3182,7 +3182,7 @@
       "termCategory": "",
       "phonetic": "/ˈdɪdʒɪtəl ˈsɪgnətʃər/",
       "definition": "A short string of data a user produces for a document using a private key such that anyone with the corresponding public key, the signature, and the document can verify that (1) the document was 'signed' by the owner of that particular private key, and (2) the document was not changed after it was signed.",
-      "definitionSource": "https://academy.binance.com/en/glossary/digital-signature",
+      "definitionSource": "Consensys Software Inc., A Blockchain Glossary for Beginners",
       "sampleSentence": "",
       "extended": "",
       "alternate": [
@@ -3210,11 +3210,11 @@
       "commentary": ""
     },
     "direct-market-access-dma": {
-      "term": "Direct Market Access (DMA)",
+      "term": "direct market access (DMA)",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
-      "definition": "Direct Market Access allows investors to place trades directly on exchanges, bypassing brokers for faster execution, more control, and lower fees.",
+      "definition": "Direct market access allows investors to place trades directly on exchanges, bypassing brokers for faster execution, more control, and lower fees.",
       "definitionSource": "https://academy.binance.com/en/glossary/direct-market-access-dma",
       "sampleSentence": "",
       "extended": "",
@@ -3238,7 +3238,7 @@
       "commentary": ""
     },
     "divergence": {
-      "term": "Divergence",
+      "term": "divergence",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -3252,7 +3252,7 @@
       "commentary": ""
     },
     "diversification": {
-      "term": "Diversification",
+      "term": "diversification",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -3294,7 +3294,7 @@
       "commentary": ""
     },
     "dollar-cost-averaging": {
-      "term": "Dollar Cost Averaging (DCA)",
+      "term": "dollar cost averaging (DCA)",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -3308,7 +3308,7 @@
       "commentary": ""
     },
     "dot-plot": {
-      "term": "Dot Plot",
+      "term": "dot plot",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -3330,23 +3330,14 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "When a given amount of coins are spent more than once. Usually as a result of a race attack or a 51% attack.",
+          "source": "https://academy.binance.com/en/glossary/double-spending"
+        }
+      ],
       "termSource": "",
       "dateFirstRecorded": "",
-      "commentary": ""
-    },
-    "double-spending": {
-      "term": "Double Spending",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "When a given amount of coins are spent more than once. Usually as a result of a race attack or a 51% attack.",
-      "definitionSource": "https://academy.binance.com/en/glossary/double-spending",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "https://academy.binance.com/en/glossary/double-spending",
-      "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
     "eclipse-attack": {

--- a/locales/en-US/en-US.json
+++ b/locales/en-US/en-US.json
@@ -3429,8 +3429,8 @@
       "partOfSpeech": "noun",
       "termCategory": "",
       "phonetic": "/ˈiːaɪˈpiː ˈfɪftiˌfaɪvˈnaɪn/",
-      "definition": "EIP (Ethereum Improvement Proposal)\n\nThe EIP process is a public and open process through which suggestions are made as to how to change (and hopefully, improve) the way the Ethereum network functions as a whole. Individual EIPs are referred to by the name assigned to them in the repository, for example, EIP-1559.\nEIP-1559 will change Ethereum’s fee market mechanism. Fundamentally, EIP-1559 gets rid of the first-price auction as the main gas fee calculation. In first-price auctions, people bid a set amount of money to pay for their transaction to be processed, and the highest bidder wins. With EIP-1559, there will be a discrete “base fee” for transactions to be included in the next block. For users or applications that want to prioritize their transaction, they can add a “tip,” which is called a “priority fee” to pay a miner for faster inclusion.",
-      "definitionSource": "",
+      "definition": "Fundamentally, EIP-1559 gets rid of the first-price auction as the main gas fee calculation. In first-price auctions, people bid a set amount of money to pay for their transaction to be processed, and the highest bidder wins. With EIP-1559, there will be a discrete “base fee” for transactions to be included in the next block. For users or applications that want to prioritize their transaction, they can add a “tip,” which is called a “priority fee” to pay a miner for faster inclusion.",
+      "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
       "alternate": [],
@@ -3528,7 +3528,7 @@
       "termCategory": "",
       "phonetic": "/ɛnˈkrɪpʃən/",
       "definition": "Encrpytion, literally 'in a hidden place', is the art and science of encoding information to control who can read it, or how it is to be read. Encryption occurs in natural (human) languages, as well as in machine and computer languages. Highly complex, and therefore difficult to decipher, encryption is an essential element enabling blockchain networks to be simultaneously public and secure.",
-      "definitionSource": "https://academy.binance.com/en/glossary/encryption",
+      "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
       "alternate": [
@@ -3542,7 +3542,7 @@
       "commentary": ""
     },
     "endogenous-variable": {
-      "term": "Endogenous Variable",
+      "term": "endogenous variable",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -3622,7 +3622,7 @@
       "termCategory": "",
       "phonetic": "/ˈɜrk ˈwʌnˈwʌnˈfaɪvˈfaɪv/",
       "definition": "A token standard for creating semi-fungible tokens, meaning you can launch both fungible and non-fungible tokens within a single smart contract.",
-      "definitionSource": "https://academy.binance.com/en/glossary/erc-1155",
+      "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
       "alternate": [
@@ -3641,7 +3641,7 @@
       "termCategory": "",
       "phonetic": "/ˈɜrk-ˈtwɛnti ˈtoʊkən ˈstændərd/",
       "definition": "ERC is the abbreviation for Ethereum Request for Comment and is followed by the assignment number of the standard. ERC-20 is a technical standard for smart contracts which is used to issue the majority of tokens (in particular, cryptocurrency tokens) extant on Ethereum. This list of rules states the requirements that a token must fulfill to be compliant and function within the Ethereum network.",
-      "definitionSource": "https://academy.binance.com/en/glossary/erc-20",
+      "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
       "alternate": [
@@ -3673,8 +3673,8 @@
       "partOfSpeech": "noun",
       "termCategory": "",
       "phonetic": "/ˈɜrk-ˈsɛvənˈtwɛnti ˈtoʊkən ˈstændərd/",
-      "definition": "ERC-721 Token Standard\n\nA standard for Ethereum smart contracts, which allows for the issuance of a non-fungible token: this is the standard that created what we all now know as an NFT. This token standard is used to represent a unique digital asset that is not interchangeable, as opposed to the ERC-20 (or other equivalent) standard, which issues identical, interchangeable tokens.",
-      "definitionSource": "https://academy.binance.com/en/glossary/erc-721",
+      "definition": "ERC-721 is a standard for Ethereum smart contracts, which allows for the issuance of a non-fungible token: this is the standard that created what we all now know as an NFT. This token standard is used to represent a unique digital asset that is not interchangeable, as opposed to the ERC-20 (or other equivalent) standard, which issues identical, interchangeable tokens.",
+      "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
       "alternate": [
@@ -3838,26 +3838,17 @@
       "termCategory": "",
       "phonetic": "/ɪˈθiːriəm ˈvɜrʧuəl məˈʃiːn/, /ˈiːˈvɛm/",
       "definition": "The EVM is a virtual machine that operates on the Ethereum network. It is Turing complete and allows anyone, anywhere to execute arbitrary EVM bytecode. All Ethereum nodes run on the EVM. It is home for smart contracts based on the Ethereum blockchain.",
-      "definitionSource": "",
+      "definitionSource": "Consensys Software, Inc., A Blockchain Glossary for Beginners",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "The Ethereum Virtual Machine (EVM) is a Turing-complete programmable machine that executes smart contracts, which are typically coded in Solidity.",
+          "source": "https://academy.binance.com/en/glossary/ethereum-virtual-machine-evm"
+        }
+      ],
       "termSource": "",
       "dateFirstRecorded": "",
-      "commentary": ""
-    },
-    "ethereum-virtual-machine-evm": {
-      "term": "Ethereum Virtual Machine (EVM)",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "The Ethereum Virtual Machine (EVM) is a Turing-complete programmable machine that executes smart contracts, which are typically coded in Solidity.",
-      "definitionSource": "https://academy.binance.com/en/glossary/ethereum-virtual-machine-evm",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "https://academy.binance.com/en/glossary/ethereum-virtual-machine-evm",
-      "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
     "etherscan": {

--- a/locales/en-US/en-US.json
+++ b/locales/en-US/en-US.json
@@ -3899,7 +3899,7 @@
       "termCategory": "",
       "phonetic": "/ɪksˈtʃeɪndʒ/",
       "definition": "A place to trade cryptocurrency. Centralized exchanges, operated by companies like Coinbase and Gemini, function as intermediaries, while decentralized exchanges do not have a central authority.",
-      "definitionSource": "https://academy.binance.com/en/glossary/exchange",
+      "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
       "alternate": [
@@ -3941,7 +3941,7 @@
       "commentary": ""
     },
     "exogenous-variable": {
-      "term": "Exogenous Variable",
+      "term": "exogenous variable",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -3955,7 +3955,7 @@
       "commentary": ""
     },
     "exponential-moving-average-ema": {
-      "term": "Exponential Moving Average (EMA)",
+      "term": "exponential moving average (EMA)",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -3969,7 +3969,7 @@
       "commentary": ""
     },
     "externally-owned-account-eoa": {
-      "term": "Externally Owned Account (EOA)",
+      "term": "Externally Owned Account",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -3983,7 +3983,7 @@
       "commentary": ""
     },
     "fakeout": {
-      "term": "Fakeout",
+      "term": "fakeout",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -3997,7 +3997,7 @@
       "commentary": ""
     },
     "falling-knife": {
-      "term": "Falling Knife",
+      "term": "falling knife",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -4011,7 +4011,7 @@
       "commentary": ""
     },
     "fan-tokens": {
-      "term": "Fan Tokens",
+      "term": "fan tokens",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -4095,14 +4095,14 @@
       "commentary": ""
     },
     "fiat": {
-      "term": "Fiat",
+      "term": "fiat",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
       "definition": "Money that a government has declared to be legal tender.",
       "definitionSource": "https://academy.binance.com/en/glossary/fiat",
       "sampleSentence": "",
-      "extended": "",
+      "extended": "While it is often referred to simply as 'fiat', the full phrase is 'fiat currency'. The word 'fiat' refers, in Latin, to 'trusting'; hence, a fiat currency is one that trusts in something else to provide it value. For example, we are trusting that a government will maintain the value of a currency, rather than it having some sort of inherent value, or value derived from the things for which it can be exchanged.",
       "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/fiat",
       "dateFirstRecorded": "2025-01-31",
@@ -4123,11 +4123,11 @@
       "commentary": ""
     },
     "fibonacci-retracement": {
-      "term": "Fibonacci Retracement",
+      "term": "Fibonacci retracement",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
-      "definition": "Fibonacci Retracement is a popular technical analysis (TA) tool used by traders to identify potential support and resistance levels in financial markets.",
+      "definition": "Fibonacci retracement is a popular technical analysis (TA) tool used by traders to identify potential support and resistance levels in financial markets.",
       "definitionSource": "https://academy.binance.com/en/glossary/fibonacci-retracement",
       "sampleSentence": "",
       "extended": "",
@@ -4137,7 +4137,7 @@
       "commentary": ""
     },
     "fill-or-kill-order": {
-      "term": "Fill Or Kill Order (FOK)",
+      "term": "fill or kill order (FOK)",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -4152,11 +4152,11 @@
     },
     "finality": {
       "term": "finality",
-      "partOfSpeech": "adjective",
+      "partOfSpeech": "noun",
       "termCategory": "",
       "phonetic": "/ˈfaɪnəl/, /faɪˈnælɪti/",
       "definition": "A transaction is considered 'final' once it can no longer be changed. In a sense, this happens once there are sufficient confirmations of the transaction, but for all intents and purposes, a transaction is final once the block that contains it is mined or validated. Keep in mind that this reflects a fundamental rule of blockchains: unlike traditional financial systems where charges can be 'reversed', there is no 'undoing' a transaction on the blockchain. Once finality is reached, the transaction is immutable.",
-      "definitionSource": "https://academy.binance.com/en/glossary/finality",
+      "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
       "alternate": [
@@ -4286,7 +4286,7 @@
       "commentary": ""
     },
     "fiscal-policy": {
-      "term": "Fiscal Policy",
+      "term": "fiscal policy",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -4300,7 +4300,7 @@
       "commentary": ""
     },
     "flappening": {
-      "term": "Flappening",
+      "term": "flappening",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -4315,8 +4315,8 @@
     },
     "flashbots": {
       "term": "Flashbots",
-      "partOfSpeech": "",
-      "termCategory": "",
+      "partOfSpeech": "proper noun",
+      "termCategory": "web3",
       "phonetic": "",
       "definition": "Explore Flashbots, a research & development organization focused on refining MEV-related blockchain solutions on Ethereum.",
       "definitionSource": "https://academy.binance.com/en/glossary/flashbots",
@@ -4328,7 +4328,7 @@
       "commentary": ""
     },
     "flippening": {
-      "term": "Flippening",
+      "term": "flippening",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -4342,7 +4342,7 @@
       "commentary": ""
     },
     "flow-variable": {
-      "term": "Flow Variable",
+      "term": "flow variable",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -4356,7 +4356,7 @@
       "commentary": ""
     },
     "forced-liquidation": {
-      "term": "Forced Liquidation",
+      "term": "forced liquidation",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -4370,7 +4370,7 @@
       "commentary": ""
     },
     "forex-fx": {
-      "term": "Forex (FX)",
+      "term": "Forex",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -4389,7 +4389,7 @@
       "termCategory": "",
       "phonetic": "/fɔrk/",
       "definition": "Forking' is a term that comes from the world of collaborative software development, and refers to the action of copying an existing application or set of code and modifying it to create an alternate version. At the blockchain protocol level, a 'fork' creates an alternative version of a blockchain. Forks are often enacted intentionally to apply upgrades to a network. Soft Forks render two chains with some compatibility, while Hard Forks create a new version of the chain that must be adopted to continue participation. In the instance of a contentious Hard Fork, this can create two versions of a blockchain network. See also 'hard fork'.",
-      "definitionSource": "https://academy.binance.com/en/glossary/fork",
+      "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
       "alternate": [
@@ -4407,9 +4407,9 @@
       "commentary": ""
     },
     "formal-verification": {
-      "term": "Formal Verification",
-      "partOfSpeech": "",
-      "termCategory": "",
+      "term": "formal verification",
+      "partOfSpeech": "noun phrase",
+      "termCategory": "cryptography",
       "phonetic": "",
       "definition": "Using mathematically rigorous proofs to ensure certain properties of cryptographic algorithms and blockchain mechanisms",
       "definitionSource": "https://academy.binance.com/en/glossary/formal-verification",
@@ -4440,7 +4440,7 @@
       "termCategory": "",
       "phonetic": "/frɔd pruːf/",
       "definition": "A security model for certain layer 2 solutions where, to increase speed, transactions are rolled up into batches and submitted to Ethereum in a single transaction. They are assumed valid but can be challenged if fraud is suspected. A fraud proof will then run the transaction to see if fraud took place. This method increases the amount of transactions possible while maintaining security.",
-      "definitionSource": "https://academy.binance.com/en/glossary/fraud-proof",
+      "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
       "alternate": [
@@ -4454,7 +4454,7 @@
       "commentary": ""
     },
     "fren": {
-      "term": "Fren",
+      "term": "fren",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -4487,7 +4487,7 @@
       "termCategory": "",
       "phonetic": "/fʊl noʊd/",
       "definition": "Public blockchains consist of a network of computers which sync the network's data, coordinate transaction requests, and participate in consensus regarding the validity of those transactions; each one of these computers is called a 'node'. A full node is a computer that can fully validate transactions and download the entire data of a specific blockchain. In contrast, a “lightweight” or “light” node does not download all pieces of a blockchain’s data, and uses a different validation process.",
-      "definitionSource": "https://academy.binance.com/en/glossary/full-node",
+      "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
       "alternate": [
@@ -4501,11 +4501,11 @@
       "commentary": ""
     },
     "fully-diluted-valuation-fdv": {
-      "term": "Fully Diluted Valuation (FDV)",
+      "term": "fully diluted valuation",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
-      "definition": "Fully Diluted Valuation (FDV) is a metric that tells us what a crypto project’s market value could be if all its tokens were available for trading now.",
+      "definition": "Fully diluted valuation (FDV) is a metric that tells us what a crypto project’s market value could be if all its tokens were available for trading now.",
       "definitionSource": "https://academy.binance.com/en/glossary/fully-diluted-valuation-fdv",
       "sampleSentence": "",
       "extended": "",
@@ -4515,7 +4515,7 @@
       "commentary": ""
     },
     "fundamental-analysis": {
-      "term": "Fundamental Analysis (FA)",
+      "term": "fundamental analysis",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -4529,7 +4529,7 @@
       "commentary": ""
     },
     "funding-fees": {
-      "term": "Funding Fees",
+      "term": "funding fees",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -4543,7 +4543,7 @@
       "commentary": ""
     },
     "fungibility": {
-      "term": "Fungibility",
+      "term": "fungibility",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -4557,7 +4557,7 @@
       "commentary": ""
     },
     "futures-contract": {
-      "term": "Futures Contract",
+      "term": "futures contract",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -4604,7 +4604,7 @@
       "termCategory": "",
       "phonetic": "/ɡæs/",
       "definition": "A measure of the computational steps required for a transaction on the Ethereum network. This then equates to a fee for network users paid in small units of ETH specified as gwei. For more on gas, see MetaMask’s user guide here:\n\nUser Guide: Gas",
-      "definitionSource": "https://academy.binance.com/en/glossary/gas",
+      "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
       "alternate": [
@@ -4637,7 +4637,7 @@
       "termCategory": "",
       "phonetic": "/ɡæs ˈlɪmɪt/",
       "definition": "The gas limit is the maximum amount you’re willing to pay for any given transaction to go through the Ethereum network. Another way of looking at it is as a “rough estimate” of how much computing power your transaction will take.",
-      "definitionSource": "https://academy.binance.com/en/glossary/gas-limit",
+      "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
       "alternate": [
@@ -4693,7 +4693,7 @@
       "commentary": ""
     },
     "gdp-deflator": {
-      "term": "GDP Deflator",
+      "term": "GDP deflator",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -4777,7 +4777,7 @@
       "termCategory": "",
       "phonetic": "/ˈɡɪthʌb/",
       "definition": "GitHub is an online software development platform. It's used for storing, tracking, and collaborating on software projects. It makes it easy for developers to share code files and collaborate with fellow developers on open-source projects. GitHub also serves as a social networking site where developers can openly network, collaborate, and pitch their work. GitHub",
-      "definitionSource": "https://academy.binance.com/en/glossary/github",
+      "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
       "alternate": [
@@ -4791,11 +4791,11 @@
       "commentary": ""
     },
     "gm-good-morning": {
-      "term": "GM (Good Morning)",
+      "term": "gm",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
-      "definition": "GM stands for \"Good Morning,\" and its use in the crypto community reflects the inclusive and collaborative nature of the space.",
+      "definition": "'gm' stands for 'Good Morning,' and its use in the crypto community reflects the inclusive and collaborative nature of the space.",
       "definitionSource": "https://academy.binance.com/en/glossary/gm-good-morning",
       "sampleSentence": "",
       "extended": "",
@@ -4819,7 +4819,7 @@
       "commentary": ""
     },
     "golden-cross": {
-      "term": "Golden Cross",
+      "term": "golden cross",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -4833,7 +4833,7 @@
       "commentary": ""
     },
     "golden-ratio": {
-      "term": "Golden Ratio",
+      "term": "golden ratio",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -4847,7 +4847,7 @@
       "commentary": ""
     },
     "goldilocks": {
-      "term": "Goldilocks",
+      "term": "goldilocks",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -4861,7 +4861,7 @@
       "commentary": ""
     },
     "gossip-protocol": {
-      "term": "Gossip Protocol",
+      "term": "gossip protocol",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -4889,7 +4889,7 @@
       "commentary": ""
     },
     "gross-domestic-product-gdp": {
-      "term": "Gross Domestic Product (GDP)",
+      "term": "Gross Domestic Product",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -4922,7 +4922,7 @@
       "termCategory": "",
       "phonetic": "/ɡwiː/",
       "definition": "A minuscule and common denomination of ETH, and the unit in which gas prices are often specified. See 'ether (denominations)' entry for more information.",
-      "definitionSource": "https://academy.binance.com/en/glossary/gwei",
+      "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
       "alternate": [
@@ -4936,7 +4936,7 @@
       "commentary": ""
     },
     "hackathon": {
-      "term": "Hackathon",
+      "term": "hackathon",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -4950,9 +4950,9 @@
       "commentary": ""
     },
     "hacker": {
-      "term": "Hacker",
-      "partOfSpeech": "",
-      "termCategory": "",
+      "term": "hacker",
+      "partOfSpeech": "noun",
+      "termCategory": "computer science",
       "phonetic": "",
       "definition": "An individual that has an advanced understanding of computer systems and networks, including programmers and cybersecurity experts.",
       "definitionSource": "https://academy.binance.com/en/glossary/hacker",
@@ -4964,9 +4964,9 @@
       "commentary": ""
     },
     "haha-money-printer-go-brrrrr": {
-      "term": "Haha Money Printer Go Brrrrr",
+      "term": "haha money printer go brrrrr",
       "partOfSpeech": "",
-      "termCategory": "",
+      "termCategory": "memes",
       "phonetic": "",
       "definition": "Haha Money Printer Go Brrrrr is meme created in response to the Federal Reserve's 2020 plan to print money.",
       "definitionSource": "https://academy.binance.com/en/glossary/haha-money-printer-go-brrrrr",
@@ -4983,7 +4983,7 @@
       "termCategory": "",
       "phonetic": "/ˈhælvɪŋ/",
       "definition": "Many cryptocurrencies have a finite supply, which makes them a scarce digital commodity. For example, the total amount of bitcoin that will ever be issued is 21 million. The number of bitcoins generated per block is decreased 50% every four years. This is called “halving.” The final halving will take place in the year 2140.",
-      "definitionSource": "https://academy.binance.com/en/glossary/halving",
+      "definitionSource": "Consensys Software, Inc., A Blockchain Glossary for Beginners",
       "sampleSentence": "",
       "extended": "",
       "alternate": [
@@ -4997,7 +4997,7 @@
       "commentary": ""
     },
     "hard-cap": {
-      "term": "Hard Cap",
+      "term": "hard cap",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -5025,9 +5025,9 @@
       "commentary": ""
     },
     "hard-landing": {
-      "term": "Hard Landing",
-      "partOfSpeech": "",
-      "termCategory": "",
+      "term": "hard landing",
+      "partOfSpeech": "noun phrase",
+      "termCategory": "economics",
       "phonetic": "",
       "definition": "In economic terms, a hard landing refers to a situation where an economy rapidly transitions from growth to slow growth or recession.",
       "definitionSource": "https://academy.binance.com/en/glossary/hard-landing",
@@ -5072,7 +5072,7 @@
       "termCategory": "",
       "phonetic": "/hæʃ/",
       "definition": "In computing, ‘hashing’ is an operation performed on lists or sets of data to create a reliable index for that data. A particular datum, or a reference to it, is fed into an algorithm, which transforms the datum and returns a standardized, and generally unrecognizable, ‘hash’ of it, sometimes referred to as that datum or file’s “digital fingerprint.” Each block in a blockchain contains the hash value that validated the block before it, followed by its own hash value (this is how the continuity of the ‘chain’ is constructed). Hashes can be used to confirm that blockchain transactions are complete and valid. You may see references to the “transaction hash” or “tx hash”; this should be understood as “unique identifier of the transaction”.",
-      "definitionSource": "https://academy.binance.com/en/glossary/hash",
+      "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
       "alternate": [
@@ -5090,7 +5090,7 @@
       "commentary": ""
     },
     "hash-rate": {
-      "term": "Hash Rate",
+      "term": "hash rate",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -5104,7 +5104,7 @@
       "commentary": ""
     },
     "hashed-timelock-contract": {
-      "term": "Hashed TimeLock Contract (HTLC)",
+      "term": "hashed timeLock contract",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -5132,7 +5132,7 @@
       "commentary": ""
     },
     "herd-instinct": {
-      "term": "Herd Instinct",
+      "term": "herd instinct",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -5160,7 +5160,7 @@
       "commentary": ""
     },
     "high-frequency-trading-hft": {
-      "term": "High-Frequency Trading (HFT)",
+      "term": "high-frequency trading",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -5181,14 +5181,14 @@
       "definition": "A typo of 'Hold' originating from bitcointalk that has also been retrofitted to be an acronym for Hold on for Dear Life.",
       "definitionSource": "https://academy.binance.com/en/glossary/hodl",
       "sampleSentence": "",
-      "extended": "",
+      "extended": "See also 'BUIDL'.",
       "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/hodl",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
     "honeypot": {
-      "term": "Honeypot",
+      "term": "honeypot",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -5272,7 +5272,7 @@
       "commentary": ""
     },
     "iceberg-order": {
-      "term": "Iceberg Order",
+      "term": "iceberg order",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -5319,7 +5319,7 @@
       "termCategory": "",
       "phonetic": "/ɪˈmjuːtəbɪlɪti/",
       "definition": "The inability to be altered or changed. This is a key element of blockchain networks: once written onto a blockchain ledger, data cannot be altered. This immutability provides the basis for commerce and trade to take place on blockchain networks.",
-      "definitionSource": "https://academy.binance.com/en/glossary/immutability",
+      "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
       "alternate": [
@@ -5333,7 +5333,7 @@
       "commentary": ""
     },
     "index-funds": {
-      "term": "Index Funds",
+      "term": "index funds",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -5361,21 +5361,21 @@
       "commentary": ""
     },
     "initial-coin-offering": {
-      "term": "Initial Coin Offering (ICO)",
+      "term": "Initial Coin Offering",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
       "definition": "A fundraising method in which new projects will sell their cryptocurrency to investors.",
       "definitionSource": "https://academy.binance.com/en/glossary/initial-coin-offering",
       "sampleSentence": "",
-      "extended": "",
+      "extended": "Often referred to by its initialism, 'ICO'.",
       "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/initial-coin-offering",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
     "initial-dex-offering-ido": {
-      "term": "Initial DEX Offering (IDO)",
+      "term": "Initial DEX Offering",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -5389,7 +5389,7 @@
       "commentary": ""
     },
     "initial-exchange-offering": {
-      "term": "Initial Exchange Offering (IEO)",
+      "term": "Initial Exchange Offering",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -5403,7 +5403,7 @@
       "commentary": ""
     },
     "initial-public-offering": {
-      "term": "Initial Public Offering (IPO)",
+      "term": "Initial Public Offering",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -5417,7 +5417,7 @@
       "commentary": ""
     },
     "inscription": {
-      "term": "Inscription",
+      "term": "inscription",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -5435,8 +5435,8 @@
       "partOfSpeech": "noun",
       "termCategory": "",
       "phonetic": "/ˈɪnsaɪdər ˈtreɪdɪŋ/",
-      "definition": "Insider trading happens when someone purchases or sells stocks while possessing private, material information about that stock. Insider Trading",
-      "definitionSource": "",
+      "definition": "Insider trading happens when someone purchases or sells stocks while possessing private, material information about that stock.",
+      "definitionSource": "Consensys Software, Inc., A Blockchain Glossary for Beginners",
       "sampleSentence": "",
       "extended": "",
       "alternate": [],
@@ -5445,7 +5445,7 @@
       "commentary": ""
     },
     "integrated-circuit": {
-      "term": "Integrated Circuit (IC)",
+      "term": "integrated circuit",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -5459,7 +5459,7 @@
       "commentary": ""
     },
     "interest-rates": {
-      "term": "Interest Rates",
+      "term": "interest rate",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -5492,7 +5492,7 @@
       "termCategory": "",
       "phonetic": "/ˌɪntərɒpəˈræbɪlɪti/",
       "definition": "Blockchain interoperability, or cross-chain interoperability, is the ability to see and share information across multiple blockchains. One of the clear benefits of blockchain interoperability is being able to trade assets across various blockchains without the need for a centralized, custodial exchange. Interoperability",
-      "definitionSource": "https://academy.binance.com/en/glossary/interoperability",
+      "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
       "alternate": [
@@ -5514,23 +5514,14 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "An open-source project building a protocol for distributed content storage and access.",
+          "source": "https://academy.binance.com/en/glossary/interplanetary-file-system-ipfs",
+        }
+      ],
       "termSource": "",
       "dateFirstRecorded": "",
-      "commentary": ""
-    },
-    "interplanetary-file-system-ipfs": {
-      "term": "InterPlanetary File System (IPFS)",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "An open-source project building a protocol for distributed content storage and access.",
-      "definitionSource": "https://academy.binance.com/en/glossary/interplanetary-file-system-ipfs",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "https://academy.binance.com/en/glossary/interplanetary-file-system-ipfs",
-      "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
     "iou": {

--- a/locales/en-US/en-US.json
+++ b/locales/en-US/en-US.json
@@ -9,6 +9,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -22,6 +23,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -35,6 +37,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -48,6 +51,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -61,6 +65,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -87,6 +92,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -100,6 +106,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/absolute-advantage",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/absolute-advantage",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -126,6 +133,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -139,6 +147,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/active-management",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/active-management",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -152,6 +161,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/actively-validated-services-avs",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/actively-validated-services-avs",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -165,6 +175,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/ad-hoc",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/ad-hoc",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -191,6 +202,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -204,6 +216,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -243,6 +256,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -256,6 +270,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -269,6 +284,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/algorithm",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/algorithm",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -282,6 +298,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/all-or-none-order",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/all-or-none-order",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -295,6 +312,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/all-time-high",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/all-time-high",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -308,6 +326,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/allocation",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/allocation",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -321,6 +340,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/alpha",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/alpha",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -347,6 +367,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -360,6 +381,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/angel-investor",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/angel-investor",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -373,6 +395,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/anti-money-laundering",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/anti-money-laundering",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -386,6 +409,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -412,6 +436,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -425,6 +450,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/application-programming-interface",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/application-programming-interface",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -438,6 +464,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/application-specific-integrated-circuit",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/application-specific-integrated-circuit",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -451,6 +478,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/arbitrage",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/arbitrage",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -464,6 +492,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -477,6 +506,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/arc-20",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/arc-20",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -490,6 +520,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/artificial-intelligence-ai",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/artificial-intelligence-ai",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -503,6 +534,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -516,6 +548,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/asic-resistant",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/asic-resistant",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -529,6 +562,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/asking-price",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/asking-price",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -542,6 +576,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/asset-management",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/asset-management",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -568,6 +603,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/assets-under-management-aum",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/assets-under-management-aum",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -581,6 +617,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/asynchronous",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/asynchronous",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -594,6 +631,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/atomic-swap",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/atomic-swap",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -607,6 +645,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/attack-surface",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/attack-surface",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -633,6 +672,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/auction",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/auction",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -646,6 +686,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -659,6 +700,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/automated-market-maker-amm",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/automated-market-maker-amm",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -672,6 +714,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -685,6 +728,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -698,6 +742,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -711,6 +756,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/b-tokens",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/b-tokens",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -724,6 +770,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/bags",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/bags",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -737,6 +784,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -750,6 +798,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -763,6 +812,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/beacon-chain",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/beacon-chain",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -776,6 +826,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/bear-market",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/bear-market",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -789,6 +840,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/benchmark",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/benchmark",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -802,6 +854,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/bep-1155",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/bep-1155",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -815,6 +868,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/bep-20",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/bep-20",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -828,6 +882,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/bep-721",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/bep-721",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -841,6 +896,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/bep-95",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/bep-95",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -854,6 +910,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -867,6 +924,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/beta-coefficient",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/beta-coefficient",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -880,6 +938,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/beta-release",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/beta-release",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -893,6 +952,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/bid-ask-spread",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/bid-ask-spread",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -906,6 +966,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/bid-price",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/bid-price",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -919,6 +980,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -932,6 +994,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/binance-blockchain-charity-foundation",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/binance-blockchain-charity-foundation",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -945,6 +1008,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/binance-ecosystem-fund",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/binance-ecosystem-fund",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -958,6 +1022,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/binancian",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/binancian",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -971,6 +1036,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/bitcoin",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/bitcoin",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -984,6 +1050,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/bitcoin-core",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/bitcoin-core",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -997,6 +1064,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/bitcoin-dominance",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/bitcoin-dominance",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1010,6 +1078,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/bitcoin-maximalists",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/bitcoin-maximalists",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1023,6 +1092,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/bitcoin-pizza",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/bitcoin-pizza",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1036,6 +1106,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/black-swan-event",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/black-swan-event",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1062,6 +1133,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/block-explorer",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/block-explorer",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1075,6 +1147,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/block-header",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/block-header",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1127,6 +1200,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1166,6 +1240,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1179,6 +1254,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/bloom-filter",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/bloom-filter",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1192,6 +1268,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/blue-chip-token",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/blue-chip-token",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1205,6 +1282,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/bnb",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/bnb",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1218,6 +1296,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1231,6 +1310,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/bnsol",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/bnsol",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1244,6 +1324,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/bollinger-bands",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/bollinger-bands",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1257,6 +1338,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/bond",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/bond",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1270,6 +1352,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/bounty",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/bounty",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1296,6 +1379,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1309,6 +1393,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/brc-20-tokens",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/brc-20-tokens",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1322,6 +1407,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/break-even-point",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/break-even-point",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1335,6 +1421,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/breakeven-multiple",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/breakeven-multiple",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1348,6 +1435,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/breakout",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/breakout",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1374,6 +1462,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/bscscan",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/bscscan",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1387,6 +1476,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1400,6 +1490,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/btc-wallet-address",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/btc-wallet-address",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1413,6 +1504,7 @@
       "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "Consensys Software Inc., Blockchain Glossary for Beginners",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1426,6 +1518,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/bull-market",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/bull-market",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1439,6 +1532,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/burner-wallet",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/burner-wallet",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1452,6 +1546,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/buy-wall",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/buy-wall",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1465,6 +1560,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1478,6 +1574,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1491,6 +1588,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1504,6 +1602,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/candidate-block",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/candidate-block",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1517,6 +1616,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/candlestick",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/candlestick",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1530,6 +1630,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/capitulation",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/capitulation",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1543,6 +1644,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1556,6 +1658,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/censorship-resistance",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/censorship-resistance",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1569,6 +1672,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/central-bank",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/central-bank",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1582,6 +1686,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/central-bank-digital-currency-cbdc",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/central-bank-digital-currency-cbdc",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1595,6 +1700,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/central-processing-unit",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/central-processing-unit",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1608,6 +1714,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/centralized",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/centralized",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1634,6 +1741,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1660,6 +1768,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/chatgpt",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/chatgpt",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1673,6 +1782,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1686,6 +1796,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/cipher",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/cipher",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1699,6 +1810,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/circulating-supply",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/circulating-supply",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1712,6 +1824,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1725,6 +1838,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/cloud",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/cloud",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1738,6 +1852,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1751,6 +1866,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/coin",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/coin",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1764,6 +1880,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1777,6 +1894,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1803,6 +1921,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1816,6 +1935,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/collateral",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/collateral",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1829,6 +1949,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/colocation",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/colocation",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1842,6 +1963,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/commodity-futures-trading-commission",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/commodity-futures-trading-commission",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1855,6 +1977,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1868,6 +1991,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1881,6 +2005,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/compound-interest",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/compound-interest",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1907,6 +2032,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/confirmation-time",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/confirmation-time",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1920,6 +2046,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/confluence",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/confluence",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1946,6 +2073,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/consensus-algorithm",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/consensus-algorithm",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1959,6 +2087,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1972,6 +2101,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1985,6 +2115,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1998,6 +2129,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2011,6 +2143,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2024,6 +2157,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/consumer-price-index-(cpi)",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/consumer-price-index-(cpi)",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2037,6 +2171,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/contango-and-backwardation",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/contango-and-backwardation",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2050,6 +2185,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2076,6 +2212,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2089,6 +2226,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/copy-trading",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/copy-trading",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2102,6 +2240,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/counterparty-risk",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/counterparty-risk",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2115,6 +2254,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/credentials",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/credentials",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2128,6 +2268,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/cross-chain-bridges",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/cross-chain-bridges",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2141,6 +2282,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2154,6 +2296,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2167,6 +2310,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2180,6 +2324,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2193,6 +2338,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/crypto-etfs",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/crypto-etfs",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2206,6 +2352,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/crypto-fear-and-greed-index",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/crypto-fear-and-greed-index",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2219,6 +2366,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2232,6 +2380,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/crypto-protocol",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/crypto-protocol",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2245,6 +2394,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2258,6 +2408,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/crypto-winter",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/crypto-winter",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2271,6 +2422,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2284,6 +2436,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/cryptocurrency",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/cryptocurrency",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2297,6 +2450,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2310,6 +2464,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/cryptography",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/cryptography",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2323,6 +2478,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2336,6 +2492,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/custody",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/custody",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2349,6 +2506,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2362,6 +2520,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/daemon",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/daemon",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2375,6 +2534,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2388,6 +2548,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/danksharding",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/danksharding",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2401,6 +2562,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2414,6 +2576,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2427,6 +2590,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2440,6 +2604,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/dead-cat-bounce",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/dead-cat-bounce",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2453,6 +2618,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/death-cross",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/death-cross",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2466,6 +2632,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2479,6 +2646,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/decentralized-application",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/decentralized-application",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2492,6 +2660,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/decentralized-autonomous-cooperative",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/decentralized-autonomous-cooperative",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2531,6 +2700,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2544,6 +2714,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/decentralized-indexes",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/decentralized-indexes",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2557,6 +2728,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2570,6 +2742,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/decryption",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/decryption",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2583,6 +2756,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/deep-web",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/deep-web",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2596,6 +2770,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2609,6 +2784,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2622,6 +2798,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/delisting",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/delisting",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2635,6 +2812,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2648,6 +2826,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/depeg",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/depeg",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2661,6 +2840,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2674,6 +2854,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/depression",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/depression",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2687,6 +2868,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2700,6 +2882,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/design-flaw-attack",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/design-flaw-attack",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2713,6 +2896,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2726,6 +2910,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2739,6 +2924,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2752,6 +2938,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2765,6 +2952,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/diamond-hands",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/diamond-hands",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2778,6 +2966,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/difficulty",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/difficulty",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2791,6 +2980,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/difficulty-bomb",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/difficulty-bomb",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2804,6 +2994,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2817,6 +3008,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2830,6 +3022,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/digital-signature",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/digital-signature",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2843,6 +3036,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2856,6 +3050,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/direct-market-access-dma",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/direct-market-access-dma",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2869,6 +3064,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2882,6 +3078,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/divergence",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/divergence",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2895,6 +3092,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/diversification",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/diversification",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2908,6 +3106,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2921,6 +3120,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/do-your-own-research",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/do-your-own-research",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2934,6 +3134,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/dollar-cost-averaging",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/dollar-cost-averaging",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2947,6 +3148,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/dot-plot",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/dot-plot",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2960,6 +3162,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2973,6 +3176,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/double-spending",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/double-spending",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2986,6 +3190,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/eclipse-attack",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/eclipse-attack",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2999,6 +3204,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3012,6 +3218,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3025,6 +3232,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3038,6 +3246,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/efficient-market-hypothesis-emh",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/efficient-market-hypothesis-emh",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3051,6 +3260,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/eigenlayer",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/eigenlayer",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3064,6 +3274,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/eip",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/eip",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3077,6 +3288,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3090,6 +3302,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/eip-3074",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/eip-3074",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3103,6 +3316,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/eip-4844",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/eip-4844",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3116,6 +3330,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/eip-7251",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/eip-7251",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3129,6 +3344,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/eip-7702",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/eip-7702",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3142,6 +3358,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/elasticity",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/elasticity",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3155,6 +3372,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3168,6 +3386,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/encryption",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/encryption",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3181,6 +3400,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/endogenous-variable",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/endogenous-variable",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3194,6 +3414,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3207,6 +3428,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3220,6 +3442,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3233,6 +3456,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3246,6 +3470,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/erc-1155",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/erc-1155",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3259,6 +3484,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/erc-20",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/erc-20",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3272,6 +3498,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/erc-404",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/erc-404",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3285,6 +3512,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/erc-721",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/erc-721",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3298,6 +3526,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/etf",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/etf",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3311,6 +3540,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3324,6 +3554,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3337,6 +3568,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3350,6 +3582,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3363,6 +3596,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/ethereum-classic",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/ethereum-classic",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3376,6 +3610,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/ethereum-foundation",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/ethereum-foundation",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3389,6 +3624,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3402,6 +3638,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3415,6 +3652,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3428,6 +3666,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3441,6 +3680,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/ethereum-virtual-machine-evm",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/ethereum-virtual-machine-evm",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3454,6 +3694,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3467,6 +3708,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3480,6 +3722,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3493,6 +3736,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/exchange",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/exchange",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3506,6 +3750,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3519,6 +3764,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3532,6 +3778,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/exogenous-variable",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/exogenous-variable",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3545,6 +3792,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/exponential-moving-average-ema",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/exponential-moving-average-ema",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3558,6 +3806,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/externally-owned-account-eoa",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/externally-owned-account-eoa",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3571,6 +3820,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/fakeout",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/fakeout",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3584,6 +3834,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/falling-knife",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/falling-knife",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3597,6 +3848,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/fan-tokens",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/fan-tokens",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3610,6 +3862,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3623,6 +3876,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3636,6 +3890,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3649,6 +3904,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/fear-of-missing-out",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/fear-of-missing-out",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3662,6 +3918,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/fear-uncertainty-and-doubt",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/fear-uncertainty-and-doubt",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3675,6 +3932,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/fiat",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/fiat",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3688,6 +3946,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3701,6 +3960,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/fibonacci-retracement",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/fibonacci-retracement",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3714,6 +3974,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/fill-or-kill-order",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/fill-or-kill-order",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3727,6 +3988,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/finality",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/finality",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3740,6 +4002,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3753,6 +4016,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3766,6 +4030,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3779,6 +4044,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3792,6 +4058,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3805,6 +4072,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3818,6 +4086,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3831,6 +4100,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/first-mover-advantage",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/first-mover-advantage",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3844,6 +4114,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/fiscal-policy",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/fiscal-policy",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3857,6 +4128,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/flappening",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/flappening",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3870,6 +4142,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/flashbots",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/flashbots",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3883,6 +4156,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/flippening",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/flippening",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3896,6 +4170,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/flow-variable",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/flow-variable",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3909,6 +4184,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/forced-liquidation",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/forced-liquidation",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3922,6 +4198,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/forex-fx",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/forex-fx",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3935,6 +4212,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/fork",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/fork",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3948,6 +4226,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/formal-verification",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/formal-verification",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3961,6 +4240,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3974,6 +4254,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/fraud-proof",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/fraud-proof",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3987,6 +4268,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/fren",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/fren",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4000,6 +4282,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4013,6 +4296,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/full-node",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/full-node",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4026,6 +4310,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/fully-diluted-valuation-fdv",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/fully-diluted-valuation-fdv",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4039,6 +4324,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/fundamental-analysis",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/fundamental-analysis",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4052,6 +4338,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/funding-fees",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/funding-fees",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4065,6 +4352,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/fungibility",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/fungibility",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4078,6 +4366,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/futures-contract",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/futures-contract",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4091,6 +4380,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/gamefi",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/gamefi",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4104,6 +4394,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4117,6 +4408,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/gas",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/gas",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4130,6 +4422,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4143,6 +4436,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/gas-limit",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/gas-limit",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4156,6 +4450,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4169,6 +4464,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4182,6 +4478,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4195,6 +4492,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/gdp-deflator",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/gdp-deflator",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4208,6 +4506,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/general-public-license",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/general-public-license",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4221,6 +4520,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/genesis-block",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/genesis-block",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4234,6 +4534,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4247,6 +4548,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4260,6 +4562,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/github",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/github",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4273,6 +4576,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/gm-good-morning",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/gm-good-morning",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4286,6 +4590,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4299,6 +4604,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/golden-cross",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/golden-cross",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4312,6 +4618,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/golden-ratio",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/golden-ratio",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4325,6 +4632,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/goldilocks",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/goldilocks",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4338,6 +4646,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/gossip-protocol",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/gossip-protocol",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4351,6 +4660,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4364,6 +4674,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/gross-domestic-product-gdp",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/gross-domestic-product-gdp",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4377,6 +4688,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4390,6 +4702,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/gwei",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/gwei",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4403,6 +4716,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/hackathon",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/hackathon",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4416,6 +4730,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/hacker",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/hacker",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4429,6 +4744,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/haha-money-printer-go-brrrrr",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/haha-money-printer-go-brrrrr",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4442,6 +4758,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/halving",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/halving",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4455,6 +4772,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/hard-cap",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/hard-cap",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4468,6 +4786,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4481,6 +4800,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/hard-landing",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/hard-landing",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4494,6 +4814,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4507,6 +4828,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4520,6 +4842,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/hash",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/hash",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4533,6 +4856,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/hash-rate",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/hash-rate",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4546,6 +4870,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/hashed-timelock-contract",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/hashed-timelock-contract",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4559,6 +4884,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4572,6 +4898,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/herd-instinct",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/herd-instinct",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4585,6 +4912,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4598,6 +4926,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/high-frequency-trading-hft",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/high-frequency-trading-hft",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4611,6 +4940,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/hodl",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/hodl",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4624,6 +4954,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/honeypot",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/honeypot",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4637,6 +4968,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4650,6 +4982,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4663,6 +4996,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4676,6 +5010,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4689,6 +5024,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4702,6 +5038,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/iceberg-order",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/iceberg-order",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4715,6 +5052,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4728,6 +5066,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4741,6 +5080,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/immutability",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/immutability",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4754,6 +5094,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/index-funds",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/index-funds",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4767,6 +5108,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4780,6 +5122,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/initial-coin-offering",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/initial-coin-offering",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4793,6 +5136,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/initial-dex-offering-ido",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/initial-dex-offering-ido",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4806,6 +5150,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/initial-exchange-offering",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/initial-exchange-offering",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4819,6 +5164,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/initial-public-offering",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/initial-public-offering",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4832,6 +5178,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/inscription",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/inscription",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4845,6 +5192,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4858,6 +5206,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/integrated-circuit",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/integrated-circuit",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4871,6 +5220,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/interest-rates",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/interest-rates",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4884,6 +5234,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4897,6 +5248,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/interoperability",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/interoperability",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4910,6 +5262,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4923,6 +5276,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/interplanetary-file-system-ipfs",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/interplanetary-file-system-ipfs",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4936,6 +5290,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/iou",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/iou",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4949,6 +5304,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4962,6 +5318,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4975,6 +5332,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4988,6 +5346,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/isolated-margin",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/isolated-margin",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5001,6 +5360,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/issuance",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/issuance",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5014,6 +5374,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5027,6 +5388,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5040,6 +5402,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/keccak",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/keccak",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5053,6 +5416,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5066,6 +5430,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/know-your-customer",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/know-your-customer",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5079,6 +5444,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5092,6 +5458,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5105,6 +5472,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5118,6 +5486,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5131,6 +5500,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/laspeyres-index",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/laspeyres-index",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5144,6 +5514,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/latency",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/latency",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5157,6 +5528,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5170,6 +5542,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5183,6 +5556,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/law-of-demand",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/law-of-demand",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5196,6 +5570,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5209,6 +5584,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5222,6 +5598,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/layer-2",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/layer-2",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5235,6 +5612,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/ledger",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/ledger",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5248,6 +5626,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5261,6 +5640,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5274,6 +5654,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/leveraged-tokens",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/leveraged-tokens",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5287,6 +5668,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/library",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/library",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5300,6 +5682,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5313,6 +5696,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5326,6 +5710,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/lightning-network",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/lightning-network",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5339,6 +5724,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/limit-order",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/limit-order",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5352,6 +5738,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5365,6 +5752,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/linux",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/linux",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5378,6 +5766,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5391,6 +5780,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/liquid-staking",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/liquid-staking",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5404,6 +5794,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/liquid-staking-token-lst",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/liquid-staking-token-lst",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5417,6 +5808,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5430,6 +5822,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/liquidity",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/liquidity",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5443,6 +5836,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/liquidity-crisis",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/liquidity-crisis",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5456,6 +5850,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5469,6 +5864,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/liquidity-provider",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/liquidity-provider",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5482,6 +5878,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/liquidity-ratios",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/liquidity-ratios",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5495,6 +5892,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5508,6 +5906,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/listing",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/listing",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5521,6 +5920,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/mainnet",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/mainnet",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5534,6 +5934,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/mainnet-swap",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/mainnet-swap",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5547,6 +5948,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/maker",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/maker",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5560,6 +5962,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5573,6 +5976,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/malware",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/malware",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5586,6 +5990,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/margin-trading",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/margin-trading",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5599,6 +6004,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5612,6 +6018,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/market-capitalization",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/market-capitalization",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5625,6 +6032,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/market-momentum",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/market-momentum",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5638,6 +6046,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/market-order",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/market-order",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5651,6 +6060,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/masternode",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/masternode",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5664,6 +6074,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/matching-engine",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/matching-engine",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5677,6 +6088,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5690,6 +6102,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5703,6 +6116,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/maximum-supply",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/maximum-supply",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5716,6 +6130,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5729,6 +6144,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/mempool",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/mempool",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5742,6 +6158,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5755,6 +6172,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5768,6 +6186,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/merged-mining",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/merged-mining",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5781,6 +6200,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5794,6 +6214,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/merkle-tree",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/merkle-tree",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5807,6 +6228,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5820,6 +6242,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/metadata",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/metadata",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5833,6 +6256,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5846,6 +6270,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5859,6 +6284,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5872,6 +6298,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5885,6 +6312,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5898,6 +6326,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/metaverse",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/metaverse",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5911,6 +6340,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5924,6 +6354,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5937,6 +6368,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/microtransactions",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/microtransactions",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5950,6 +6382,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5963,6 +6396,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5976,6 +6410,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/mining",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/mining",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5989,6 +6424,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/mining-farm",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/mining-farm",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6002,6 +6438,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/mint",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/mint",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6015,6 +6452,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6028,6 +6466,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6041,6 +6480,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6054,6 +6494,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/monetary-policy",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/monetary-policy",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6067,6 +6508,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/money-markets",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/money-markets",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6080,6 +6522,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/monitoring-tag",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/monitoring-tag",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6093,6 +6536,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/moon",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/moon",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6106,6 +6550,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6119,6 +6564,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/moving-average-envelopes",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/moving-average-envelopes",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6132,6 +6578,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/moving-average-ribbon",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/moving-average-ribbon",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6145,6 +6592,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/mt-gox",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/mt-gox",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6158,6 +6606,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6171,6 +6620,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6184,6 +6634,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/multisignature",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/multisignature",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6197,6 +6648,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/nakamoto-consensus",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/nakamoto-consensus",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6210,6 +6662,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6223,6 +6676,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/net-asset-value-nav",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/net-asset-value-nav",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6236,6 +6690,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6249,6 +6704,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6262,6 +6718,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6275,6 +6732,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6288,6 +6746,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6301,6 +6760,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6314,6 +6774,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/nft-floor-prices",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/nft-floor-prices",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6327,6 +6788,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/nft-mystery-boxes",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/nft-mystery-boxes",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6340,6 +6802,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/ngmi",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/ngmi",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6353,6 +6816,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6366,6 +6830,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/node",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/node",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6379,6 +6844,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6392,6 +6858,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/non-fungible-token-nft",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/non-fungible-token-nft",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6405,6 +6872,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/nonce",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/nonce",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6418,6 +6886,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/oco-order",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/oco-order",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6431,6 +6900,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/off-chain",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/off-chain",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6444,6 +6914,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6457,6 +6928,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/offline-signing-orchestrator-oso",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/offline-signing-orchestrator-oso",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6470,6 +6942,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/offshore-account",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/offshore-account",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6483,6 +6956,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6496,6 +6970,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/on-chain",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/on-chain",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6509,6 +6984,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6522,6 +6998,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6535,6 +7012,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/opbnb",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/opbnb",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6548,6 +7026,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/open-source-software-oss",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/open-source-software-oss",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6561,6 +7040,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6574,6 +7054,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6587,6 +7068,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/opportunity-cost",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/opportunity-cost",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6600,6 +7082,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6613,6 +7096,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6626,6 +7110,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/oracle",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/oracle",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6639,6 +7124,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/orc-20-tokens",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/orc-20-tokens",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6652,6 +7138,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/order-book",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/order-book",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6665,6 +7152,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/ordinals",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/ordinals",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6678,6 +7166,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/orphan-block",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/orphan-block",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6691,6 +7180,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6704,6 +7194,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6717,6 +7208,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/pancakeswap",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/pancakeswap",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6730,6 +7222,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/paper-wallet",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/paper-wallet",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6743,6 +7236,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/parallelization",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/parallelization",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6756,6 +7250,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6769,6 +7264,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6782,6 +7278,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/passive-management",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/passive-management",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6795,6 +7292,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6808,6 +7306,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6821,6 +7320,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6834,6 +7334,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6847,6 +7348,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/peer-to-peer",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/peer-to-peer",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6860,6 +7362,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/pegged-currency",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/pegged-currency",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6873,6 +7376,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6886,6 +7390,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6899,6 +7404,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/permissionless-blockchain",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/permissionless-blockchain",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6912,6 +7418,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/phishing",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/phishing",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6925,6 +7432,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6938,6 +7446,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/plasma",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/plasma",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6951,6 +7460,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6964,6 +7474,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/polkadot-crowdloan",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/polkadot-crowdloan",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6977,6 +7488,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6990,6 +7502,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/ponzi-scheme",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/ponzi-scheme",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7003,6 +7516,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7016,6 +7530,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7029,6 +7544,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7042,6 +7558,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/premining",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/premining",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7055,6 +7572,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/price-action",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/price-action",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7068,6 +7586,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7081,6 +7600,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/prisoners-dilemma",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/prisoners-dilemma",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7094,6 +7614,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7107,6 +7628,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7120,6 +7642,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/private-key",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/private-key",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7133,6 +7656,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/private-sale",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/private-sale",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7146,6 +7670,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/progressive-web-application",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/progressive-web-application",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7159,6 +7684,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/proof-of-attendance-protocol-poap",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/proof-of-attendance-protocol-poap",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7172,6 +7698,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/proof-of-reserves-por",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/proof-of-reserves-por",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7185,6 +7712,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/proof-of-stake",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/proof-of-stake",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7198,6 +7726,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/proof-of-staked-authority-posa",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/proof-of-staked-authority-posa",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7211,6 +7740,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/proof-of-work",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/proof-of-work",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7224,6 +7754,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/proposer-builder-separation-pbs",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/proposer-builder-separation-pbs",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7237,6 +7768,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/proto-danksharding",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/proto-danksharding",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7250,6 +7782,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7263,6 +7796,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/pseudorandom",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/pseudorandom",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7276,6 +7810,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7289,6 +7824,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7302,6 +7838,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/public-key",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/public-key",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7315,6 +7852,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7328,6 +7866,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/pump-and-dump",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/pump-and-dump",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7341,6 +7880,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7354,6 +7894,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/quantitative-easing-qe",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/quantitative-easing-qe",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7367,6 +7908,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/quantitative-tightening-qt",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/quantitative-tightening-qt",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7380,6 +7922,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/quantum-computing",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/quantum-computing",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7393,6 +7936,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7406,6 +7950,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/race-attack",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/race-attack",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7419,6 +7964,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/ransomware",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/ransomware",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7432,6 +7978,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7445,6 +7992,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/real-world-assets-rwas",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/real-world-assets-rwas",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7458,6 +8006,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/recession",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/recession",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7471,6 +8020,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/recursive-inscription",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/recursive-inscription",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7484,6 +8034,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/rekt",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/rekt",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7497,6 +8048,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/relative-strength-index",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/relative-strength-index",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7510,6 +8062,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7523,6 +8076,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7536,6 +8090,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/resistance",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/resistance",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7549,6 +8104,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/return-on-investment",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/return-on-investment",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7562,6 +8118,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/revenge-trading",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/revenge-trading",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7575,6 +8132,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7588,6 +8146,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/risk-premium",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/risk-premium",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7601,6 +8160,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/roadmap",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/roadmap",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7614,6 +8174,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7627,6 +8188,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7640,6 +8202,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7653,6 +8216,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/routing-attack",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/routing-attack",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7666,6 +8230,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7679,6 +8244,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/rug-pull",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/rug-pull",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7692,6 +8258,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7705,6 +8272,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/sahm-rule",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/sahm-rule",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7718,6 +8286,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7731,6 +8300,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7744,6 +8314,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/sandwich-trading",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/sandwich-trading",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7757,6 +8328,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7770,6 +8342,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/satoshi",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/satoshi",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7783,6 +8356,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/satoshi-nakamoto",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/satoshi-nakamoto",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7796,6 +8370,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7809,6 +8384,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7822,6 +8398,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7835,6 +8412,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7848,6 +8426,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7861,6 +8440,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7874,6 +8454,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7887,6 +8468,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/secure-asset-fund-for-users",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/secure-asset-fund-for-users",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7900,6 +8482,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/securities-and-exchange-commission",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/securities-and-exchange-commission",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7913,6 +8496,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/security-audit",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/security-audit",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7926,6 +8510,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7939,6 +8524,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7952,6 +8538,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/security-token-offering-sto",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/security-token-offering-sto",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7965,6 +8552,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/seed-phrase",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/seed-phrase",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7978,6 +8566,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/seed-tag",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/seed-tag",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7991,6 +8580,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/segregated-witness",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/segregated-witness",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8004,6 +8594,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8017,6 +8608,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8030,6 +8622,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/selfish-mining",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/selfish-mining",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8043,6 +8636,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/sell-wall",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/sell-wall",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8056,6 +8650,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/sentiment",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/sentiment",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8069,6 +8664,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8082,6 +8678,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8095,6 +8692,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8108,6 +8706,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8121,6 +8720,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/sharding",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/sharding",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8134,6 +8734,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/sharpe-ratio",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/sharpe-ratio",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8147,6 +8748,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8160,6 +8762,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8173,6 +8776,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/sidechains",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/sidechains",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8186,6 +8790,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8199,6 +8804,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/simple-moving-average-sma",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/simple-moving-average-sma",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8212,6 +8818,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/slashing",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/slashing",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8225,6 +8832,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8238,6 +8846,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/slippage",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/slippage",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8251,6 +8860,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8264,6 +8874,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/smart-contract",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/smart-contract",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8277,6 +8888,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/smart-contract-wallet",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/smart-contract-wallet",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8290,6 +8902,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/snapshot",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/snapshot",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8303,6 +8916,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/social-recovery-wallet",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/social-recovery-wallet",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8316,6 +8930,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/social-trading",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/social-trading",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8329,6 +8944,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/socialfi",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/socialfi",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8342,6 +8958,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8355,6 +8972,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/soft-landing",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/soft-landing",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8368,6 +8986,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/solidity",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/solidity",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8381,6 +9000,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/source-code",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/source-code",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8394,6 +9014,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/spl",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/spl",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8407,6 +9028,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/src-20-tokens",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/src-20-tokens",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8420,6 +9042,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/stablecoin",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/stablecoin",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8433,6 +9056,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/stagflation",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/stagflation",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8446,6 +9070,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8459,6 +9084,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8472,6 +9098,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/staking-pool",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/staking-pool",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8485,6 +9112,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8498,6 +9126,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/state-channel",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/state-channel",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8511,6 +9140,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8524,6 +9154,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/steth",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/steth",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8537,6 +9168,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8550,6 +9182,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/stock-variable",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/stock-variable",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8563,6 +9196,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/store-of-value",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/store-of-value",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8576,6 +9210,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8589,6 +9224,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/supercomputer",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/supercomputer",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8602,6 +9238,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/supply-chain",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/supply-chain",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8615,6 +9252,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/support",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/support",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8628,6 +9266,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8641,6 +9280,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/sybil-attack",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/sybil-attack",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8654,6 +9294,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8667,6 +9308,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/taker",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/taker",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8680,6 +9322,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/tank",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/tank",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8693,6 +9336,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8706,6 +9350,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8719,6 +9364,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/testnet",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/testnet",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8732,6 +9378,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8745,6 +9392,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8758,6 +9406,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8771,6 +9420,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/ticker",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/ticker",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8784,6 +9434,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/ticker-symbol",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/ticker-symbol",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8797,6 +9448,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/token",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/token",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8810,6 +9462,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/token-generation-event-tge",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/token-generation-event-tge",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8823,6 +9476,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/token-lockup",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/token-lockup",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8836,6 +9490,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/token-merge",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/token-merge",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8849,6 +9504,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/token-sale",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/token-sale",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8862,6 +9518,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8875,6 +9532,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/token-standards",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/token-standards",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8888,6 +9546,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/tokenization",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/tokenization",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8901,6 +9560,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/tokenomics",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/tokenomics",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8914,6 +9574,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/total-supply",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/total-supply",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8927,6 +9588,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/total-value-locked-tvl",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/total-value-locked-tvl",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8940,6 +9602,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/tradfi",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/tradfi",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8953,6 +9616,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8966,6 +9630,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8979,6 +9644,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8992,6 +9658,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/transaction-id",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/transaction-id",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9005,6 +9672,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9018,6 +9686,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/transactions-per-second-tps",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/transactions-per-second-tps",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9031,6 +9700,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9044,6 +9714,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/treasury-bills-t-bills",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/treasury-bills-t-bills",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9057,6 +9728,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9070,6 +9742,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/trueusd-tusd",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/trueusd-tusd",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9083,6 +9756,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9096,6 +9770,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/trustless",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/trustless",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9109,6 +9784,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/turing-complete",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/turing-complete",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9122,6 +9798,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9135,6 +9812,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9148,6 +9826,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9161,6 +9840,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/understanding-cz-s-number-4",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/understanding-cz-s-number-4",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9174,6 +9854,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9187,6 +9868,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9200,6 +9882,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/unit-of-account",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/unit-of-account",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9213,6 +9896,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9226,6 +9910,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/unspent-transaction-output-utxo",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/unspent-transaction-output-utxo",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9239,6 +9924,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9252,6 +9938,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9265,6 +9952,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9278,6 +9966,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9291,6 +9980,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/user-interface",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/user-interface",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9304,6 +9994,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/utility-token",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/utility-token",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9317,6 +10008,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9330,6 +10022,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9343,6 +10036,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9356,6 +10050,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9369,6 +10064,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/verification-code",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/verification-code",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9382,6 +10078,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9395,6 +10092,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9408,6 +10106,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/virtual-machine",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/virtual-machine",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9421,6 +10120,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/vladimir-club",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/vladimir-club",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9434,6 +10134,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/volatility",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/volatility",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9447,6 +10148,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/volume",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/volume",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9460,6 +10162,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/wagmi",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/wagmi",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9473,6 +10176,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/wallet",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/wallet",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9486,6 +10190,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9499,6 +10204,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9512,6 +10218,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/wash-trading",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/wash-trading",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9525,6 +10232,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/weak-hands",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/weak-hands",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9538,6 +10246,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/weak-subjectivity",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/weak-subjectivity",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9551,6 +10260,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/web-1",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/web-1",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9564,6 +10274,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9577,6 +10288,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9590,6 +10302,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9603,6 +10316,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9616,6 +10330,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9629,6 +10344,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/wei",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/wei",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9642,6 +10358,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/weighted-moving-average-wma",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/weighted-moving-average-wma",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9655,6 +10372,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/whale",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/whale",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9668,6 +10386,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/whiskers",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/whiskers",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9681,6 +10400,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/whitelist",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/whitelist",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9694,6 +10414,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9707,6 +10428,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/wick",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/wick",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9720,6 +10442,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/win-rate",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/win-rate",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9733,6 +10456,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/wrapped-ether",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/wrapped-ether",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9746,6 +10470,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9759,6 +10484,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/wyckoff",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/wyckoff",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9772,6 +10498,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9785,6 +10512,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9798,6 +10526,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9811,6 +10540,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9824,6 +10554,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/yield-farming",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/yield-farming",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9837,6 +10568,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9850,6 +10582,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9863,6 +10596,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/zero-knowledge-proofs",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/zero-knowledge-proofs",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9876,6 +10610,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9889,6 +10624,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/zk-rollup",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/zk-rollup",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9902,6 +10638,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/zk-snarks",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/zk-snarks",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9915,6 +10652,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/zk-starks",
       "sampleSentence": "",
       "extended": "",
+      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/zk-starks",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""

--- a/locales/en-US/en-US.json
+++ b/locales/en-US/en-US.json
@@ -9,7 +9,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -23,7 +22,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -37,7 +35,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -51,7 +48,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -65,7 +61,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -79,7 +74,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "Solving for this attack vector is one of the key design decisions in the Bitcoin protocol, as well as Ethereum, and others. In the case of Bitcoin, this was solved through the Proof of Work consensus mechanism, wherein the difficulty involved in mining new blocks effectively prevents any one actor from gaining this sort of control.",
-      "alternate": [],
       "termSource": "Consensys Software Inc., Blockchain Glossary for Beginners",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -93,13 +87,12 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
     },
     "absolute-advantage": {
-      "term": "Absolute Advantage",
+      "term": "absolute advantage",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -107,7 +100,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/absolute-advantage",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/absolute-advantage",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -121,12 +113,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "These public-private key pairs can be generated one at a time, or they can be *derived* from what is known as a **seed phrase** or **secret recovery phrase**; for more on this, see HD wallet.",
-      "alternate": [
-        {
-          "definition": "A record in the Solana ledger that either holds data or is an executable program. Like an account at a traditional bank, a Solana account may hold funds called lamports. Like a file in Linux, it is addressable by a key, often referred to as a public key or pubkey. The key may be one of: - an ed25519 public key - a program-derived account address (32byte value forced off the ed25519 curve) - a hash of an ed25519 public key with a 32 character string",
-          "source": "https://solana.com/docs/references/terminology#account"
-        }
-      ],
       "termSource": "Many",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -140,13 +126,12 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
     },
     "active-management": {
-      "term": "Active Management",
+      "term": "active management",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -154,13 +139,12 @@
       "definitionSource": "https://academy.binance.com/en/glossary/active-management",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/active-management",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
     "actively-validated-services-avs": {
-      "term": "Actively Validated Services (AVS)",
+      "term": "actively validated services (AVS)",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -168,7 +152,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/actively-validated-services-avs",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/actively-validated-services-avs",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -182,7 +165,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/ad-hoc",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/ad-hoc",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -196,12 +178,6 @@
       "definitionSource": "James Beck, Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "For example, on some networks, particularly EVM-style, every account will have an address, to which tokens could be sent. Smart contracts on those networks also have addresses, so that other contracts or protocols can interact with them. In Ethereum, the address begins with 0x; For example: 0x06A85356DCb5b307096726FB86A78c59D38e08ee",
-      "alternate": [
-        {
-          "definition": "String of text that designates the location of a particular wallet on the blockchain. Often a hashed version of a public key.",
-          "source": "https://academy.binance.com/en/glossary/address"
-        }
-      ],
       "termSource": "Consensys Software Inc., Blockchain Glossary for Beginners",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -215,7 +191,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -229,7 +204,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -243,7 +217,6 @@
       "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "Many hardware wallets use air-gapping as a security mechanism to keep users' private keys, or Secret Recovery Phrase offline, and thus safer from any kind of attack. Other, one-way communication methods are sometimes employed in such devices, e.g., QR codes.",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -254,15 +227,9 @@
       "termCategory": "",
       "phonetic": "/ˈɛrˌdrɑp/",
       "definition": "A token distribution method in which cryptocurrency or tokens are sent to a predeterimened set of wallet addresses.",
-      "definitionSource": "https://academy.binance.com/en/glossary/airdrop",
+      "definitionSource": "Education DAO, Consensys Software Inc., Blockchain Glossary for Beginners",
       "sampleSentence": "",
       "extended": "Sometimes airdrops are used for marketing purposes in exchange for simple tasks like reshares, referrals, or app downloads. The timing, recipient sourcing and inclusion methods, tokenomics and, if applicable, potential market value of tokens received through an airdrop are the subject of extensive debate and discussion.",
-      "alternate": [
-        {
-          "definition": "Distribution of digital assets to the public, by virtue of holding a certain token or by virtue of being an active wallet address.",
-          "source": "https://academy.binance.com/en/glossary/airdrop"
-        }
-      ],
       "termSource": "https://academy.binance.com/en/glossary/airdrop",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -276,7 +243,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -290,7 +256,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -304,18 +269,12 @@
       "definitionSource": "https://academy.binance.com/en/glossary/algorithm",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
-        {
-          "definition": "A sequence of unambiguous instructions used for the purpose of solving a problem.",
-          "source": "https://academy.binance.com/en/glossary/algorithm"
-        }
-      ],
       "termSource": "https://academy.binance.com/en/glossary/algorithm",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
     "all-or-none-order": {
-      "term": "All or None Order (AON)",
+      "term": "all or none order (AON)",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -323,13 +282,12 @@
       "definitionSource": "https://academy.binance.com/en/glossary/all-or-none-order",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/all-or-none-order",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
     "all-time-high": {
-      "term": "All-Time High (ATH)",
+      "term": "all-time high (ATH)",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -337,13 +295,12 @@
       "definitionSource": "https://academy.binance.com/en/glossary/all-time-high",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/all-time-high",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
     "allocation": {
-      "term": "Allocation",
+      "term": "allocation",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -351,7 +308,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/allocation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/allocation",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -365,7 +321,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/alpha",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/alpha",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -379,12 +334,6 @@
       "definitionSource": "James Beck, Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "The term is less used in Ethereum or smart contract-enabled blockchain communities. Many altcoins are forks of Bitcoin with minor changes (e.g., Litecoin). See also 'fork'.",
-      "alternate": [
-        {
-          "definition": "A cryptocurrency that is alternative to Bitcoin. Altcoin is used to describe cryptocurrencies that are not Bitcoin.",
-          "source": "https://academy.binance.com/en/glossary/altcoin"
-        }
-      ],
       "termSource": "Consensys Software Inc., Blockchain Glossary for Beginners",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -398,13 +347,12 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
     },
     "angel-investor": {
-      "term": "Angel Investor",
+      "term": "angel investor",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -412,13 +360,12 @@
       "definitionSource": "https://academy.binance.com/en/glossary/angel-investor",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/angel-investor",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
     "anti-money-laundering": {
-      "term": "Anti Money Laundering (AML)",
+      "term": "anti-money laundering (AML)",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -426,7 +373,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/anti-money-laundering",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/anti-money-laundering",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -440,7 +386,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -454,7 +399,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "An appchain generally offers an optimized execution environment for the application. Rather than being a 'monolithic' blockchain with its own executioon and consensus mechanisms, it may e.g. still rely on an underlying blockchain for consensus. See also: 'blockchain trilemma', 'modular blockchain', 'Layer 2', 'Layer 3'.",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -468,7 +412,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -482,7 +425,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/application-programming-interface",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/application-programming-interface",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -496,13 +438,12 @@
       "definitionSource": "https://academy.binance.com/en/glossary/application-specific-integrated-circuit",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/application-specific-integrated-circuit",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
     "arbitrage": {
-      "term": "Arbitrage",
+      "term": "arbitrage",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -510,7 +451,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/arbitrage",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/arbitrage",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -524,7 +464,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -538,7 +477,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/arc-20",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/arc-20",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -552,7 +490,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/artificial-intelligence-ai",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/artificial-intelligence-ai",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -566,7 +503,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -580,13 +516,12 @@
       "definitionSource": "https://academy.binance.com/en/glossary/asic-resistant",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/asic-resistant",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
     "asking-price": {
-      "term": "Ask Price",
+      "term": "asking price",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -594,13 +529,12 @@
       "definitionSource": "https://academy.binance.com/en/glossary/asking-price",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/asking-price",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
     "asset-management": {
-      "term": "Asset Management",
+      "term": "asset management",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -608,7 +542,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/asset-management",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/asset-management",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -622,7 +555,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "In the crypto context, 'asset provenance' refers to the ability to trace the ownership and transfer of a specific cryptocurrency or token from its creation or minting to its current holder.",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -636,13 +568,12 @@
       "definitionSource": "https://academy.binance.com/en/glossary/assets-under-management-aum",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/assets-under-management-aum",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
     "asynchronous": {
-      "term": "Asynchronous",
+      "term": "asynchronous",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -650,13 +581,12 @@
       "definitionSource": "https://academy.binance.com/en/glossary/asynchronous",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/asynchronous",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
     "atomic-swap": {
-      "term": "Atomic Swap",
+      "term": "atomic swap",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -664,13 +594,12 @@
       "definitionSource": "https://academy.binance.com/en/glossary/atomic-swap",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/atomic-swap",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
     "attack-surface": {
-      "term": "Attack surface",
+      "term": "attack surface",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -678,7 +607,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/attack-surface",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/attack-surface",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -692,13 +620,12 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "While that may sound vague, that's because attestations are used in a broad range of contexts, and have both been crucial to the development of key blockchain network protocols – such as in Proof of Stake (PoS) mechanisms, in which validators *attest* to the validity of the transactions they're recording in blocks and syncing through the consensus protocol – or in more recent developments, wherein protocols like the Ethereum Attestation Service allow for the creation of custom attestation 'schemata', publicly accessible on a network. Individual 'attestations' can then be written according to the fields and structures defined in each individual schema, stored on-chain by users executing a call to the schema and signing it with a public key.",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
     },
     "auction": {
-      "term": "Auction",
+      "term": "auction",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -706,7 +633,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/auction",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/auction",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -720,7 +646,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -734,7 +659,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/automated-market-maker-amm",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/automated-market-maker-amm",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -748,7 +672,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -762,7 +685,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -776,7 +698,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -790,13 +711,12 @@
       "definitionSource": "https://academy.binance.com/en/glossary/b-tokens",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/b-tokens",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
     "bags": {
-      "term": "Bags",
+      "term": "bags",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -804,7 +724,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/bags",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/bags",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -818,7 +737,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -832,7 +750,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -846,18 +763,12 @@
       "definitionSource": "https://academy.binance.com/en/glossary/beacon-chain",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
-        {
-          "definition": "The Beacon Chain is Ethereum’s proof-of-stake (PoS) layer where consensus is reached.",
-          "source": "https://academy.binance.com/en/glossary/beacon-chain"
-        }
-      ],
       "termSource": "https://academy.binance.com/en/glossary/beacon-chain",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
     "bear-market": {
-      "term": "Bear Market",
+      "term": "bear market",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -865,13 +776,12 @@
       "definitionSource": "https://academy.binance.com/en/glossary/bear-market",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/bear-market",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
     "benchmark": {
-      "term": "Benchmark",
+      "term": "benchmark",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -879,7 +789,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/benchmark",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/benchmark",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -893,7 +802,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/bep-1155",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/bep-1155",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -907,7 +815,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/bep-20",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/bep-20",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -921,7 +828,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/bep-721",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/bep-721",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -935,7 +841,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/bep-95",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/bep-95",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -949,13 +854,12 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
     },
     "beta-coefficient": {
-      "term": "Beta (Coefficient)",
+      "term": "beta (coefficient)",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -963,13 +867,12 @@
       "definitionSource": "https://academy.binance.com/en/glossary/beta-coefficient",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/beta-coefficient",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
     "beta-release": {
-      "term": "Beta (Release)",
+      "term": "beta (release)",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -977,13 +880,12 @@
       "definitionSource": "https://academy.binance.com/en/glossary/beta-release",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/beta-release",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
     "bid-ask-spread": {
-      "term": "Bid-Ask Spread",
+      "term": "bid-ask spread",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -991,13 +893,12 @@
       "definitionSource": "https://academy.binance.com/en/glossary/bid-ask-spread",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/bid-ask-spread",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
     "bid-price": {
-      "term": "Bid Price",
+      "term": "bid price",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -1005,7 +906,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/bid-price",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/bid-price",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1019,7 +919,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1033,7 +932,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/binance-blockchain-charity-foundation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/binance-blockchain-charity-foundation",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1047,7 +945,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/binance-ecosystem-fund",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/binance-ecosystem-fund",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1061,7 +958,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/binancian",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/binancian",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1075,12 +971,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/bitcoin",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
-        {
-          "definition": "A cryptocurrency created by the pseudonymous developer(s) Satoshi Nakamoto, initially described as a 'Peer-to-Peer e-cash'.",
-          "source": "https://academy.binance.com/en/glossary/bitcoin"
-        }
-      ],
       "termSource": "https://academy.binance.com/en/glossary/bitcoin",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1094,7 +984,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/bitcoin-core",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/bitcoin-core",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1108,7 +997,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/bitcoin-dominance",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/bitcoin-dominance",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1122,7 +1010,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/bitcoin-maximalists",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/bitcoin-maximalists",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1136,7 +1023,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/bitcoin-pizza",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/bitcoin-pizza",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1150,7 +1036,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/black-swan-event",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/black-swan-event",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1164,16 +1049,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/block",
       "sampleSentence": "",
       "extended": "Imagine a ledger that is being constantly synced between any number of exact copies of itself. People keep sending requests to add new entries to the ledger; these requests are transactions. When there are enough transactions ready, they get put into a specific order, and the *nodes*, each of which is keeping a copy of that ledger, reach consensus that the transactions are valid. Then, the transactions are cryptographically locked, in that order, into a 'block' and added forever to the ledger. This 'block' forms the starting point for the next one; in this way, they are all linked together in a chain, hence–blockchain.",
-      "alternate": [
-        {
-          "definition": "A computer file that stores transaction data. These can then be arranged in a linear sequence, which will form a blockchain.",
-          "source": "https://academy.binance.com/en/glossary/block"
-        },
-        {
-          "definition": "A contiguous set of entries on the ledger covered by a vote. A leader produces at most one block per slot.",
-          "source": "https://solana.com/docs/references/terminology#block"
-        }
-      ],
       "termSource": "https://academy.binance.com/en/glossary/block",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1187,7 +1062,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/block-explorer",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/block-explorer",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1201,7 +1075,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/block-header",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/block-header",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1215,16 +1088,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/block-height",
       "sampleSentence": "",
       "extended": "For example, Height 0 would be the very first block, which is also called the Genesis Block.",
-      "alternate": [
-        {
-          "definition": "The number of blocks in the chain between itself and the first block on that blockchain (genesis block or block 0).",
-          "source": "https://academy.binance.com/en/glossary/block-height"
-        },
-        {
-          "definition": "The number of blocks beneath the current block. The first block after the genesis block has height one.",
-          "source": "https://solana.com/docs/references/terminology#block-height"
-        }
-      ],
       "termSource": "https://academy.binance.com/en/glossary/block-height",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1238,12 +1101,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/block-reward",
       "sampleSentence": "",
       "extended": "Block rewards can be a mixture of coins and transaction fees. The composition depends on the policy used by the cryptocurrency in question, and whether all of the coins have already been successfully mined. The current block reward for the Bitcoin network is 12.5 bitcoins per block.",
-      "alternate": [
-        {
-          "definition": "The sum of coins awarded by the blockchain protocol to cryptocurrency miners for each successfully mined and validated block.",
-          "source": "https://academy.binance.com/en/glossary/block-reward"
-        }
-      ],
       "termSource": "https://academy.binance.com/en/glossary/block-reward",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1257,7 +1114,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "See also 'Proof of Work', 'Proof of Stake'.",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1271,7 +1127,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1285,12 +1140,6 @@
       "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "What is commonly referred to as a 'blockchain' might be more precisely called 'a public blockchain network', or a 'distributed ledger network'. While they get called 'blockchains' or 'chains', this is essentially a sort of metonymic usage. A public blockchain network consists, usually, of several different parts: 1. The blockchain or ledger itself. Think of this as the 'hard drive' of the network. 2. The consensus mechanism, and the consensus layer; this keeps all the copies of the ledger in sync, and adds new transactions or entries to it. 3. An execution layer: depending on the network in question, this layer or environment may vary from a very few functions built into the same software as the consensus client, to a very complex, Turing-complete, full-on Virtual Machine environment requiring those who run it to consider hardware requirements. There are, additionally, 'downstream' aspects of any one of these blockchain networks, including wallets, private-public key derivation logic, which programming languages can be used in interacting with it, etc. etc.",
-      "alternate": [
-        {
-          "definition": "A decentralized, digitized ledger that records transaction information about a cryptocurrency in a chronological order.",
-          "source": "https://academy.binance.com/en/glossary/blockchain"
-        }
-      ],
       "termSource": "https://academy.binance.com/en/glossary/blockchain",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1304,7 +1153,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "While a blockchain is designed to keep information forever, and be “readable by anyone”, finding the specific information you’re interested in may require indexing data off the blockchain–that is, sorting it according to given categories (sender address, token type, etc) into a separate database which can then be queried by the user; this essential function is provided by blockchain explorers. A prominent example is etherscan, which also offers explorers on a number of other networks.",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1318,7 +1166,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1332,7 +1179,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/bloom-filter",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/bloom-filter",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1346,7 +1192,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/blue-chip-token",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/blue-chip-token",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1360,7 +1205,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/bnb",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/bnb",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1374,7 +1218,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1388,7 +1231,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/bnsol",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/bnsol",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1402,7 +1244,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/bollinger-bands",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/bollinger-bands",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1416,7 +1257,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/bond",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/bond",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1430,12 +1270,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/bounty",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
-        {
-          "definition": "A reward posted by a group or individual to incentivize certain work, behavior (such as referrals), or development.",
-          "source": "https://academy.binance.com/en/glossary/bounty"
-        }
-      ],
       "termSource": "https://academy.binance.com/en/glossary/bounty",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1449,7 +1283,6 @@
       "definitionSource": "MetaMask - kumavis, Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "Humans are not capable of generating enough entropy, or randomness, and therefore the wallets derived from these phrases are insecure; brain wallets can be brute forced by super fast computers. For this reason, brain wallet are insecure and should not be used. See also 'seed phrase'', 'Secret Recovery Phrase'.",
-      "alternate": [],
       "termSource": "MetaMask Help Center",
       "dateFirstRecorded": "2018",
       "commentary": ""
@@ -1463,7 +1296,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1477,7 +1309,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/brc-20-tokens",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/brc-20-tokens",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1491,7 +1322,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/break-even-point",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/break-even-point",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1505,7 +1335,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/breakeven-multiple",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/breakeven-multiple",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1519,7 +1348,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/breakout",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/breakout",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1533,7 +1361,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "It would be fair to say both that the term 'bridge' is generally accurate, and that it does a lot of heavy lifting. The way that bridges are created, and maintained, varies from one to another, but often involve some sort of 'paired smart contracts', one on each network. These contracts would, e.g., lock, or burn, tokens on one chain, and either mint or somehow disburse an equivalent token, and amount of them, on the destination chain.",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1547,7 +1374,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/bscscan",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/bscscan",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1561,7 +1387,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1575,7 +1400,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/btc-wallet-address",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/btc-wallet-address",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1589,12 +1413,6 @@
       "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
-        {
-          "definition": "Originally derived from HODL, a term referring to keeping your heads down and focusing on building your product.",
-          "source": "https://academy.binance.com/en/glossary/buidl"
-        }
-      ],
       "termSource": "Consensys Software Inc., Blockchain Glossary for Beginners",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1608,7 +1426,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/bull-market",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/bull-market",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1622,7 +1439,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/burner-wallet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/burner-wallet",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1636,7 +1452,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/buy-wall",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/buy-wall",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1650,7 +1465,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1664,7 +1478,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1678,7 +1491,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1692,7 +1504,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/candidate-block",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/candidate-block",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1706,7 +1517,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/candlestick",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/candlestick",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1720,7 +1530,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/capitulation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/capitulation",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1734,7 +1543,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1748,7 +1556,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/censorship-resistance",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/censorship-resistance",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1762,7 +1569,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/central-bank",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/central-bank",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1776,7 +1582,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/central-bank-digital-currency-cbdc",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/central-bank-digital-currency-cbdc",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1790,7 +1595,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/central-processing-unit",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/central-processing-unit",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1804,7 +1608,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/centralized",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/centralized",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1818,12 +1621,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/centralized-exchange",
       "sampleSentence": "",
       "extended": "Centralized exchanges typically offer a wide range of trading pairs, with many popular cryptocurrencies available for trade. They also usually have high liquidity and offer advanced trading features such as margin trading, order types, and charting tools.\nHowever, centralized exchanges also have several drawbacks. They are often targeted by hackers, as the centralized nature of the exchange makes them a single point of failure. They also require users to trust the exchange to hold their funds securely and execute trades fairly, which can be a source of concern for some users.",
-      "alternate": [
-        {
-          "definition": "Understand the world of centralized exchanges, traditional crypto marketplaces known for high liquidity, advanced trading tools, and risk considerations.",
-          "source": "https://academy.binance.com/en/glossary/centralized-exchange"
-        }
-      ],
       "termSource": "https://academy.binance.com/en/glossary/centralized-exchange",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1837,7 +1634,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1851,7 +1647,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "Ethereum networks have two identifiers, a network ID and a chain ID. Although they often have the same value, they have different uses. Peer-to-peer communication between nodes uses the network ID, while the transaction signature process uses the chain ID.",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1865,7 +1660,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/chatgpt",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/chatgpt",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1879,7 +1673,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1893,7 +1686,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/cipher",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/cipher",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1907,7 +1699,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/circulating-supply",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/circulating-supply",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1921,12 +1712,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
-        {
-          "definition": "A computer program that accesses the Solana server network cluster.",
-          "source": "https://solana.com/docs/references/terminology#client"
-        }
-      ],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1940,7 +1725,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/cloud",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/cloud",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1954,7 +1738,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1968,12 +1751,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/coin",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
-        {
-          "definition": "A cryptocurrency or digital cash that is independent of any other platform, which is used as exchange of value.",
-          "source": "https://academy.binance.com/en/glossary/coin"
-        }
-      ],
       "termSource": "https://academy.binance.com/en/glossary/coin",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1987,7 +1764,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2001,7 +1777,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2015,12 +1790,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/cold-storage",
       "sampleSentence": "",
       "extended": "See also: airgapping",
-      "alternate": [
-        {
-          "definition": "Discover the essentials of cold storage: learn what it is and how it protects your cryptocurrency holdings.",
-          "source": "https://academy.binance.com/en/glossary/cold-storage"
-        }
-      ],
       "termSource": "https://academy.binance.com/en/glossary/cold-storage",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2034,7 +1803,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2048,7 +1816,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/collateral",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/collateral",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2062,7 +1829,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/colocation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/colocation",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2076,7 +1842,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/commodity-futures-trading-commission",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/commodity-futures-trading-commission",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2090,7 +1855,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2104,7 +1868,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2118,7 +1881,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/compound-interest",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/compound-interest",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2132,7 +1894,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "Under a Proof of Work (PoW) consensus mechanism, this happens through a process known as mining; under Proof of Stake (PoS), the process is known as validation. Once a transaction is successfully confirmed, it theoretically cannot be reversed or double spent. The more confirmations a transaction has, the harder it becomes to perform a double spend attack.",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2146,12 +1907,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/confirmation-time",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
-        {
-          "definition": "The wallclock duration between a leader creating a tick entry and creating a confirmed block.",
-          "source": "https://solana.com/docs/references/terminology#confirmation-time"
-        }
-      ],
       "termSource": "https://academy.binance.com/en/glossary/confirmation-time",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2165,7 +1920,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/confluence",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/confluence",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2179,7 +1933,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "In a blockchain network, the consensus layer is implemented by the consensus protocol or algorithm that defines how new blocks are added to the chain, and how the network reaches agreement on the current state of the ledger. There are various types of consensus mechanisms used in blockchain networks, including proof of work (PoW), proof of stake (PoS), and delegated proof of stake (DPoS). The consensus client implements the specific consensus mechanism used by the network and ensures that all nodes follow the rules and reach agreement on the current state of the blockchain.",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2193,7 +1946,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/consensus-algorithm",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/consensus-algorithm",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2207,7 +1959,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2221,7 +1972,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2235,7 +1985,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2249,7 +1998,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2263,7 +2011,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2277,7 +2024,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/consumer-price-index-(cpi)",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/consumer-price-index-(cpi)",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2291,7 +2037,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/contango-and-backwardation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/contango-and-backwardation",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2305,7 +2050,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2319,7 +2063,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "The interplay between accounts and contracts, as public blockchain technology has advanced, has resulted in a particularly dense semantic web. When a smart contract is deployed, the Externally Owned Account, or EOA (controlled by a human), which is used to pay the gas fees required to deploy the contract -- that is, write it to the blockchain and make it available in the first place -- is referred to as the 'contract deploying account'. The resulting smart contract itself has an account as well -- the public address which can be used to 'call', or access its methods -- that's the one we're calling, here, a 'contract account'. But don't worry, it gets significantly worse; at a certain point, new techniques began to be used, to 'abstract away' the difficulties involved in EOAs; this move towards 'account abstraction' resulted in the creation of end user-accessible, shall we say, accounts which are created and controlled by... Smart contracts (which, remember, have their own accounts). There was much soul-searching and hand-wringing in trying to figure out what to call these things; often, they are referred to as... *Smart Contract Accounts*, capitalized; that's SCA, for short.",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2333,7 +2076,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2347,7 +2089,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/copy-trading",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/copy-trading",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2361,7 +2102,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/counterparty-risk",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/counterparty-risk",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2375,7 +2115,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/credentials",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/credentials",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2389,7 +2128,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/cross-chain-bridges",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/cross-chain-bridges",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2403,7 +2141,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2417,7 +2154,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2431,7 +2167,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2445,7 +2180,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2459,7 +2193,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/crypto-etfs",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/crypto-etfs",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2473,7 +2206,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/crypto-fear-and-greed-index",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/crypto-fear-and-greed-index",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2487,7 +2219,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2501,7 +2232,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/crypto-protocol",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/crypto-protocol",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2515,7 +2245,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2529,7 +2258,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/crypto-winter",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/crypto-winter",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2543,7 +2271,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2557,12 +2284,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/cryptocurrency",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
-        {
-          "definition": "A digital currency that is secured by cryptography to work as a medium of exchange within a peer-to-peer (P2P) economic system.",
-          "source": "https://academy.binance.com/en/glossary/cryptocurrency"
-        }
-      ],
       "termSource": "https://academy.binance.com/en/glossary/cryptocurrency",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2576,7 +2297,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2590,12 +2310,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/cryptography",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
-        {
-          "definition": "The science of using mathematical theories and computation in order to encrypt and decrypt information.",
-          "source": "https://academy.binance.com/en/glossary/cryptography"
-        }
-      ],
       "termSource": "https://academy.binance.com/en/glossary/cryptography",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2609,7 +2323,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2623,12 +2336,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/custody",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
-        {
-          "definition": "Refers to the holding of assets on behalf of a client. Can also refer to the ownership of one's funds or assets.",
-          "source": "https://academy.binance.com/en/glossary/custody"
-        }
-      ],
       "termSource": "https://academy.binance.com/en/glossary/custody",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2642,7 +2349,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2656,7 +2362,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/daemon",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/daemon",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2670,7 +2375,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2684,7 +2388,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/danksharding",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/danksharding",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2698,7 +2401,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2712,7 +2414,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2726,7 +2427,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2740,7 +2440,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/dead-cat-bounce",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/dead-cat-bounce",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2754,7 +2453,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/death-cross",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/death-cross",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2768,7 +2466,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2782,12 +2479,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/decentralized-application",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
-        {
-          "definition": "DApps are applications that run on a P2P network of computers rather than a central database. Users can freely connect to DApps using crypto wallets.",
-          "source": "https://academy.binance.com/en/glossary/decentralized-application"
-        }
-      ],
       "termSource": "https://academy.binance.com/en/glossary/decentralized-application",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2801,7 +2492,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/decentralized-autonomous-cooperative",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/decentralized-autonomous-cooperative",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2815,12 +2505,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/decentralized-autonomous-organization",
       "sampleSentence": "",
       "extended": "Alternatively, the first known example of a DAO is referred to as The DAO. The DAO served as a form of investor-directed venture capital fund, which sought to provide enterprises with new decentralized business models. Ethereum-based, The DAO’s code was open source. The organization set the record for the most crowdfunded project in 2016. Those funds were partially stolen by hackers. The hack caused an Ethereum hard-fork which lead to the creation of Ethereum Classic.",
-      "alternate": [
-        {
-          "definition": "Definition: A system of hard-coded rules that define which actions a decentralized organization will take.",
-          "source": "https://academy.binance.com/en/glossary/decentralized-autonomous-organization"
-        }
-      ],
       "termSource": "https://academy.binance.com/en/glossary/decentralized-autonomous-organization",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2834,12 +2518,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/decentralized-exchange",
       "sampleSentence": "",
       "extended": "This includes familiar concepts like loans and interest-bearing financial instruments, as well as so-called “DeFi primitives”, novel solutions like token swapping and liquidity pools. The trading is peer-to-peer, or between pools of liquidity. This is in contrast with a centralized exchange, which is more akin to a bank or investment firm that specializes in cryptocurrencies. Additionally, there are so-called on-ramp providers, who could be compared to currency brokers, exchanging traditional “fiat” money for cryptocurrencies, and do not hold customer’s funds “on deposit” the way a centralized exchange does. There are important technical and regulatory differences between these, which are constantly evolving.",
-      "alternate": [
-        {
-          "definition": "An exchange which does not require users to deposit funds to start trading and does not hold the funds for the user.",
-          "source": "https://academy.binance.com/en/glossary/decentralized-exchange"
-        }
-      ],
       "termSource": "https://academy.binance.com/en/glossary/decentralized-exchange",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2853,7 +2531,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2867,7 +2544,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/decentralized-indexes",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/decentralized-indexes",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2881,7 +2557,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2895,7 +2570,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/decryption",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/decryption",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2909,7 +2583,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/deep-web",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/deep-web",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2923,7 +2596,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2937,7 +2609,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2951,7 +2622,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/delisting",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/delisting",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2965,7 +2635,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2979,7 +2648,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/depeg",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/depeg",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2993,7 +2661,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3007,7 +2674,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/depression",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/depression",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3021,7 +2687,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3035,7 +2700,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/design-flaw-attack",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/design-flaw-attack",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3049,7 +2713,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3063,7 +2726,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3077,7 +2739,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3091,7 +2752,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3105,7 +2765,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/diamond-hands",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/diamond-hands",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3119,12 +2778,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/difficulty",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
-        {
-          "definition": "In cryptocurrency, difficulty indicates the difficulty required to mine a block. Learn more at Binance Academy.",
-          "source": "https://academy.binance.com/en/glossary/difficulty"
-        }
-      ],
       "termSource": "https://academy.binance.com/en/glossary/difficulty",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3138,12 +2791,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/difficulty-bomb",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
-        {
-          "definition": "The term 'difficulty bomb' denotes the increase in mining difficulty in Ethereum, as part of its migration to Proof of Stake.",
-          "source": "https://academy.binance.com/en/glossary/difficulty-bomb"
-        }
-      ],
       "termSource": "https://academy.binance.com/en/glossary/difficulty-bomb",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3157,7 +2804,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3171,7 +2817,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3185,12 +2830,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/digital-signature",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
-        {
-          "definition": "A cryptographic tool to verify the authenticity and integrity of digital data, ensuring the security of data communication and cryptocurrency transactions.",
-          "source": "https://academy.binance.com/en/glossary/digital-signature"
-        }
-      ],
       "termSource": "https://academy.binance.com/en/glossary/digital-signature",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3204,7 +2843,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3218,7 +2856,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/direct-market-access-dma",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/direct-market-access-dma",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3232,7 +2869,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3246,7 +2882,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/divergence",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/divergence",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3260,7 +2895,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/diversification",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/diversification",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3274,7 +2908,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3288,7 +2921,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/do-your-own-research",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/do-your-own-research",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3302,7 +2934,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/dollar-cost-averaging",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/dollar-cost-averaging",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3316,7 +2947,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/dot-plot",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/dot-plot",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3330,7 +2960,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3344,7 +2973,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/double-spending",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/double-spending",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3358,7 +2986,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/eclipse-attack",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/eclipse-attack",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3372,7 +2999,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3386,7 +3012,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3400,7 +3025,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3414,7 +3038,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/efficient-market-hypothesis-emh",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/efficient-market-hypothesis-emh",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3428,7 +3051,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/eigenlayer",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/eigenlayer",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3442,7 +3064,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/eip",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/eip",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3456,7 +3077,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3470,7 +3090,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/eip-3074",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/eip-3074",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3484,7 +3103,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/eip-4844",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/eip-4844",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3498,7 +3116,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/eip-7251",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/eip-7251",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3512,7 +3129,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/eip-7702",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/eip-7702",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3526,7 +3142,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/elasticity",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/elasticity",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3540,7 +3155,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3554,12 +3168,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/encryption",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
-        {
-          "definition": "Conversion of information or data into a secure code in order to prevent unauthorised access to the information or data.",
-          "source": "https://academy.binance.com/en/glossary/encryption"
-        }
-      ],
       "termSource": "https://academy.binance.com/en/glossary/encryption",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3573,7 +3181,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/endogenous-variable",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/endogenous-variable",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3587,7 +3194,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3601,7 +3207,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3615,12 +3220,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
-        {
-          "definition": "The time, i.e. number of slots, for which a leader schedule is valid.",
-          "source": "https://solana.com/docs/references/terminology#epoch"
-        }
-      ],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3634,7 +3233,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3648,12 +3246,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/erc-1155",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
-        {
-          "definition": "Discover the versatility of ERC-1155 tokens. Ideal for gaming, digital collectibles and managing multiple token types efficiently.",
-          "source": "https://academy.binance.com/en/glossary/erc-1155"
-        }
-      ],
       "termSource": "https://academy.binance.com/en/glossary/erc-1155",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3667,12 +3259,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/erc-20",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
-        {
-          "definition": "A technical standard used to issue and implement tokens on the Ethereum blockchain proposed in November 2015 by Fabian Vogelsteller.",
-          "source": "https://academy.binance.com/en/glossary/erc-20"
-        }
-      ],
       "termSource": "https://academy.binance.com/en/glossary/erc-20",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3686,7 +3272,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/erc-404",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/erc-404",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3700,12 +3285,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/erc-721",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
-        {
-          "definition": "An Ethereum based non-fungible token. This means that each token is unique and as a result, not interchangeable.",
-          "source": "https://academy.binance.com/en/glossary/erc-721"
-        }
-      ],
       "termSource": "https://academy.binance.com/en/glossary/erc-721",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3719,7 +3298,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/etf",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/etf",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3733,7 +3311,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3747,7 +3324,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3761,7 +3337,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3775,7 +3350,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3789,7 +3363,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/ethereum-classic",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/ethereum-classic",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3803,7 +3376,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/ethereum-foundation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/ethereum-foundation",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3817,7 +3389,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3831,7 +3402,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3845,7 +3415,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3859,7 +3428,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3873,7 +3441,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/ethereum-virtual-machine-evm",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/ethereum-virtual-machine-evm",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3887,7 +3454,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3901,7 +3467,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3915,7 +3480,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3929,12 +3493,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/exchange",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
-        {
-          "definition": "A marketplace for cryptocurrencies where users can buy and sell coins.",
-          "source": "https://academy.binance.com/en/glossary/exchange"
-        }
-      ],
       "termSource": "https://academy.binance.com/en/glossary/exchange",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3948,7 +3506,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3962,7 +3519,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3976,7 +3532,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/exogenous-variable",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/exogenous-variable",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3990,7 +3545,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/exponential-moving-average-ema",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/exponential-moving-average-ema",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4004,7 +3558,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/externally-owned-account-eoa",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/externally-owned-account-eoa",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4018,7 +3571,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/fakeout",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/fakeout",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4032,7 +3584,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/falling-knife",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/falling-knife",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4046,7 +3597,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/fan-tokens",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/fan-tokens",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4060,7 +3610,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4074,7 +3623,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4088,7 +3636,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4102,7 +3649,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/fear-of-missing-out",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/fear-of-missing-out",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4116,7 +3662,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/fear-uncertainty-and-doubt",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/fear-uncertainty-and-doubt",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4130,7 +3675,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/fiat",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/fiat",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4144,7 +3688,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4158,7 +3701,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/fibonacci-retracement",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/fibonacci-retracement",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4172,7 +3714,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/fill-or-kill-order",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/fill-or-kill-order",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4186,16 +3727,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/finality",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
-        {
-          "definition": "The assurance or guarantee that completed (cryptocurrency) transactions cannot be altered, reversed or canceled.",
-          "source": "https://academy.binance.com/en/glossary/finality"
-        },
-        {
-          "definition": "When nodes representing 2/3rd of the stake have a common root.",
-          "source": "https://solana.com/docs/references/terminology#finality"
-        }
-      ],
       "termSource": "https://academy.binance.com/en/glossary/finality",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4209,7 +3740,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4223,7 +3753,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4237,7 +3766,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4251,7 +3779,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4265,7 +3792,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4279,7 +3805,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4293,7 +3818,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4307,7 +3831,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/first-mover-advantage",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/first-mover-advantage",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4321,7 +3844,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/fiscal-policy",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/fiscal-policy",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4335,7 +3857,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/flappening",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/flappening",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4349,7 +3870,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/flashbots",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/flashbots",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4363,7 +3883,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/flippening",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/flippening",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4377,7 +3896,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/flow-variable",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/flow-variable",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4391,7 +3909,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/forced-liquidation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/forced-liquidation",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4405,7 +3922,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/forex-fx",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/forex-fx",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4419,16 +3935,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/fork",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
-        {
-          "definition": "A fork is a divergence in the blockchain network by creating a split in the blockchain's transaction history. There are two types of forks - soft and hard.",
-          "source": "https://academy.binance.com/en/glossary/fork"
-        },
-        {
-          "definition": "A ledger derived from common entries but then diverged.",
-          "source": "https://solana.com/docs/references/terminology#fork"
-        }
-      ],
       "termSource": "https://academy.binance.com/en/glossary/fork",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4442,7 +3948,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/formal-verification",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/formal-verification",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4456,7 +3961,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4470,12 +3974,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/fraud-proof",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
-        {
-          "definition": "A fraud proof is a cryptographical evidence that a verifier submits to challenge a transaction's validity. They are widely used for blockchain scalability.",
-          "source": "https://academy.binance.com/en/glossary/fraud-proof"
-        }
-      ],
       "termSource": "https://academy.binance.com/en/glossary/fraud-proof",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4489,7 +3987,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/fren",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/fren",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4503,7 +4000,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4517,12 +4013,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/full-node",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
-        {
-          "definition": "Computer that fully implements the entirety of rules of an underlying blockchain network and validates transactions on a blockchain.",
-          "source": "https://academy.binance.com/en/glossary/full-node"
-        }
-      ],
       "termSource": "https://academy.binance.com/en/glossary/full-node",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4536,7 +4026,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/fully-diluted-valuation-fdv",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/fully-diluted-valuation-fdv",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4550,7 +4039,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/fundamental-analysis",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/fundamental-analysis",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4564,7 +4052,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/funding-fees",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/funding-fees",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4578,7 +4065,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/fungibility",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/fungibility",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4592,7 +4078,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/futures-contract",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/futures-contract",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4606,7 +4091,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/gamefi",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/gamefi",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4620,7 +4104,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4634,12 +4117,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/gas",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
-        {
-          "definition": "The pricing mechanism employed  on the Ethereum blockchain to calculate the costs of smart contracts operations and transaction fees.",
-          "source": "https://academy.binance.com/en/glossary/gas"
-        }
-      ],
       "termSource": "https://academy.binance.com/en/glossary/gas",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4653,7 +4130,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4667,12 +4143,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/gas-limit",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
-        {
-          "definition": "Maximum price a cryptocurrency user is willing to pay as a fee when sending a transaction, or performing a smart contract function.",
-          "source": "https://academy.binance.com/en/glossary/gas-limit"
-        }
-      ],
       "termSource": "https://academy.binance.com/en/glossary/gas-limit",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4686,7 +4156,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4700,7 +4169,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4714,7 +4182,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4728,7 +4195,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/gdp-deflator",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/gdp-deflator",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4742,7 +4208,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/general-public-license",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/general-public-license",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4753,19 +4218,9 @@
       "termCategory": "",
       "phonetic": "/ˈdʒɛnɪsɪs blɒk/",
       "definition": "The initial block of data computed in the history of a blockchain network.",
-      "definitionSource": "wordsofweb3",
+      "definitionSource": "https://academy.binance.com/en/glossary/genesis-block",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
-        {
-          "definition": "The first ever block recorded on its respective blockchain network, also referred to as Block 0 or Block 1.",
-          "source": "https://academy.binance.com/en/glossary/genesis-block"
-        },
-        {
-          "definition": "The first block in the chain.",
-          "source": "https://solana.com/docs/references/terminology#genesis-block"
-        }
-      ],
       "termSource": "https://academy.binance.com/en/glossary/genesis-block",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4779,7 +4234,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4793,7 +4247,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4807,12 +4260,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/github",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
-        {
-          "definition": "A site/system/folder/repository where a team can share, collaborate, and save their open source or proprietary code.",
-          "source": "https://academy.binance.com/en/glossary/github"
-        }
-      ],
       "termSource": "https://academy.binance.com/en/glossary/github",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4826,7 +4273,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/gm-good-morning",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/gm-good-morning",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4840,7 +4286,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4854,7 +4299,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/golden-cross",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/golden-cross",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4868,7 +4312,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/golden-ratio",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/golden-ratio",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4882,7 +4325,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/goldilocks",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/goldilocks",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4896,7 +4338,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/gossip-protocol",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/gossip-protocol",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4910,7 +4351,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4924,7 +4364,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/gross-domestic-product-gdp",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/gross-domestic-product-gdp",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4938,7 +4377,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4952,12 +4390,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/gwei",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
-        {
-          "definition": "A small denomination of ether. It is widely used as a measure of gas prices. 1,000,000,000 wei = 1 Giga wei (Gwei)",
-          "source": "https://academy.binance.com/en/glossary/gwei"
-        }
-      ],
       "termSource": "https://academy.binance.com/en/glossary/gwei",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4971,7 +4403,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/hackathon",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/hackathon",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4985,7 +4416,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/hacker",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/hacker",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4999,7 +4429,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/haha-money-printer-go-brrrrr",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/haha-money-printer-go-brrrrr",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5013,12 +4442,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/halving",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
-        {
-          "definition": "Halving is a process that reduces the block reward of a PoW crypto like Bitcoin (BTC) to half. The next halving of Bitcoin is expected around 2024.",
-          "source": "https://academy.binance.com/en/glossary/halving"
-        }
-      ],
       "termSource": "https://academy.binance.com/en/glossary/halving",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5032,7 +4455,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/hard-cap",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/hard-cap",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5046,7 +4468,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5060,7 +4481,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/hard-landing",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/hard-landing",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5074,7 +4494,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5088,7 +4507,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5102,16 +4520,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/hash",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
-        {
-          "definition": "The output produced by a hash function after a piece of data is mapped. May also be referred to as hash value, hash code, or digest.",
-          "source": "https://academy.binance.com/en/glossary/hash"
-        },
-        {
-          "definition": "A digital fingerprint of a sequence of bytes.",
-          "source": "https://solana.com/docs/references/terminology#hash"
-        }
-      ],
       "termSource": "https://academy.binance.com/en/glossary/hash",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5125,7 +4533,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/hash-rate",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/hash-rate",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5139,7 +4546,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/hashed-timelock-contract",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/hashed-timelock-contract",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5153,7 +4559,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5167,7 +4572,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/herd-instinct",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/herd-instinct",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5181,7 +4585,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5195,7 +4598,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/high-frequency-trading-hft",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/high-frequency-trading-hft",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5209,7 +4611,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/hodl",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/hodl",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5223,7 +4624,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/honeypot",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/honeypot",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5237,7 +4637,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5251,7 +4650,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5265,7 +4663,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5279,7 +4676,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5293,7 +4689,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5307,7 +4702,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/iceberg-order",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/iceberg-order",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5321,7 +4715,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5335,7 +4728,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5349,12 +4741,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/immutability",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
-        {
-          "definition": "The inability to change or be changed. One of the core features behind Bitcoin and blockchain technology.",
-          "source": "https://academy.binance.com/en/glossary/immutability"
-        }
-      ],
       "termSource": "https://academy.binance.com/en/glossary/immutability",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5368,7 +4754,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/index-funds",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/index-funds",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5382,7 +4767,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5396,7 +4780,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/initial-coin-offering",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/initial-coin-offering",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5410,7 +4793,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/initial-dex-offering-ido",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/initial-dex-offering-ido",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5424,7 +4806,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/initial-exchange-offering",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/initial-exchange-offering",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5438,7 +4819,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/initial-public-offering",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/initial-public-offering",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5452,7 +4832,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/inscription",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/inscription",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5466,7 +4845,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5480,7 +4858,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/integrated-circuit",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/integrated-circuit",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5494,7 +4871,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/interest-rates",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/interest-rates",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5508,7 +4884,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5522,12 +4897,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/interoperability",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
-        {
-          "definition": "A concept of allowing blockchains to be compatible with each other and build upon each other's features and use-cases.",
-          "source": "https://academy.binance.com/en/glossary/interoperability"
-        }
-      ],
       "termSource": "https://academy.binance.com/en/glossary/interoperability",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5541,7 +4910,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5555,7 +4923,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/interplanetary-file-system-ipfs",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/interplanetary-file-system-ipfs",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5569,7 +4936,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/iou",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/iou",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5583,7 +4949,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5597,7 +4962,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5611,7 +4975,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5625,7 +4988,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/isolated-margin",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/isolated-margin",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5639,7 +5001,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/issuance",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/issuance",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5653,7 +5014,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5667,7 +5027,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5681,7 +5040,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/keccak",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/keccak",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5695,7 +5053,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5709,12 +5066,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/know-your-customer",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
-        {
-          "definition": "A standard procedure in the finance industry which allows companies to identify their customers and comply with KYC AML laws",
-          "source": "https://academy.binance.com/en/glossary/know-your-customer"
-        }
-      ],
       "termSource": "https://academy.binance.com/en/glossary/know-your-customer",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5728,7 +5079,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5742,7 +5092,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5756,7 +5105,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5770,7 +5118,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5784,7 +5131,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/laspeyres-index",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/laspeyres-index",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5798,12 +5144,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/latency",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
-        {
-          "definition": "The time between submitting a transaction to a network and the first confirmation of acceptance by the network.",
-          "source": "https://academy.binance.com/en/glossary/latency"
-        }
-      ],
       "termSource": "https://academy.binance.com/en/glossary/latency",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5817,7 +5157,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5831,7 +5170,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5845,7 +5183,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/law-of-demand",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/law-of-demand",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5859,7 +5196,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5873,7 +5209,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5887,12 +5222,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/layer-2",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
-        {
-          "definition": "A secondary framework or protocol that is built on top of an existing blockchain system to provide increased scalability.",
-          "source": "https://academy.binance.com/en/glossary/layer-2"
-        }
-      ],
       "termSource": "https://academy.binance.com/en/glossary/layer-2",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5906,12 +5235,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/ledger",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
-        {
-          "definition": "A list of entries containing transactions signed by clients. Conceptually, this can be traced back to the genesis block, but an actual validator's ledger may have only newer blocks to reduce storage, as older ones are not needed for validation of future blocks by design.",
-          "source": "https://solana.com/docs/references/terminology#ledger"
-        }
-      ],
       "termSource": "https://academy.binance.com/en/glossary/ledger",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5925,7 +5248,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5939,7 +5261,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5953,7 +5274,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/leveraged-tokens",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/leveraged-tokens",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5967,12 +5287,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/library",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
-        {
-          "definition": "A collection of stable resources, which may include executable files, documentation, message templates, and written code.",
-          "source": "https://academy.binance.com/en/glossary/library"
-        }
-      ],
       "termSource": "https://academy.binance.com/en/glossary/library",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5986,7 +5300,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6000,12 +5313,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
-        {
-          "definition": "A type of client that can verify it's pointing to a valid cluster. It performs more ledger verification than a thin client and less than a validator.",
-          "source": "https://solana.com/docs/references/terminology#light-client"
-        }
-      ],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6019,12 +5326,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/lightning-network",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
-        {
-          "definition": "A second layer operating on top of a blockchain, enabling increased transaction speed among participating nodes.",
-          "source": "https://academy.binance.com/en/glossary/lightning-network"
-        }
-      ],
       "termSource": "https://academy.binance.com/en/glossary/lightning-network",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6038,7 +5339,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/limit-order",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/limit-order",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6052,7 +5352,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6066,7 +5365,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/linux",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/linux",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6080,7 +5378,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6094,7 +5391,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/liquid-staking",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/liquid-staking",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6108,7 +5404,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/liquid-staking-token-lst",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/liquid-staking-token-lst",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6122,7 +5417,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6136,12 +5430,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/liquidity",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
-        {
-          "definition": "The ability to sell or buy any given asset without causing significant fluctuations in the market price for that asset.",
-          "source": "https://academy.binance.com/en/glossary/liquidity"
-        }
-      ],
       "termSource": "https://academy.binance.com/en/glossary/liquidity",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6155,7 +5443,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/liquidity-crisis",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/liquidity-crisis",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6169,7 +5456,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6183,7 +5469,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/liquidity-provider",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/liquidity-provider",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6197,7 +5482,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/liquidity-ratios",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/liquidity-ratios",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6211,7 +5495,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6225,7 +5508,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/listing",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/listing",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6239,12 +5521,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/mainnet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
-        {
-          "definition": "A blockchain protocol which is fully developed and deployed where transactions are being broadcasted, verified, and recorded.",
-          "source": "https://academy.binance.com/en/glossary/mainnet"
-        }
-      ],
       "termSource": "https://academy.binance.com/en/glossary/mainnet",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6258,7 +5534,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/mainnet-swap",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/mainnet-swap",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6272,7 +5547,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/maker",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/maker",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6286,7 +5560,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6300,12 +5573,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/malware",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
-        {
-          "definition": "Any software program or code that is created to infiltrate and intentionally cause damage to computer systems and networks.",
-          "source": "https://academy.binance.com/en/glossary/malware"
-        }
-      ],
       "termSource": "https://academy.binance.com/en/glossary/malware",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6319,7 +5586,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/margin-trading",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/margin-trading",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6333,7 +5599,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6347,7 +5612,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/market-capitalization",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/market-capitalization",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6361,7 +5625,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/market-momentum",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/market-momentum",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6375,7 +5638,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/market-order",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/market-order",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6389,7 +5651,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/masternode",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/masternode",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6403,7 +5664,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/matching-engine",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/matching-engine",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6417,7 +5677,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6431,7 +5690,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6445,7 +5703,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/maximum-supply",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/maximum-supply",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6459,7 +5716,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6473,12 +5729,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/mempool",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
-        {
-          "definition": "A node’s mechanism for keeping track of unconfirmed transactions that the node has seen (but have not yet been added to a block).",
-          "source": "https://academy.binance.com/en/glossary/mempool"
-        }
-      ],
       "termSource": "https://academy.binance.com/en/glossary/mempool",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6492,7 +5742,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6506,7 +5755,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6520,7 +5768,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/merged-mining",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/merged-mining",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6534,7 +5781,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6548,7 +5794,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/merkle-tree",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/merkle-tree",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6562,7 +5807,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6576,12 +5820,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/metadata",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
-        {
-          "definition": "Data that includes information about other data, such as information about features of a specific transaction.",
-          "source": "https://academy.binance.com/en/glossary/metadata"
-        }
-      ],
       "termSource": "https://academy.binance.com/en/glossary/metadata",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6595,7 +5833,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6609,7 +5846,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6623,7 +5859,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6637,7 +5872,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6651,7 +5885,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6665,12 +5898,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/metaverse",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
-        {
-          "definition": "The metaverse is a concept of a persistent, online, 3D virtual environment that many believe will be a key element of future digital experiences.",
-          "source": "https://academy.binance.com/en/glossary/metaverse"
-        }
-      ],
       "termSource": "https://academy.binance.com/en/glossary/metaverse",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6684,7 +5911,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6698,7 +5924,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6712,7 +5937,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/microtransactions",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/microtransactions",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6726,7 +5950,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6740,7 +5963,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6754,12 +5976,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/mining",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
-        {
-          "definition": "The verification of transactions on a blockchain network, in which transactions are added as entries into the blockchain ledger.",
-          "source": "https://academy.binance.com/en/glossary/mining"
-        }
-      ],
       "termSource": "https://academy.binance.com/en/glossary/mining",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6773,7 +5989,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/mining-farm",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/mining-farm",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6787,12 +6002,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/mint",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
-        {
-          "definition": "Minting adds fresh tokens into the crypto ecosystem, enabling them to be traded or used within its network. Minting is similar to mining, with some key differences.",
-          "source": "https://academy.binance.com/en/glossary/mint"
-        }
-      ],
       "termSource": "https://academy.binance.com/en/glossary/mint",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6806,7 +6015,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6820,7 +6028,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6834,7 +6041,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6848,7 +6054,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/monetary-policy",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/monetary-policy",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6862,7 +6067,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/money-markets",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/money-markets",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6876,7 +6080,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/monitoring-tag",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/monitoring-tag",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6890,7 +6093,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/moon",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/moon",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6904,7 +6106,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6918,7 +6119,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/moving-average-envelopes",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/moving-average-envelopes",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6932,7 +6132,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/moving-average-ribbon",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/moving-average-ribbon",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6946,7 +6145,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/mt-gox",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/mt-gox",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6960,7 +6158,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6974,7 +6171,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6988,7 +6184,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/multisignature",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/multisignature",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7002,7 +6197,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/nakamoto-consensus",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/nakamoto-consensus",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7016,7 +6210,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7030,7 +6223,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/net-asset-value-nav",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/net-asset-value-nav",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7044,7 +6236,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7058,7 +6249,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7072,7 +6262,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7086,7 +6275,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7100,7 +6288,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7114,7 +6301,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7128,7 +6314,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/nft-floor-prices",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/nft-floor-prices",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7142,7 +6327,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/nft-mystery-boxes",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/nft-mystery-boxes",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7156,7 +6340,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/ngmi",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/ngmi",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7170,7 +6353,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7184,16 +6366,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/node",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
-        {
-          "definition": "A participant on a blockchain network that communicates with other participants to ensure the security and integrity of the system.",
-          "source": "https://academy.binance.com/en/glossary/node"
-        },
-        {
-          "definition": "A computer participating in a cluster.",
-          "source": "https://solana.com/docs/references/terminology#node"
-        }
-      ],
       "termSource": "https://academy.binance.com/en/glossary/node",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7207,7 +6379,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7221,7 +6392,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/non-fungible-token-nft",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/non-fungible-token-nft",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7235,12 +6405,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/nonce",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
-        {
-          "definition": "A single-use arbitrary string or number generated for verification purposes to prevent replaying past transactions.",
-          "source": "https://academy.binance.com/en/glossary/nonce"
-        }
-      ],
       "termSource": "https://academy.binance.com/en/glossary/nonce",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7254,7 +6418,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/oco-order",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/oco-order",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7268,12 +6431,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/off-chain",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
-        {
-          "definition": "Discover how off-chain transactions in crypto enhance scalability and speed. Explore their use in Layer 2 solutions, reducing transaction costs.",
-          "source": "https://academy.binance.com/en/glossary/off-chain"
-        }
-      ],
       "termSource": "https://academy.binance.com/en/glossary/off-chain",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7287,7 +6444,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7301,7 +6457,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/offline-signing-orchestrator-oso",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/offline-signing-orchestrator-oso",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7315,7 +6470,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/offshore-account",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/offshore-account",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7329,7 +6483,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7343,12 +6496,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/on-chain",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
-        {
-          "definition": "On-chain refers to transactions and activities directly recorded on the blockchain, ensuring data transparency, security, and immutability.",
-          "source": "https://academy.binance.com/en/glossary/on-chain"
-        }
-      ],
       "termSource": "https://academy.binance.com/en/glossary/on-chain",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7362,7 +6509,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7376,7 +6522,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7390,7 +6535,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/opbnb",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/opbnb",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7404,7 +6548,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/open-source-software-oss",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/open-source-software-oss",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7418,7 +6561,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7432,7 +6574,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7446,7 +6587,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/opportunity-cost",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/opportunity-cost",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7460,7 +6600,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7474,7 +6613,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7488,12 +6626,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/oracle",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
-        {
-          "definition": "A data source or feed from a third party used for determining outcomes for smart contracts.",
-          "source": "https://academy.binance.com/en/glossary/oracle"
-        }
-      ],
       "termSource": "https://academy.binance.com/en/glossary/oracle",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7507,7 +6639,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/orc-20-tokens",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/orc-20-tokens",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7521,7 +6652,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/order-book",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/order-book",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7535,7 +6665,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/ordinals",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/ordinals",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7549,7 +6678,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/orphan-block",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/orphan-block",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7563,7 +6691,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7577,7 +6704,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7591,7 +6717,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/pancakeswap",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/pancakeswap",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7605,7 +6730,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/paper-wallet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/paper-wallet",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7619,7 +6743,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/parallelization",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/parallelization",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7633,7 +6756,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7647,7 +6769,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7661,7 +6782,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/passive-management",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/passive-management",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7675,7 +6795,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7689,7 +6808,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7703,7 +6821,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7717,7 +6834,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7731,7 +6847,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/peer-to-peer",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/peer-to-peer",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7745,7 +6860,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/pegged-currency",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/pegged-currency",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7759,7 +6873,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7773,7 +6886,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7787,7 +6899,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/permissionless-blockchain",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/permissionless-blockchain",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7801,12 +6912,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/phishing",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
-        {
-          "definition": "A malicious attack where a bad actor will attempt to obtain the credentials of a user in order to gain unauthorised access into their account.",
-          "source": "https://academy.binance.com/en/glossary/phishing"
-        }
-      ],
       "termSource": "https://academy.binance.com/en/glossary/phishing",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7820,7 +6925,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7834,12 +6938,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/plasma",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
-        {
-          "definition": "An Ethereum off-chain scaling solution which may allow Etherum to greatly increase the transactions per second capablities.",
-          "source": "https://academy.binance.com/en/glossary/plasma"
-        }
-      ],
       "termSource": "https://academy.binance.com/en/glossary/plasma",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7853,7 +6951,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7867,7 +6964,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/polkadot-crowdloan",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/polkadot-crowdloan",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7881,7 +6977,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7895,7 +6990,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/ponzi-scheme",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/ponzi-scheme",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7909,7 +7003,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7923,7 +7016,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7937,7 +7029,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7951,7 +7042,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/premining",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/premining",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7965,7 +7055,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/price-action",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/price-action",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7979,7 +7068,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7993,7 +7081,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/prisoners-dilemma",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/prisoners-dilemma",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8007,7 +7094,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8021,7 +7107,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8035,16 +7120,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/private-key",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
-        {
-          "definition": "In the context of cryptocurrency, a private key is a number that allows users to sign transactions and to generate receiving addresses.",
-          "source": "https://academy.binance.com/en/glossary/private-key"
-        },
-        {
-          "definition": "The private key of a keypair.",
-          "source": "https://solana.com/docs/references/terminology#private-key"
-        }
-      ],
       "termSource": "https://academy.binance.com/en/glossary/private-key",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8058,7 +7133,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/private-sale",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/private-sale",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8072,7 +7146,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/progressive-web-application",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/progressive-web-application",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8086,7 +7159,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/proof-of-attendance-protocol-poap",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/proof-of-attendance-protocol-poap",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8100,7 +7172,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/proof-of-reserves-por",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/proof-of-reserves-por",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8114,12 +7185,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/proof-of-stake",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
-        {
-          "definition": "A consensus mechanism that reward block validators according to the amount of coins they have at stake.",
-          "source": "https://academy.binance.com/en/glossary/proof-of-stake"
-        }
-      ],
       "termSource": "https://academy.binance.com/en/glossary/proof-of-stake",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8133,7 +7198,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/proof-of-staked-authority-posa",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/proof-of-staked-authority-posa",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8147,12 +7211,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/proof-of-work",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
-        {
-          "definition": "Proof of Work is a crypto consensus mechanism where miners use special equipment to solve cryptographic puzzles to validate transactions and create new blocks.",
-          "source": "https://academy.binance.com/en/glossary/proof-of-work"
-        }
-      ],
       "termSource": "https://academy.binance.com/en/glossary/proof-of-work",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8166,7 +7224,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/proposer-builder-separation-pbs",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/proposer-builder-separation-pbs",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8180,7 +7237,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/proto-danksharding",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/proto-danksharding",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8194,7 +7250,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8208,7 +7263,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/pseudorandom",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/pseudorandom",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8222,7 +7276,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8236,7 +7289,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8250,16 +7302,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/public-key",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
-        {
-          "definition": "A public key is one-half of a key pair used to encrypt messages or verify digital signatures. In the crypto space, it essentially works as your wallet address.",
-          "source": "https://academy.binance.com/en/glossary/public-key"
-        },
-        {
-          "definition": "The public key of a keypair.",
-          "source": "https://solana.com/docs/references/terminology#public-key-pubkey"
-        }
-      ],
       "termSource": "https://academy.binance.com/en/glossary/public-key",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8273,7 +7315,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8287,7 +7328,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/pump-and-dump",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/pump-and-dump",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8301,7 +7341,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8315,7 +7354,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/quantitative-easing-qe",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/quantitative-easing-qe",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8329,7 +7367,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/quantitative-tightening-qt",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/quantitative-tightening-qt",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8343,7 +7380,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/quantum-computing",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/quantum-computing",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8357,7 +7393,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8371,7 +7406,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/race-attack",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/race-attack",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8385,7 +7419,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/ransomware",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/ransomware",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8399,7 +7432,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8413,7 +7445,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/real-world-assets-rwas",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/real-world-assets-rwas",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8427,7 +7458,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/recession",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/recession",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8441,7 +7471,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/recursive-inscription",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/recursive-inscription",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8455,7 +7484,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/rekt",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/rekt",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8469,7 +7497,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/relative-strength-index",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/relative-strength-index",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8483,7 +7510,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8497,7 +7523,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8511,7 +7536,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/resistance",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/resistance",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8525,7 +7549,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/return-on-investment",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/return-on-investment",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8539,7 +7562,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/revenge-trading",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/revenge-trading",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8553,7 +7575,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8567,7 +7588,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/risk-premium",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/risk-premium",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8581,12 +7601,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/roadmap",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
-        {
-          "definition": "A business planning technique which lays out the short and long term goals of a company within a flexible estimated timeline.",
-          "source": "https://academy.binance.com/en/glossary/roadmap"
-        }
-      ],
       "termSource": "https://academy.binance.com/en/glossary/roadmap",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8600,7 +7614,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8614,7 +7627,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8628,7 +7640,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8642,7 +7653,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/routing-attack",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/routing-attack",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8656,7 +7666,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8670,12 +7679,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/rug-pull",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
-        {
-          "definition": "A rug pull in the crypto industry is when a development team suddenly abandons a project and sells or removes all its liquidity.",
-          "source": "https://academy.binance.com/en/glossary/rug-pull"
-        }
-      ],
       "termSource": "https://academy.binance.com/en/glossary/rug-pull",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8689,7 +7692,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8703,7 +7705,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/sahm-rule",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/sahm-rule",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8717,7 +7718,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8731,7 +7731,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8745,7 +7744,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/sandwich-trading",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/sandwich-trading",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8759,7 +7757,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8773,7 +7770,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/satoshi",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/satoshi",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8787,12 +7783,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/satoshi-nakamoto",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
-        {
-          "definition": "Satoshi Nakamoto was the pseudonym of the creator or creators of the bitcoin protocol and whitepaper.",
-          "source": "https://academy.binance.com/en/glossary/satoshi-nakamoto"
-        }
-      ],
       "termSource": "https://academy.binance.com/en/glossary/satoshi-nakamoto",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8806,7 +7796,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8820,7 +7809,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8834,7 +7822,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8848,7 +7835,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8862,7 +7848,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8876,7 +7861,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8890,7 +7874,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8904,7 +7887,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/secure-asset-fund-for-users",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/secure-asset-fund-for-users",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8918,7 +7900,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/securities-and-exchange-commission",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/securities-and-exchange-commission",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8932,7 +7913,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/security-audit",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/security-audit",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8946,7 +7926,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8960,7 +7939,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8974,7 +7952,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/security-token-offering-sto",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/security-token-offering-sto",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8988,12 +7965,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/seed-phrase",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
-        {
-          "definition": "A seed phrase or menmonic seed is a collection of words that can be used to access your cryptocurrency wallet.",
-          "source": "https://academy.binance.com/en/glossary/seed-phrase"
-        }
-      ],
       "termSource": "https://academy.binance.com/en/glossary/seed-phrase",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9007,7 +7978,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/seed-tag",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/seed-tag",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9021,7 +7991,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/segregated-witness",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/segregated-witness",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9035,7 +8004,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9049,7 +8017,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9063,7 +8030,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/selfish-mining",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/selfish-mining",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9077,7 +8043,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/sell-wall",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/sell-wall",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9091,7 +8056,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/sentiment",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/sentiment",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9105,7 +8069,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9119,7 +8082,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9133,7 +8095,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9147,7 +8108,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9161,12 +8121,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/sharding",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
-        {
-          "definition": "Sharding is a method of splitting blockchains ( or other types of databases) into smaller, partitioned blockchains that manage specific data segments.",
-          "source": "https://academy.binance.com/en/glossary/sharding"
-        }
-      ],
       "termSource": "https://academy.binance.com/en/glossary/sharding",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9180,7 +8134,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/sharpe-ratio",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/sharpe-ratio",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9194,7 +8147,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9208,7 +8160,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9222,7 +8173,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/sidechains",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/sidechains",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9236,12 +8186,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
-        {
-          "definition": "A 64-byte ed25519 signature of R (32-bytes) and S (32-bytes). With the requirement that R is a packed Edwards point not of small order and S is a scalar in the range of 0 <= S < L. This requirement ensures no signature malleability. Each transaction must have at least one signature for fee account. Thus, the first signature in transaction can be treated as transaction id",
-          "source": "https://solana.com/docs/references/terminology#signature"
-        }
-      ],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9255,7 +8199,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/simple-moving-average-sma",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/simple-moving-average-sma",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9269,7 +8212,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/slashing",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/slashing",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9283,7 +8225,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9297,12 +8238,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/slippage",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
-        {
-          "definition": "Slippage occurs when a trade settles at a different price than originally requested or expected, usually in low-liquidity markets and when using market orders.",
-          "source": "https://academy.binance.com/en/glossary/slippage"
-        }
-      ],
       "termSource": "https://academy.binance.com/en/glossary/slippage",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9316,12 +8251,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
-        {
-          "definition": "The period of time for which each leader ingests transactions and produces a block. Collectively, slots create a logical clock. Slots are ordered sequentially and non-overlapping, comprising roughly equal real-world time as per PoH.",
-          "source": "https://solana.com/docs/references/terminology#slot"
-        }
-      ],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9335,16 +8264,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/smart-contract",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
-        {
-          "definition": "Smart contracts are self-executing contracts that exist on certain blockchain networks. Their conditions and terms are written directly into lines of code.",
-          "source": "https://academy.binance.com/en/glossary/smart-contract"
-        },
-        {
-          "definition": "See onchain program.",
-          "source": "https://solana.com/docs/references/terminology#smart-contract"
-        }
-      ],
       "termSource": "https://academy.binance.com/en/glossary/smart-contract",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9358,7 +8277,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/smart-contract-wallet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/smart-contract-wallet",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9372,7 +8290,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/snapshot",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/snapshot",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9386,7 +8303,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/social-recovery-wallet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/social-recovery-wallet",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9400,7 +8316,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/social-trading",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/social-trading",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9414,7 +8329,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/socialfi",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/socialfi",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9428,7 +8342,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9442,7 +8355,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/soft-landing",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/soft-landing",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9456,12 +8368,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/solidity",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
-        {
-          "definition": "Solidity is a programming language created in 2014 that was specifically designed to write and implement smart contracts on the Ethereum blockchain.",
-          "source": "https://academy.binance.com/en/glossary/solidity"
-        }
-      ],
       "termSource": "https://academy.binance.com/en/glossary/solidity",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9475,7 +8381,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/source-code",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/source-code",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9489,7 +8394,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/spl",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/spl",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9503,7 +8407,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/src-20-tokens",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/src-20-tokens",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9517,12 +8420,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/stablecoin",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
-        {
-          "definition": "A type of cryptocurrency that is designed to maintain a stable value, rather than experiencing significant price changes.",
-          "source": "https://academy.binance.com/en/glossary/stablecoin"
-        }
-      ],
       "termSource": "https://academy.binance.com/en/glossary/stablecoin",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9536,7 +8433,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/stagflation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/stagflation",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9550,12 +8446,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
-        {
-          "definition": "Tokens forfeit to the cluster if malicious validator behavior can be proven.",
-          "source": "https://solana.com/docs/references/terminology#stake"
-        }
-      ],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9569,7 +8459,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9583,7 +8472,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/staking-pool",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/staking-pool",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9597,7 +8485,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9611,7 +8498,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/state-channel",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/state-channel",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9625,7 +8511,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9639,7 +8524,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/steth",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/steth",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9653,7 +8537,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9667,7 +8550,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/stock-variable",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/stock-variable",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9681,7 +8563,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/store-of-value",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/store-of-value",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9695,7 +8576,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9709,7 +8589,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/supercomputer",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/supercomputer",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9723,7 +8602,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/supply-chain",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/supply-chain",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9737,7 +8615,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/support",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/support",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9751,7 +8628,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9765,7 +8641,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/sybil-attack",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/sybil-attack",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9779,7 +8654,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9793,7 +8667,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/taker",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/taker",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9807,7 +8680,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/tank",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/tank",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9821,7 +8693,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9835,7 +8706,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9849,12 +8719,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/testnet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
-        {
-          "definition": "Testnets are replicas of the mainnet, offering risk-free, secure environments for exploring and testing blockchain features.",
-          "source": "https://academy.binance.com/en/glossary/testnet"
-        }
-      ],
       "termSource": "https://academy.binance.com/en/glossary/testnet",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9868,7 +8732,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9882,7 +8745,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9896,7 +8758,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9910,7 +8771,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/ticker",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/ticker",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9924,7 +8784,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/ticker-symbol",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/ticker-symbol",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9938,16 +8797,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/token",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
-        {
-          "definition": "Tokens (not to be confused with coins) are digital units issued on a blockchain. They can hold value or be redeemed for assets.",
-          "source": "https://academy.binance.com/en/glossary/token"
-        },
-        {
-          "definition": "A digitally transferable asset.",
-          "source": "https://solana.com/docs/references/terminology#token"
-        }
-      ],
       "termSource": "https://academy.binance.com/en/glossary/token",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9961,7 +8810,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/token-generation-event-tge",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/token-generation-event-tge",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9975,12 +8823,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/token-lockup",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
-        {
-          "definition": "Token lockup or vesting period refers to the time span in which tokens or coins are not allowed to be transferred or traded.",
-          "source": "https://academy.binance.com/en/glossary/token-lockup"
-        }
-      ],
       "termSource": "https://academy.binance.com/en/glossary/token-lockup",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9994,7 +8836,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/token-merge",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/token-merge",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -10008,7 +8849,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/token-sale",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/token-sale",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -10022,7 +8862,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10036,7 +8875,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/token-standards",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/token-standards",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -10050,7 +8888,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/tokenization",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/tokenization",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -10064,7 +8901,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/tokenomics",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/tokenomics",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -10078,7 +8914,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/total-supply",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/total-supply",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -10092,7 +8927,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/total-value-locked-tvl",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/total-value-locked-tvl",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -10106,7 +8940,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/tradfi",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/tradfi",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -10120,12 +8953,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
-        {
-          "definition": "One or more instructions signed by a client using one or more keypairs and executed atomically with only two possible outcomes: success or failure.",
-          "source": "https://solana.com/docs/references/terminology#transaction"
-        }
-      ],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10139,7 +8966,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10153,7 +8979,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10167,16 +8992,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/transaction-id",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
-        {
-          "definition": "A transaction ID (TXID) is a unique string of characters that labels each transaction on the blockchain.",
-          "source": "https://academy.binance.com/en/glossary/transaction-id"
-        },
-        {
-          "definition": "The first signature in a transaction, which can be used to uniquely identify the transaction across the complete ledger.",
-          "source": "https://solana.com/docs/references/terminology#transaction-id"
-        }
-      ],
       "termSource": "https://academy.binance.com/en/glossary/transaction-id",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -10190,7 +9005,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10204,7 +9018,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/transactions-per-second-tps",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/transactions-per-second-tps",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -10218,7 +9031,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10232,7 +9044,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/treasury-bills-t-bills",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/treasury-bills-t-bills",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -10246,7 +9057,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10260,7 +9070,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/trueusd-tusd",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/trueusd-tusd",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -10274,7 +9083,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10288,12 +9096,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/trustless",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
-        {
-          "definition": "No single entity has authority over the system and consensus is achieved between participants who do not have to trust each other.",
-          "source": "https://academy.binance.com/en/glossary/trustless"
-        }
-      ],
       "termSource": "https://academy.binance.com/en/glossary/trustless",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -10307,12 +9109,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/turing-complete",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
-        {
-          "definition": "A machine that, given enough time and memory along with the necessary instructions, can solve any computational problem.",
-          "source": "https://academy.binance.com/en/glossary/turing-complete"
-        }
-      ],
       "termSource": "https://academy.binance.com/en/glossary/turing-complete",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -10326,7 +9122,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10340,7 +9135,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10354,7 +9148,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10368,7 +9161,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/understanding-cz-s-number-4",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/understanding-cz-s-number-4",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -10382,7 +9174,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10396,7 +9187,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10410,7 +9200,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/unit-of-account",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/unit-of-account",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -10424,7 +9213,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10438,7 +9226,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/unspent-transaction-output-utxo",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/unspent-transaction-output-utxo",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -10452,7 +9239,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10466,7 +9252,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10480,7 +9265,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10494,7 +9278,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10508,7 +9291,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/user-interface",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/user-interface",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -10522,7 +9304,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/utility-token",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/utility-token",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -10536,7 +9317,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10550,12 +9330,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
-        {
-          "definition": "A full participant in a Solana network cluster that produces new blocks. A validator validates the transactions added to the ledger",
-          "source": "https://solana.com/docs/references/terminology#validator"
-        }
-      ],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10569,7 +9343,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10583,7 +9356,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10597,7 +9369,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/verification-code",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/verification-code",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -10611,7 +9382,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10625,7 +9395,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10639,7 +9408,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/virtual-machine",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/virtual-machine",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -10653,7 +9421,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/vladimir-club",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/vladimir-club",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -10667,7 +9434,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/volatility",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/volatility",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -10681,7 +9447,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/volume",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/volume",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -10695,7 +9460,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/wagmi",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/wagmi",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -10709,16 +9473,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/wallet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
-        {
-          "definition": "Used to send and receive cryptocurrencies. Different types include software wallets, hardware wallets, and paper wallets.",
-          "source": "https://academy.binance.com/en/glossary/wallet"
-        },
-        {
-          "definition": "A collection of keypairs that allows users to manage their funds.",
-          "source": "https://solana.com/docs/references/terminology#wallet"
-        }
-      ],
       "termSource": "https://academy.binance.com/en/glossary/wallet",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -10732,7 +9486,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10746,7 +9499,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10760,7 +9512,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/wash-trading",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/wash-trading",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -10774,7 +9525,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/weak-hands",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/weak-hands",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -10788,7 +9538,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/weak-subjectivity",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/weak-subjectivity",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -10802,7 +9551,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/web-1",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/web-1",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -10816,7 +9564,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10830,7 +9577,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10844,7 +9590,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10858,7 +9603,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10872,7 +9616,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10886,12 +9629,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/wei",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
-        {
-          "definition": "The smallest possible denomination of ether (ETH), the currency used on the Ethereum network. Often used when referring to gas prices.",
-          "source": "https://academy.binance.com/en/glossary/wei"
-        }
-      ],
       "termSource": "https://academy.binance.com/en/glossary/wei",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -10905,7 +9642,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/weighted-moving-average-wma",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/weighted-moving-average-wma",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -10919,7 +9655,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/whale",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/whale",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -10933,7 +9668,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/whiskers",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/whiskers",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -10947,7 +9681,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/whitelist",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/whitelist",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -10961,7 +9694,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10975,7 +9707,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/wick",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/wick",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -10989,7 +9720,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/win-rate",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/win-rate",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -11003,7 +9733,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/wrapped-ether",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/wrapped-ether",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -11017,7 +9746,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -11031,7 +9759,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/wyckoff",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/wyckoff",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -11045,7 +9772,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -11059,7 +9785,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -11073,7 +9798,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -11087,7 +9811,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -11101,12 +9824,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/yield-farming",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
-        {
-          "definition": "Yield farming is a high-risk practice in DeFi where investors lock up assets to provide liquidity, lend or stake in return for rewards or interest.",
-          "source": "https://academy.binance.com/en/glossary/yield-farming"
-        }
-      ],
       "termSource": "https://academy.binance.com/en/glossary/yield-farming",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -11120,7 +9837,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -11134,7 +9850,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -11148,7 +9863,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/zero-knowledge-proofs",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/zero-knowledge-proofs",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -11162,7 +9876,6 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -11176,7 +9889,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/zk-rollup",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/zk-rollup",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -11190,12 +9902,6 @@
       "definitionSource": "https://academy.binance.com/en/glossary/zk-snarks",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
-        {
-          "definition": "“Zero-Knowledge Succinct Non-Interactive Argument of Knowledge” - an approach to zero-knowledge proofs.",
-          "source": "https://academy.binance.com/en/glossary/zk-snarks"
-        }
-      ],
       "termSource": "https://academy.binance.com/en/glossary/zk-snarks",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -11209,1045 +9915,8 @@
       "definitionSource": "https://academy.binance.com/en/glossary/zk-starks",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/zk-starks",
       "dateFirstRecorded": "2025-01-31",
-      "commentary": ""
-    },
-    "account-owner": {
-      "term": "account owner",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "The address of the program that owns the account. Only the owning program is capable of modifying the account. See also authority.",
-      "definitionSource": "https://solana.com/docs/references/terminology#account-owner",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "Solana Glossary",
-      "dateFirstRecorded": "2025-02-14",
-      "commentary": ""
-    },
-    "app": {
-      "term": "app",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "A front-end application that interacts with a Solana cluster.",
-      "definitionSource": "https://solana.com/docs/references/terminology#app",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "Solana Glossary",
-      "dateFirstRecorded": "2025-02-14",
-      "commentary": ""
-    },
-    "authority": {
-      "term": "authority",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "The address of a user that has some kind of permission over an account. For example: - The ability to mint new tokens is given to the account that is the 'mint authority' for the token mint. - The ability to upgrade a program is given to the account that is the 'upgrade authority' of a program.",
-      "definitionSource": "https://solana.com/docs/references/terminology#authority",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "Solana Glossary",
-      "dateFirstRecorded": "2025-02-14",
-      "commentary": ""
-    },
-    "bank-state": {
-      "term": "bank state",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "The result of interpreting all programs on the ledger at a given tick height. It includes at least the set of all accounts holding nonzero native tokens.",
-      "definitionSource": "https://solana.com/docs/references/terminology#bank-state",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "Solana Glossary",
-      "dateFirstRecorded": "2025-02-14",
-      "commentary": ""
-    },
-    "blockhash": {
-      "term": "blockhash",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "A unique value (hash) that identifies a record (block). Solana computes a blockhash from the last entry id of the block.",
-      "definitionSource": "https://solana.com/docs/references/terminology#blockhash",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "Solana Glossary",
-      "dateFirstRecorded": "2025-02-14",
-      "commentary": ""
-    },
-    "bootstrap-validator": {
-      "term": "bootstrap validator",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "The validator that produces the genesis (first) block of a block chain.",
-      "definitionSource": "https://solana.com/docs/references/terminology#bootstrap-validator",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "Solana Glossary",
-      "dateFirstRecorded": "2025-02-14",
-      "commentary": ""
-    },
-    "BPF-loader": {
-      "term": "BPF loader",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "The Solana program that owns and loads BPF onchain programs, allowing the program to interface with the runtime.",
-      "definitionSource": "https://solana.com/docs/references/terminology#bpf-loader",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "Solana Glossary",
-      "dateFirstRecorded": "2025-02-14",
-      "commentary": ""
-    },
-    "commitment": {
-      "term": "commitment",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "A measure of the network confirmation for the block.",
-      "definitionSource": "https://solana.com/docs/references/terminology#commitment",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "Solana Glossary",
-      "dateFirstRecorded": "2025-02-14",
-      "commentary": ""
-    },
-    "cluster": {
-      "term": "cluster",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "A set of validators maintaining a single ledger.",
-      "definitionSource": "https://solana.com/docs/references/terminology#cluster",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "Solana Glossary",
-      "dateFirstRecorded": "2025-02-14",
-      "commentary": ""
-    },
-    "compute-budget": {
-      "term": "compute budget",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "The maximum number of compute units consumed per transaction.",
-      "definitionSource": "https://solana.com/docs/references/terminology#compute-budget",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "Solana Glossary",
-      "dateFirstRecorded": "2025-02-14",
-      "commentary": ""
-    },
-    "compute-units": {
-      "term": "compute units",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "The smallest unit of measure for consumption of computational resources of the blockchain.",
-      "definitionSource": "https://solana.com/docs/references/terminology#compute-units",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "Solana Glossary",
-      "dateFirstRecorded": "2025-02-14",
-      "commentary": ""
-    },
-    "confirmed-block": {
-      "term": "confirmed block",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "A block that has received a super majority of ledger votes.",
-      "definitionSource": "https://solana.com/docs/references/terminology#confirmed-block",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "Solana Glossary",
-      "dateFirstRecorded": "2025-02-14",
-      "commentary": ""
-    },
-    "control-plane": {
-      "term": "control plane",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "A gossip network connecting all nodes of a cluster.",
-      "definitionSource": "https://solana.com/docs/references/terminology#control-plane",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "Solana Glossary",
-      "dateFirstRecorded": "2025-02-14",
-      "commentary": ""
-    },
-    "cooldown-period": {
-      "term": "cooldown period",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "Some number of epochs after stake has been deactivated while it progressively becomes available for withdrawal. During this period, the stake is considered to be \"deactivating\". More info about: warmup and cooldown",
-      "definitionSource": "https://solana.com/docs/references/terminology#cooldown-period",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "Solana Glossary",
-      "dateFirstRecorded": "2025-02-14",
-      "commentary": ""
-    },
-    "credit": {
-      "term": "credit",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "See vote credit.",
-      "definitionSource": "https://solana.com/docs/references/terminology#credit",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "Solana Glossary",
-      "dateFirstRecorded": "2025-02-14",
-      "commentary": ""
-    },
-    "cross-program-invocation-CPI": {
-      "term": "cross-program invocation (CPI)",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "A call from one onchain program to another. For more information, see calling between programs.",
-      "definitionSource": "https://solana.com/docs/references/terminology#cross-program-invocation-cpi",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "Solana Glossary",
-      "dateFirstRecorded": "2025-02-14",
-      "commentary": ""
-    },
-    "data-plane": {
-      "term": "data plane",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "A multicast network used to efficiently validate entries and gain consensus.",
-      "definitionSource": "https://solana.com/docs/references/terminology#data-plane",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "Solana Glossary",
-      "dateFirstRecorded": "2025-02-14",
-      "commentary": ""
-    },
-    "drone": {
-      "term": "drone",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "An offchain service that acts as a custodian for a user's private key. It typically serves to validate and sign transactions.",
-      "definitionSource": "https://solana.com/docs/references/terminology#drone",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "Solana Glossary",
-      "dateFirstRecorded": "2025-02-14",
-      "commentary": ""
-    },
-    "entry": {
-      "term": "entry",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "An entry on the ledger either a tick or a transaction's entry.",
-      "definitionSource": "https://solana.com/docs/references/terminology#entry",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "Solana Glossary",
-      "dateFirstRecorded": "2025-02-14",
-      "commentary": ""
-    },
-    "entry-id": {
-      "term": "entry id",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "A preimage resistant hash over the final contents of an entry, which acts as the entry's globally unique identifier. The hash serves as evidence of: - The entry being generated after a duration of time - The specified transactions are those included in the entry - The entry's position with respect to other entries in ledger See proof of history.",
-      "definitionSource": "https://solana.com/docs/references/terminology#entry-id",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "Solana Glossary",
-      "dateFirstRecorded": "2025-02-14",
-      "commentary": ""
-    },
-    "fee-account": {
-      "term": "fee account",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "The fee account in the transaction is the account that pays for the cost of including the transaction in the ledger. This is the first account in the transaction. This account must be declared as Read-Write (writable) in the transaction since paying for the transaction reduces the account balance.",
-      "definitionSource": "https://solana.com/docs/references/terminology#fee-account",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "Solana Glossary",
-      "dateFirstRecorded": "2025-02-14",
-      "commentary": ""
-    },
-    "genesis-config": {
-      "term": "genesis config",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "The configuration file that prepares the ledger for the genesis block.",
-      "definitionSource": "https://solana.com/docs/references/terminology#genesis-config",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "Solana Glossary",
-      "dateFirstRecorded": "2025-02-14",
-      "commentary": ""
-    },
-    "inflation": {
-      "term": "inflation",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "An increase in token supply over time used to fund rewards for validation and to fund continued development of Solana.",
-      "definitionSource": "https://solana.com/docs/references/terminology#inflation",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "Solana Glossary",
-      "dateFirstRecorded": "2025-02-14",
-      "commentary": ""
-    },
-    "inner-instruction": {
-      "term": "inner instruction",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "See cross-program invocation.",
-      "definitionSource": "https://solana.com/docs/references/terminology#inner-instruction",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "Solana Glossary",
-      "dateFirstRecorded": "2025-02-14",
-      "commentary": ""
-    },
-    "instruction": {
-      "term": "instruction",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "A call to invoke a specific instruction handler in a program. An instruction also specifies which accounts it wants to read or modify, and additional data that serves as auxiliary input to the instruction handler. A client must include at least one instruction in a transaction, and all instructions must complete for the transaction to be considered successful.",
-      "definitionSource": "https://solana.com/docs/references/terminology#instruction",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "Solana Glossary",
-      "dateFirstRecorded": "2025-02-14",
-      "commentary": ""
-    },
-    "instruction-handler": {
-      "term": "instruction handler",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "Instruction handlers are program functions that process instructions from transactions. An instruction handler may contain one or more cross-program invocations.",
-      "definitionSource": "https://solana.com/docs/references/terminology#instruction-handler",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "Solana Glossary",
-      "dateFirstRecorded": "2025-02-14",
-      "commentary": ""
-    },
-    "keypair": {
-      "term": "keypair",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "A public key and corresponding private key for accessing an account.",
-      "definitionSource": "https://solana.com/docs/references/terminology#keypair",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "Solana Glossary",
-      "dateFirstRecorded": "2025-02-14",
-      "commentary": ""
-    },
-    "lamport": {
-      "term": "lamport",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "A fractional native token with the value of 0.000000001 sol.",
-      "definitionSource": "https://solana.com/docs/references/terminology#lamport",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "Solana Glossary",
-      "dateFirstRecorded": "2025-02-14",
-      "commentary": ""
-    },
-    "leader": {
-      "term": "leader",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "The role of a validator when it is appending entries to the ledger.",
-      "definitionSource": "https://solana.com/docs/references/terminology#leader",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "Solana Glossary",
-      "dateFirstRecorded": "2025-02-14",
-      "commentary": ""
-    },
-    "leader-schedule": {
-      "term": "leader schedule",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "A sequence of validator public keys mapped to slots. The cluster uses the leader schedule to determine which validator is the leader at any moment in time.",
-      "definitionSource": "https://solana.com/docs/references/terminology#leader-schedule",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "Solana Glossary",
-      "dateFirstRecorded": "2025-02-14",
-      "commentary": ""
-    },
-    "ledger-vote": {
-      "term": "ledger vote",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "A hash of the validator's state at a given tick height. It comprises a validator's affirmation that a block it has received has been verified, as well as a promise not to vote for a conflicting block (i.e. fork) for a specific amount of time, the lockout period.",
-      "definitionSource": "https://solana.com/docs/references/terminology#ledger-vote",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "Solana Glossary",
-      "dateFirstRecorded": "2025-02-14",
-      "commentary": ""
-    },
-    "loader": {
-      "term": "loader",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "A program with the ability to interpret the binary encoding of other onchain programs.",
-      "definitionSource": "https://solana.com/docs/references/terminology#loader",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "Solana Glossary",
-      "dateFirstRecorded": "2025-02-14",
-      "commentary": ""
-    },
-    "lockout": {
-      "term": "lockout",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "The duration of time for which a validator is unable to vote on another fork.",
-      "definitionSource": "https://solana.com/docs/references/terminology#lockout",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "Solana Glossary",
-      "dateFirstRecorded": "2025-02-14",
-      "commentary": ""
-    },
-    "message": {
-      "term": "message",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "The structured contents of a transaction. Generally containing a header, array of account addresses, recent blockhash, and an array of instructions. Learn more about the message formatting inside of transactions here.",
-      "definitionSource": "https://solana.com/docs/references/terminology#message",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "Solana Glossary",
-      "dateFirstRecorded": "2025-02-14",
-      "commentary": ""
-    },
-    "Nakamoto-coefficient": {
-      "term": "Nakamoto coefficient",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "A measure of decentralization, the Nakamoto Coefficient is the smallest number of independent entities that can act collectively to shut down a blockchain. The term was coined by Balaji S. Srinivasan and Leland Lee in Quantifying Decentralization.",
-      "definitionSource": "https://solana.com/docs/references/terminology#nakamoto-coefficient",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "Solana Glossary",
-      "dateFirstRecorded": "2025-02-14",
-      "commentary": ""
-    },
-    "native-token": {
-      "term": "native token",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "The token used to track work done by nodes in a cluster.",
-      "definitionSource": "https://solana.com/docs/references/terminology#native-token",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "Solana Glossary",
-      "dateFirstRecorded": "2025-02-14",
-      "commentary": ""
-    },
-    "node-count": {
-      "term": "node count",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "The number of validators participating in a cluster.",
-      "definitionSource": "https://solana.com/docs/references/terminology#node-count",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "Solana Glossary",
-      "dateFirstRecorded": "2025-02-14",
-      "commentary": ""
-    },
-    "onchain-program": {
-      "term": "onchain program",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "The executable code on Solana blockchain that interprets the instructions sent inside of each transaction to read and modify accounts over which it has control. These programs are often referred to as \"smart contracts\" on other blockchains.",
-      "definitionSource": "https://solana.com/docs/references/terminology#onchain-program",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "Solana Glossary",
-      "dateFirstRecorded": "2025-02-14",
-      "commentary": ""
-    },
-    "PoH": {
-      "term": "PoH",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "See Proof of History.",
-      "definitionSource": "https://solana.com/docs/references/terminology#poh",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "Solana Glossary",
-      "dateFirstRecorded": "2025-02-14",
-      "commentary": ""
-    },
-    "point": {
-      "term": "point",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "A weighted credit in a rewards regime. In the validator rewards regime, the number of points owed to a stake during redemption is the product of the vote credits earned and the number of lamports staked.",
-      "definitionSource": "https://solana.com/docs/references/terminology#point",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "Solana Glossary",
-      "dateFirstRecorded": "2025-02-14",
-      "commentary": ""
-    },
-    "program": {
-      "term": "program",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "See onchain program.",
-      "definitionSource": "https://solana.com/docs/references/terminology#program",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "Solana Glossary",
-      "dateFirstRecorded": "2025-02-14",
-      "commentary": ""
-    },
-    "program-derived-account-PDA": {
-      "term": "program derived account (PDA)",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "An account whose signing authority is a program and thus is not controlled by a private key like other accounts.",
-      "definitionSource": "https://solana.com/docs/references/terminology#program-derived-account-pda",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "Solana Glossary",
-      "dateFirstRecorded": "2025-02-14",
-      "commentary": ""
-    },
-    "program-id": {
-      "term": "program id",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "The public key of the account containing a program.",
-      "definitionSource": "https://solana.com/docs/references/terminology#program-id",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "Solana Glossary",
-      "dateFirstRecorded": "2025-02-14",
-      "commentary": ""
-    },
-    "proof-of-history-PoH": {
-      "term": "proof of history (PoH)",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "A stack of proofs, each of which proves that some data existed before the proof was created and that a precise duration of time passed before the previous proof. Like a VDF, a Proof of History can be verified in less time than it took to produce.",
-      "definitionSource": "https://solana.com/docs/references/terminology#proof-of-history-poh",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "Solana Glossary",
-      "dateFirstRecorded": "2025-02-14",
-      "commentary": ""
-    },
-    "prioritization-fee": {
-      "term": "prioritization fee",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "An additional fee user can specify in the compute budget instruction to prioritize their transactions. The prioritization fee is calculated by multiplying the requested maximum compute units by the compute-unit price (specified in increments of 0.000001 lamports per compute unit) rounded up to the nearest lamport. Transactions should request the minimum amount of compute units required for execution to minimize fees.",
-      "definitionSource": "https://solana.com/docs/references/terminology#prioritization-fee",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "Solana Glossary",
-      "dateFirstRecorded": "2025-02-14",
-      "commentary": ""
-    },
-    "rent": {
-      "term": "rent",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "Fee paid by Accounts and Programs to store data on the blockchain. When accounts do not have enough balance to pay rent, they may be Garbage Collected. See also rent exempt below. Learn more about rent here: What is rent?.",
-      "definitionSource": "https://solana.com/docs/references/terminology#rent",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "Solana Glossary",
-      "dateFirstRecorded": "2025-02-14",
-      "commentary": ""
-    },
-    "rent-exempt": {
-      "term": "rent exempt",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "Accounts that maintain a minimum lamport balance that is proportional to the amount of data stored on the account. All newly created accounts are stored on-chain permanently until the account is closed. It is not possible to create an account that falls below the rent exemption threshold.",
-      "definitionSource": "https://solana.com/docs/references/terminology#rent-exempt",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "Solana Glossary",
-      "dateFirstRecorded": "2025-02-14",
-      "commentary": ""
-    },
-    "root": {
-      "term": "root",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "A block or slot that has reached maximum lockout on a validator. The root is the highest block that is an ancestor of all active forks on a validator. All ancestor blocks of a root are also transitively a root. Blocks that are not an ancestor and not a descendant of the root are excluded from consideration for consensus and can be discarded.",
-      "definitionSource": "https://solana.com/docs/references/terminology#root",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "Solana Glossary",
-      "dateFirstRecorded": "2025-02-14",
-      "commentary": ""
-    },
-    "runtime": {
-      "term": "runtime",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "The component of a validator responsible for program execution.",
-      "definitionSource": "https://solana.com/docs/references/terminology#runtime",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "Solana Glossary",
-      "dateFirstRecorded": "2025-02-14",
-      "commentary": ""
-    },
-    "Sealevel": {
-      "term": "Sealevel",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "Solana's parallel run-time for onchain programs.",
-      "definitionSource": "https://solana.com/docs/references/terminology#sealevel",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "Solana Glossary",
-      "dateFirstRecorded": "2025-02-14",
-      "commentary": ""
-    },
-    "shred": {
-      "term": "shred",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "A fraction of a block; the smallest unit sent between validators.",
-      "definitionSource": "https://solana.com/docs/references/terminology#shred",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "Solana Glossary",
-      "dateFirstRecorded": "2025-02-14",
-      "commentary": ""
-    },
-    "skip-rate": {
-      "term": "skip rate",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "The percentage of skipped slots out of the total leader slots in the current epoch. This metric can be misleading as it has high variance after the epoch boundary when the sample size is small, as well as for validators with a low number of leader slots, however can also be useful in identifying node misconfigurations at times.",
-      "definitionSource": "https://solana.com/docs/references/terminology#skip-rate",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "Solana Glossary",
-      "dateFirstRecorded": "2025-02-14",
-      "commentary": ""
-    },
-    "skipped-slot": {
-      "term": "skipped slot",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "A past slot that did not produce a block, because the leader was offline or the fork containing the slot was abandoned for a better alternative by cluster consensus. A skipped slot will not appear as an ancestor for blocks at subsequent slots, nor increment the block height, nor expire the oldest recent_blockhash. Whether a slot has been skipped can only be determined when it becomes older than the latest rooted (thus not-skipped) slot.",
-      "definitionSource": "https://solana.com/docs/references/terminology#skipped-slot",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "Solana Glossary",
-      "dateFirstRecorded": "2025-02-14",
-      "commentary": ""
-    },
-    "SOL": {
-      "term": "SOL",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "The native token of a Solana cluster.",
-      "definitionSource": "https://solana.com/docs/references/terminology#sol",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "Solana Glossary",
-      "dateFirstRecorded": "2025-02-14",
-      "commentary": ""
-    },
-    "Solana-Program-Library": {
-      "term": "Solana Program Library (SPL)",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "A library of programs on Solana such as spl-token that facilitates tasks such as creating and using tokens.",
-      "definitionSource": "https://solana.com/docs/references/terminology#solana-program-library-spl",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "Solana Glossary",
-      "dateFirstRecorded": "2025-02-14",
-      "commentary": ""
-    },
-    "stake-weighted-quality-of-service": {
-      "term": "stake-weighted quality of service (SWQoS)",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "SWQoS allows preferential treatment for transactions that come from staked validators.",
-      "definitionSource": "https://solana.com/docs/references/terminology#stake-weighted-quality-of-service-swqos",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "Solana Glossary",
-      "dateFirstRecorded": "2025-02-14",
-      "commentary": ""
-    },
-    "supermajority": {
-      "term": "supermajority",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "2/3 of a cluster.",
-      "definitionSource": "https://solana.com/docs/references/terminology#supermajority",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "Solana Glossary",
-      "dateFirstRecorded": "2025-02-14",
-      "commentary": ""
-    },
-    "sysvar": {
-      "term": "sysvar",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "A system account. Sysvars provide cluster state information such as current tick height, rewards points values, etc. Programs can access Sysvars via a Sysvar account (pubkey) or by querying via a syscall.",
-      "definitionSource": "https://solana.com/docs/references/terminology#sysvar",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "Solana Glossary",
-      "dateFirstRecorded": "2025-02-14",
-      "commentary": ""
-    },
-    "thin-client": {
-      "term": "thin client",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "A type of client that trusts it is communicating with a valid cluster.",
-      "definitionSource": "https://solana.com/docs/references/terminology#thin-client",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "Solana Glossary",
-      "dateFirstRecorded": "2025-02-14",
-      "commentary": ""
-    },
-    "tick": {
-      "term": "tick",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "A ledger entry that estimates wallclock duration.",
-      "definitionSource": "https://solana.com/docs/references/terminology#tick",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "Solana Glossary",
-      "dateFirstRecorded": "2025-02-14",
-      "commentary": ""
-    },
-    "tick-height": {
-      "term": "tick height",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "The Nth tick in the ledger.",
-      "definitionSource": "https://solana.com/docs/references/terminology#tick-height",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "Solana Glossary",
-      "dateFirstRecorded": "2025-02-14",
-      "commentary": ""
-    },
-    "Token-Extensions-Program": {
-      "term": "Token Extensions Program",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "The Token Extensions Program has the program ID TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb and includes all the same features as the Token Program, but comes with extensions such as confidential transfers, custom transfer logic, extended metadata, and much more.",
-      "definitionSource": "https://solana.com/docs/references/terminology#token-extensions-program",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "Solana Glossary",
-      "dateFirstRecorded": "2025-02-14",
-      "commentary": ""
-    },
-    "token-mint": {
-      "term": "token mint",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "An account that can produce (or 'mint') tokens. Different tokens are distinguished by their unique token mint addresses.",
-      "definitionSource": "https://solana.com/docs/references/terminology#token-mint",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "Solana Glossary",
-      "dateFirstRecorded": "2025-02-14",
-      "commentary": ""
-    },
-    "Token-Program": {
-      "term": "Token Program",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "The Token Program has the program ID TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA, and provides the basic capabilities of transferring, freezing, and minting tokens.",
-      "definitionSource": "https://solana.com/docs/references/terminology#token-program",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "Solana Glossary",
-      "dateFirstRecorded": "2025-02-14",
-      "commentary": ""
-    },
-    "tps": {
-      "term": "tps",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "Transactions per second.",
-      "definitionSource": "https://solana.com/docs/references/terminology#tps",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "Solana Glossary",
-      "dateFirstRecorded": "2025-02-14",
-      "commentary": ""
-    },
-    "tpu": {
-      "term": "tpu",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "Transaction processing unit.",
-      "definitionSource": "https://solana.com/docs/references/terminology#tpu",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "Solana Glossary",
-      "dateFirstRecorded": "2025-02-14",
-      "commentary": ""
-    },
-    "transaction-confirmations": {
-      "term": "transaction confirmations",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "The number of confirmed blocks since the transaction was accepted onto the ledger. A transaction is finalized when its block becomes a root.",
-      "definitionSource": "https://solana.com/docs/references/terminology#transaction-confirmations",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "Solana Glossary",
-      "dateFirstRecorded": "2025-02-14",
-      "commentary": ""
-    },
-    "transactions-entry": {
-      "term": "transactions entry",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "A set of transactions that may be executed in parallel.",
-      "definitionSource": "https://solana.com/docs/references/terminology#transactions-entry",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "Solana Glossary",
-      "dateFirstRecorded": "2025-02-14",
-      "commentary": ""
-    },
-    "TVU": {
-      "term": "tvu",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "Transaction validation unit.",
-      "definitionSource": "https://solana.com/docs/references/terminology#tvu",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "Solana Glossary",
-      "dateFirstRecorded": "2025-02-14",
-      "commentary": ""
-    },
-    "VDF": {
-      "term": "VDF",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "See verifiable delay function.",
-      "definitionSource": "https://solana.com/docs/references/terminology#vdf",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "Solana Glossary",
-      "dateFirstRecorded": "2025-02-14",
-      "commentary": ""
-    },
-    "verifiable-delay-function": {
-      "term": "verifiable delay function (VDF)",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "A function that takes a fixed amount of time to execute that produces a proof that it ran, which can then be verified in less time than it took to produce.",
-      "definitionSource": "https://solana.com/docs/references/terminology#verifiable-delay-function-vdf",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "Solana Glossary",
-      "dateFirstRecorded": "2025-02-14",
-      "commentary": ""
-    },
-    "vote": {
-      "term": "vote",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "See ledger vote.",
-      "definitionSource": "https://solana.com/docs/references/terminology#vote",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "Solana Glossary",
-      "dateFirstRecorded": "2025-02-14",
-      "commentary": ""
-    },
-    "vote credit": {
-      "term": "vote credit",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "A reward tally for validators. A vote credit is awarded to a validator in its vote account when the validator reaches a root.",
-      "definitionSource": "https://solana.com/docs/references/terminology#vote-credit",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "Solana Glossary",
-      "dateFirstRecorded": "2025-02-14",
-      "commentary": ""
-    },
-    "warmup-period": {
-      "term": "warmup period",
-      "partOfSpeech": "",
-      "termCategory": "",
-      "phonetic": "",
-      "definition": "Some number of epochs after stake has been delegated while it progressively becomes effective. During this period, the stake is considered to be \"activating\". More info about: warmup and cooldown",
-      "definitionSource": "https://solana.com/docs/references/terminology#warmup-period",
-      "sampleSentence": "",
-      "extended": "",
-      "alternate": [],
-      "termSource": "Solana Glossary",
-      "dateFirstRecorded": "2025-02-14",
       "commentary": ""
     }
   }

--- a/locales/en-US/en-US.json
+++ b/locales/en-US/en-US.json
@@ -79,6 +79,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "Solving for this attack vector is one of the key design decisions in the Bitcoin protocol, as well as Ethereum, and others. In the case of Bitcoin, this was solved through the Proof of Work consensus mechanism, wherein the difficulty involved in mining new blocks effectively prevents any one actor from gaining this sort of control.",
+      "alternate": [],
       "termSource": "Consensys Software Inc., Blockchain Glossary for Beginners",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -120,6 +121,12 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "These public-private key pairs can be generated one at a time, or they can be *derived* from what is known as a **seed phrase** or **secret recovery phrase**; for more on this, see HD wallet.",
+      "alternate": [
+        {
+          "definition": "A record in the Solana ledger that either holds data or is an executable program. Like an account at a traditional bank, a Solana account may hold funds called lamports. Like a file in Linux, it is addressable by a key, often referred to as a public key or pubkey. The key may be one of: - an ed25519 public key - a program-derived account address (32byte value forced off the ed25519 curve) - a hash of an ed25519 public key with a 32 character string",
+          "source": "https://solana.com/docs/references/terminology#account"
+        }
+      ],
       "termSource": "Many",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -167,7 +174,7 @@
       "commentary": ""
     },
     "ad-hoc": {
-      "term": "Ad Hoc",
+      "term": "ad hoc",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -189,6 +196,12 @@
       "definitionSource": "James Beck, Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "For example, on some networks, particularly EVM-style, every account will have an address, to which tokens could be sent. Smart contracts on those networks also have addresses, so that other contracts or protocols can interact with them. In Ethereum, the address begins with 0x; For example: 0x06A85356DCb5b307096726FB86A78c59D38e08ee",
+      "alternate": [
+        {
+          "definition": "String of text that designates the location of a particular wallet on the blockchain. Often a hashed version of a public key.",
+          "source": "https://academy.binance.com/en/glossary/address"
+        }
+      ],
       "termSource": "Consensys Software Inc., Blockchain Glossary for Beginners",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -230,6 +243,7 @@
       "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "Many hardware wallets use air-gapping as a security mechanism to keep users' private keys, or Secret Recovery Phrase offline, and thus safer from any kind of attack. Other, one-way communication methods are sometimes employed in such devices, e.g., QR codes.",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -240,9 +254,15 @@
       "termCategory": "",
       "phonetic": "/ˈɛrˌdrɑp/",
       "definition": "A token distribution method in which cryptocurrency or tokens are sent to a predeterimened set of wallet addresses.",
-      "definitionSource": "Education DAO, Consensys Software Inc., Blockchain Glossary for Beginners",
+      "definitionSource": "https://academy.binance.com/en/glossary/airdrop",
       "sampleSentence": "",
       "extended": "Sometimes airdrops are used for marketing purposes in exchange for simple tasks like reshares, referrals, or app downloads. The timing, recipient sourcing and inclusion methods, tokenomics and, if applicable, potential market value of tokens received through an airdrop are the subject of extensive debate and discussion.",
+      "alternate": [
+        {
+          "definition": "Distribution of digital assets to the public, by virtue of holding a certain token or by virtue of being an active wallet address.",
+          "source": "https://academy.binance.com/en/glossary/airdrop"
+        }
+      ],
       "termSource": "https://academy.binance.com/en/glossary/airdrop",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -284,7 +304,12 @@
       "definitionSource": "https://academy.binance.com/en/glossary/algorithm",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "A sequence of unambiguous instructions used for the purpose of solving a problem.",
+          "source": "https://academy.binance.com/en/glossary/algorithm"
+        }
+      ],
       "termSource": "https://academy.binance.com/en/glossary/algorithm",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -332,7 +357,7 @@
       "commentary": ""
     },
     "alpha": {
-      "term": "Alpha",
+      "term": "alpha",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -354,6 +379,12 @@
       "definitionSource": "James Beck, Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "The term is less used in Ethereum or smart contract-enabled blockchain communities. Many altcoins are forks of Bitcoin with minor changes (e.g., Litecoin). See also 'fork'.",
+      "alternate": [
+        {
+          "definition": "A cryptocurrency that is alternative to Bitcoin. Altcoin is used to describe cryptocurrencies that are not Bitcoin.",
+          "source": "https://academy.binance.com/en/glossary/altcoin"
+        }
+      ],
       "termSource": "Consensys Software Inc., Blockchain Glossary for Beginners",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -423,6 +454,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "An appchain generally offers an optimized execution environment for the application. Rather than being a 'monolithic' blockchain with its own executioon and consensus mechanisms, it may e.g. still rely on an underlying blockchain for consensus. See also: 'blockchain trilemma', 'modular blockchain', 'Layer 2', 'Layer 3'.",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -512,7 +544,7 @@
       "commentary": ""
     },
     "artificial-intelligence-ai": {
-      "term": "Artificial Intelligence (AI)",
+      "term": "artificial intelligence (AI)",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -590,6 +622,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "In the crypto context, 'asset provenance' refers to the ability to trace the ownership and transfer of a specific cryptocurrency or token from its creation or minting to its current holder.",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -609,7 +642,7 @@
       "commentary": ""
     },
     "asynchronous": {
-      "term": "asynchronous",
+      "term": "Asynchronous",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -623,7 +656,7 @@
       "commentary": ""
     },
     "atomic-swap": {
-      "term": "atomic swap",
+      "term": "Atomic Swap",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -637,7 +670,7 @@
       "commentary": ""
     },
     "attack-surface": {
-      "term": "attack surface",
+      "term": "Attack surface",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -659,12 +692,13 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "While that may sound vague, that's because attestations are used in a broad range of contexts, and have both been crucial to the development of key blockchain network protocols – such as in Proof of Stake (PoS) mechanisms, in which validators *attest* to the validity of the transactions they're recording in blocks and syncing through the consensus protocol – or in more recent developments, wherein protocols like the Ethereum Attestation Service allow for the creation of custom attestation 'schemata', publicly accessible on a network. Individual 'attestations' can then be written according to the fields and structures defined in each individual schema, stored on-chain by users executing a call to the schema and signing it with a public key.",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
     },
     "auction": {
-      "term": "auction",
+      "term": "Auction",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -762,7 +796,7 @@
       "commentary": ""
     },
     "bags": {
-      "term": "bags",
+      "term": "Bags",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -812,13 +846,18 @@
       "definitionSource": "https://academy.binance.com/en/glossary/beacon-chain",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "The Beacon Chain is Ethereum’s proof-of-stake (PoS) layer where consensus is reached.",
+          "source": "https://academy.binance.com/en/glossary/beacon-chain"
+        }
+      ],
       "termSource": "https://academy.binance.com/en/glossary/beacon-chain",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
     "bear-market": {
-      "term": "bear market",
+      "term": "Bear Market",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -832,7 +871,7 @@
       "commentary": ""
     },
     "benchmark": {
-      "term": "benchmark",
+      "term": "Benchmark",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -916,7 +955,7 @@
       "commentary": ""
     },
     "beta-coefficient": {
-      "term": "beta (coefficient)",
+      "term": "Beta (Coefficient)",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -930,7 +969,7 @@
       "commentary": ""
     },
     "beta-release": {
-      "term": "beta (release)",
+      "term": "Beta (Release)",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -944,7 +983,7 @@
       "commentary": ""
     },
     "bid-ask-spread": {
-      "term": "bid-ask spread",
+      "term": "Bid-Ask Spread",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -958,7 +997,7 @@
       "commentary": ""
     },
     "bid-price": {
-      "term": "bid price",
+      "term": "Bid Price",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -1036,7 +1075,12 @@
       "definitionSource": "https://academy.binance.com/en/glossary/bitcoin",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "A cryptocurrency created by the pseudonymous developer(s) Satoshi Nakamoto, initially described as a 'Peer-to-Peer e-cash'.",
+          "source": "https://academy.binance.com/en/glossary/bitcoin"
+        }
+      ],
       "termSource": "https://academy.binance.com/en/glossary/bitcoin",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1120,6 +1164,16 @@
       "definitionSource": "https://academy.binance.com/en/glossary/block",
       "sampleSentence": "",
       "extended": "Imagine a ledger that is being constantly synced between any number of exact copies of itself. People keep sending requests to add new entries to the ledger; these requests are transactions. When there are enough transactions ready, they get put into a specific order, and the *nodes*, each of which is keeping a copy of that ledger, reach consensus that the transactions are valid. Then, the transactions are cryptographically locked, in that order, into a 'block' and added forever to the ledger. This 'block' forms the starting point for the next one; in this way, they are all linked together in a chain, hence–blockchain.",
+      "alternate": [
+        {
+          "definition": "A computer file that stores transaction data. These can then be arranged in a linear sequence, which will form a blockchain.",
+          "source": "https://academy.binance.com/en/glossary/block"
+        },
+        {
+          "definition": "A contiguous set of entries on the ledger covered by a vote. A leader produces at most one block per slot.",
+          "source": "https://solana.com/docs/references/terminology#block"
+        }
+      ],
       "termSource": "https://academy.binance.com/en/glossary/block",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1161,6 +1215,16 @@
       "definitionSource": "https://academy.binance.com/en/glossary/block-height",
       "sampleSentence": "",
       "extended": "For example, Height 0 would be the very first block, which is also called the Genesis Block.",
+      "alternate": [
+        {
+          "definition": "The number of blocks in the chain between itself and the first block on that blockchain (genesis block or block 0).",
+          "source": "https://academy.binance.com/en/glossary/block-height"
+        },
+        {
+          "definition": "The number of blocks beneath the current block. The first block after the genesis block has height one.",
+          "source": "https://solana.com/docs/references/terminology#block-height"
+        }
+      ],
       "termSource": "https://academy.binance.com/en/glossary/block-height",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1174,6 +1238,12 @@
       "definitionSource": "https://academy.binance.com/en/glossary/block-reward",
       "sampleSentence": "",
       "extended": "Block rewards can be a mixture of coins and transaction fees. The composition depends on the policy used by the cryptocurrency in question, and whether all of the coins have already been successfully mined. The current block reward for the Bitcoin network is 12.5 bitcoins per block.",
+      "alternate": [
+        {
+          "definition": "The sum of coins awarded by the blockchain protocol to cryptocurrency miners for each successfully mined and validated block.",
+          "source": "https://academy.binance.com/en/glossary/block-reward"
+        }
+      ],
       "termSource": "https://academy.binance.com/en/glossary/block-reward",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1187,6 +1257,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "See also 'Proof of Work', 'Proof of Stake'.",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1214,6 +1285,12 @@
       "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "What is commonly referred to as a 'blockchain' might be more precisely called 'a public blockchain network', or a 'distributed ledger network'. While they get called 'blockchains' or 'chains', this is essentially a sort of metonymic usage. A public blockchain network consists, usually, of several different parts: 1. The blockchain or ledger itself. Think of this as the 'hard drive' of the network. 2. The consensus mechanism, and the consensus layer; this keeps all the copies of the ledger in sync, and adds new transactions or entries to it. 3. An execution layer: depending on the network in question, this layer or environment may vary from a very few functions built into the same software as the consensus client, to a very complex, Turing-complete, full-on Virtual Machine environment requiring those who run it to consider hardware requirements. There are, additionally, 'downstream' aspects of any one of these blockchain networks, including wallets, private-public key derivation logic, which programming languages can be used in interacting with it, etc. etc.",
+      "alternate": [
+        {
+          "definition": "A decentralized, digitized ledger that records transaction information about a cryptocurrency in a chronological order.",
+          "source": "https://academy.binance.com/en/glossary/blockchain"
+        }
+      ],
       "termSource": "https://academy.binance.com/en/glossary/blockchain",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1227,6 +1304,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "While a blockchain is designed to keep information forever, and be “readable by anyone”, finding the specific information you’re interested in may require indexing data off the blockchain–that is, sorting it according to given categories (sender address, token type, etc) into a separate database which can then be queried by the user; this essential function is provided by blockchain explorers. A prominent example is etherscan, which also offers explorers on a number of other networks.",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1352,7 +1430,12 @@
       "definitionSource": "https://academy.binance.com/en/glossary/bounty",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "A reward posted by a group or individual to incentivize certain work, behavior (such as referrals), or development.",
+          "source": "https://academy.binance.com/en/glossary/bounty"
+        }
+      ],
       "termSource": "https://academy.binance.com/en/glossary/bounty",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1366,6 +1449,7 @@
       "definitionSource": "MetaMask - kumavis, Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "Humans are not capable of generating enough entropy, or randomness, and therefore the wallets derived from these phrases are insecure; brain wallets can be brute forced by super fast computers. For this reason, brain wallet are insecure and should not be used. See also 'seed phrase'', 'Secret Recovery Phrase'.",
+      "alternate": [],
       "termSource": "MetaMask Help Center",
       "dateFirstRecorded": "2018",
       "commentary": ""
@@ -1449,6 +1533,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "It would be fair to say both that the term 'bridge' is generally accurate, and that it does a lot of heavy lifting. The way that bridges are created, and maintained, varies from one to another, but often involve some sort of 'paired smart contracts', one on each network. These contracts would, e.g., lock, or burn, tokens on one chain, and either mint or somehow disburse an equivalent token, and amount of them, on the destination chain.",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1504,7 +1589,12 @@
       "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "Originally derived from HODL, a term referring to keeping your heads down and focusing on building your product.",
+          "source": "https://academy.binance.com/en/glossary/buidl"
+        }
+      ],
       "termSource": "Consensys Software Inc., Blockchain Glossary for Beginners",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1728,6 +1818,12 @@
       "definitionSource": "https://academy.binance.com/en/glossary/centralized-exchange",
       "sampleSentence": "",
       "extended": "Centralized exchanges typically offer a wide range of trading pairs, with many popular cryptocurrencies available for trade. They also usually have high liquidity and offer advanced trading features such as margin trading, order types, and charting tools.\nHowever, centralized exchanges also have several drawbacks. They are often targeted by hackers, as the centralized nature of the exchange makes them a single point of failure. They also require users to trust the exchange to hold their funds securely and execute trades fairly, which can be a source of concern for some users.",
+      "alternate": [
+        {
+          "definition": "Understand the world of centralized exchanges, traditional crypto marketplaces known for high liquidity, advanced trading tools, and risk considerations.",
+          "source": "https://academy.binance.com/en/glossary/centralized-exchange"
+        }
+      ],
       "termSource": "https://academy.binance.com/en/glossary/centralized-exchange",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1755,6 +1851,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "Ethereum networks have two identifiers, a network ID and a chain ID. Although they often have the same value, they have different uses. Peer-to-peer communication between nodes uses the network ID, while the transaction signature process uses the chain ID.",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1824,7 +1921,12 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "A computer program that accesses the Solana server network cluster.",
+          "source": "https://solana.com/docs/references/terminology#client"
+        }
+      ],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1866,7 +1968,12 @@
       "definitionSource": "https://academy.binance.com/en/glossary/coin",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "A cryptocurrency or digital cash that is independent of any other platform, which is used as exchange of value.",
+          "source": "https://academy.binance.com/en/glossary/coin"
+        }
+      ],
       "termSource": "https://academy.binance.com/en/glossary/coin",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1908,6 +2015,12 @@
       "definitionSource": "https://academy.binance.com/en/glossary/cold-storage",
       "sampleSentence": "",
       "extended": "See also: airgapping",
+      "alternate": [
+        {
+          "definition": "Discover the essentials of cold storage: learn what it is and how it protects your cryptocurrency holdings.",
+          "source": "https://academy.binance.com/en/glossary/cold-storage"
+        }
+      ],
       "termSource": "https://academy.binance.com/en/glossary/cold-storage",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2019,6 +2132,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "Under a Proof of Work (PoW) consensus mechanism, this happens through a process known as mining; under Proof of Stake (PoS), the process is known as validation. Once a transaction is successfully confirmed, it theoretically cannot be reversed or double spent. The more confirmations a transaction has, the harder it becomes to perform a double spend attack.",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2032,7 +2146,12 @@
       "definitionSource": "https://academy.binance.com/en/glossary/confirmation-time",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "The wallclock duration between a leader creating a tick entry and creating a confirmed block.",
+          "source": "https://solana.com/docs/references/terminology#confirmation-time"
+        }
+      ],
       "termSource": "https://academy.binance.com/en/glossary/confirmation-time",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2060,6 +2179,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "In a blockchain network, the consensus layer is implemented by the consensus protocol or algorithm that defines how new blocks are added to the chain, and how the network reaches agreement on the current state of the ledger. There are various types of consensus mechanisms used in blockchain networks, including proof of work (PoW), proof of stake (PoS), and delegated proof of stake (DPoS). The consensus client implements the specific consensus mechanism used by the network and ensures that all nodes follow the rules and reach agreement on the current state of the blockchain.",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2199,6 +2319,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "The interplay between accounts and contracts, as public blockchain technology has advanced, has resulted in a particularly dense semantic web. When a smart contract is deployed, the Externally Owned Account, or EOA (controlled by a human), which is used to pay the gas fees required to deploy the contract -- that is, write it to the blockchain and make it available in the first place -- is referred to as the 'contract deploying account'. The resulting smart contract itself has an account as well -- the public address which can be used to 'call', or access its methods -- that's the one we're calling, here, a 'contract account'. But don't worry, it gets significantly worse; at a certain point, new techniques began to be used, to 'abstract away' the difficulties involved in EOAs; this move towards 'account abstraction' resulted in the creation of end user-accessible, shall we say, accounts which are created and controlled by... Smart contracts (which, remember, have their own accounts). There was much soul-searching and hand-wringing in trying to figure out what to call these things; often, they are referred to as... *Smart Contract Accounts*, capitalized; that's SCA, for short.",
+      "alternate": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2436,7 +2557,12 @@
       "definitionSource": "https://academy.binance.com/en/glossary/cryptocurrency",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "A digital currency that is secured by cryptography to work as a medium of exchange within a peer-to-peer (P2P) economic system.",
+          "source": "https://academy.binance.com/en/glossary/cryptocurrency"
+        }
+      ],
       "termSource": "https://academy.binance.com/en/glossary/cryptocurrency",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2464,7 +2590,12 @@
       "definitionSource": "https://academy.binance.com/en/glossary/cryptography",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "The science of using mathematical theories and computation in order to encrypt and decrypt information.",
+          "source": "https://academy.binance.com/en/glossary/cryptography"
+        }
+      ],
       "termSource": "https://academy.binance.com/en/glossary/cryptography",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2492,7 +2623,12 @@
       "definitionSource": "https://academy.binance.com/en/glossary/custody",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "Refers to the holding of assets on behalf of a client. Can also refer to the ownership of one's funds or assets.",
+          "source": "https://academy.binance.com/en/glossary/custody"
+        }
+      ],
       "termSource": "https://academy.binance.com/en/glossary/custody",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2646,7 +2782,12 @@
       "definitionSource": "https://academy.binance.com/en/glossary/decentralized-application",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "DApps are applications that run on a P2P network of computers rather than a central database. Users can freely connect to DApps using crypto wallets.",
+          "source": "https://academy.binance.com/en/glossary/decentralized-application"
+        }
+      ],
       "termSource": "https://academy.binance.com/en/glossary/decentralized-application",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2674,6 +2815,12 @@
       "definitionSource": "https://academy.binance.com/en/glossary/decentralized-autonomous-organization",
       "sampleSentence": "",
       "extended": "Alternatively, the first known example of a DAO is referred to as The DAO. The DAO served as a form of investor-directed venture capital fund, which sought to provide enterprises with new decentralized business models. Ethereum-based, The DAO’s code was open source. The organization set the record for the most crowdfunded project in 2016. Those funds were partially stolen by hackers. The hack caused an Ethereum hard-fork which lead to the creation of Ethereum Classic.",
+      "alternate": [
+        {
+          "definition": "Definition: A system of hard-coded rules that define which actions a decentralized organization will take.",
+          "source": "https://academy.binance.com/en/glossary/decentralized-autonomous-organization"
+        }
+      ],
       "termSource": "https://academy.binance.com/en/glossary/decentralized-autonomous-organization",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2687,6 +2834,12 @@
       "definitionSource": "https://academy.binance.com/en/glossary/decentralized-exchange",
       "sampleSentence": "",
       "extended": "This includes familiar concepts like loans and interest-bearing financial instruments, as well as so-called “DeFi primitives”, novel solutions like token swapping and liquidity pools. The trading is peer-to-peer, or between pools of liquidity. This is in contrast with a centralized exchange, which is more akin to a bank or investment firm that specializes in cryptocurrencies. Additionally, there are so-called on-ramp providers, who could be compared to currency brokers, exchanging traditional “fiat” money for cryptocurrencies, and do not hold customer’s funds “on deposit” the way a centralized exchange does. There are important technical and regulatory differences between these, which are constantly evolving.",
+      "alternate": [
+        {
+          "definition": "An exchange which does not require users to deposit funds to start trading and does not hold the funds for the user.",
+          "source": "https://academy.binance.com/en/glossary/decentralized-exchange"
+        }
+      ],
       "termSource": "https://academy.binance.com/en/glossary/decentralized-exchange",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2966,7 +3119,12 @@
       "definitionSource": "https://academy.binance.com/en/glossary/difficulty",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "In cryptocurrency, difficulty indicates the difficulty required to mine a block. Learn more at Binance Academy.",
+          "source": "https://academy.binance.com/en/glossary/difficulty"
+        }
+      ],
       "termSource": "https://academy.binance.com/en/glossary/difficulty",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2980,7 +3138,12 @@
       "definitionSource": "https://academy.binance.com/en/glossary/difficulty-bomb",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "The term 'difficulty bomb' denotes the increase in mining difficulty in Ethereum, as part of its migration to Proof of Stake.",
+          "source": "https://academy.binance.com/en/glossary/difficulty-bomb"
+        }
+      ],
       "termSource": "https://academy.binance.com/en/glossary/difficulty-bomb",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3022,7 +3185,12 @@
       "definitionSource": "https://academy.binance.com/en/glossary/digital-signature",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "A cryptographic tool to verify the authenticity and integrity of digital data, ensuring the security of data communication and cryptocurrency transactions.",
+          "source": "https://academy.binance.com/en/glossary/digital-signature"
+        }
+      ],
       "termSource": "https://academy.binance.com/en/glossary/digital-signature",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3386,7 +3554,12 @@
       "definitionSource": "https://academy.binance.com/en/glossary/encryption",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "Conversion of information or data into a secure code in order to prevent unauthorised access to the information or data.",
+          "source": "https://academy.binance.com/en/glossary/encryption"
+        }
+      ],
       "termSource": "https://academy.binance.com/en/glossary/encryption",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3442,7 +3615,12 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "The time, i.e. number of slots, for which a leader schedule is valid.",
+          "source": "https://solana.com/docs/references/terminology#epoch"
+        }
+      ],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3470,7 +3648,12 @@
       "definitionSource": "https://academy.binance.com/en/glossary/erc-1155",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "Discover the versatility of ERC-1155 tokens. Ideal for gaming, digital collectibles and managing multiple token types efficiently.",
+          "source": "https://academy.binance.com/en/glossary/erc-1155"
+        }
+      ],
       "termSource": "https://academy.binance.com/en/glossary/erc-1155",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3484,7 +3667,12 @@
       "definitionSource": "https://academy.binance.com/en/glossary/erc-20",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "A technical standard used to issue and implement tokens on the Ethereum blockchain proposed in November 2015 by Fabian Vogelsteller.",
+          "source": "https://academy.binance.com/en/glossary/erc-20"
+        }
+      ],
       "termSource": "https://academy.binance.com/en/glossary/erc-20",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3512,7 +3700,12 @@
       "definitionSource": "https://academy.binance.com/en/glossary/erc-721",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "An Ethereum based non-fungible token. This means that each token is unique and as a result, not interchangeable.",
+          "source": "https://academy.binance.com/en/glossary/erc-721"
+        }
+      ],
       "termSource": "https://academy.binance.com/en/glossary/erc-721",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3736,7 +3929,12 @@
       "definitionSource": "https://academy.binance.com/en/glossary/exchange",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "A marketplace for cryptocurrencies where users can buy and sell coins.",
+          "source": "https://academy.binance.com/en/glossary/exchange"
+        }
+      ],
       "termSource": "https://academy.binance.com/en/glossary/exchange",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3988,7 +4186,16 @@
       "definitionSource": "https://academy.binance.com/en/glossary/finality",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "The assurance or guarantee that completed (cryptocurrency) transactions cannot be altered, reversed or canceled.",
+          "source": "https://academy.binance.com/en/glossary/finality"
+        },
+        {
+          "definition": "When nodes representing 2/3rd of the stake have a common root.",
+          "source": "https://solana.com/docs/references/terminology#finality"
+        }
+      ],
       "termSource": "https://academy.binance.com/en/glossary/finality",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4212,7 +4419,16 @@
       "definitionSource": "https://academy.binance.com/en/glossary/fork",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "A fork is a divergence in the blockchain network by creating a split in the blockchain's transaction history. There are two types of forks - soft and hard.",
+          "source": "https://academy.binance.com/en/glossary/fork"
+        },
+        {
+          "definition": "A ledger derived from common entries but then diverged.",
+          "source": "https://solana.com/docs/references/terminology#fork"
+        }
+      ],
       "termSource": "https://academy.binance.com/en/glossary/fork",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4254,7 +4470,12 @@
       "definitionSource": "https://academy.binance.com/en/glossary/fraud-proof",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "A fraud proof is a cryptographical evidence that a verifier submits to challenge a transaction's validity. They are widely used for blockchain scalability.",
+          "source": "https://academy.binance.com/en/glossary/fraud-proof"
+        }
+      ],
       "termSource": "https://academy.binance.com/en/glossary/fraud-proof",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4296,7 +4517,12 @@
       "definitionSource": "https://academy.binance.com/en/glossary/full-node",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "Computer that fully implements the entirety of rules of an underlying blockchain network and validates transactions on a blockchain.",
+          "source": "https://academy.binance.com/en/glossary/full-node"
+        }
+      ],
       "termSource": "https://academy.binance.com/en/glossary/full-node",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4408,7 +4634,12 @@
       "definitionSource": "https://academy.binance.com/en/glossary/gas",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "The pricing mechanism employed  on the Ethereum blockchain to calculate the costs of smart contracts operations and transaction fees.",
+          "source": "https://academy.binance.com/en/glossary/gas"
+        }
+      ],
       "termSource": "https://academy.binance.com/en/glossary/gas",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4436,7 +4667,12 @@
       "definitionSource": "https://academy.binance.com/en/glossary/gas-limit",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "Maximum price a cryptocurrency user is willing to pay as a fee when sending a transaction, or performing a smart contract function.",
+          "source": "https://academy.binance.com/en/glossary/gas-limit"
+        }
+      ],
       "termSource": "https://academy.binance.com/en/glossary/gas-limit",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4517,10 +4753,19 @@
       "termCategory": "",
       "phonetic": "/ˈdʒɛnɪsɪs blɒk/",
       "definition": "The initial block of data computed in the history of a blockchain network.",
-      "definitionSource": "https://academy.binance.com/en/glossary/genesis-block",
+      "definitionSource": "wordsofweb3",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "The first ever block recorded on its respective blockchain network, also referred to as Block 0 or Block 1.",
+          "source": "https://academy.binance.com/en/glossary/genesis-block"
+        },
+        {
+          "definition": "The first block in the chain.",
+          "source": "https://solana.com/docs/references/terminology#genesis-block"
+        }
+      ],
       "termSource": "https://academy.binance.com/en/glossary/genesis-block",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4562,7 +4807,12 @@
       "definitionSource": "https://academy.binance.com/en/glossary/github",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "A site/system/folder/repository where a team can share, collaborate, and save their open source or proprietary code.",
+          "source": "https://academy.binance.com/en/glossary/github"
+        }
+      ],
       "termSource": "https://academy.binance.com/en/glossary/github",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4702,7 +4952,12 @@
       "definitionSource": "https://academy.binance.com/en/glossary/gwei",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "A small denomination of ether. It is widely used as a measure of gas prices. 1,000,000,000 wei = 1 Giga wei (Gwei)",
+          "source": "https://academy.binance.com/en/glossary/gwei"
+        }
+      ],
       "termSource": "https://academy.binance.com/en/glossary/gwei",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4758,7 +5013,12 @@
       "definitionSource": "https://academy.binance.com/en/glossary/halving",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "Halving is a process that reduces the block reward of a PoW crypto like Bitcoin (BTC) to half. The next halving of Bitcoin is expected around 2024.",
+          "source": "https://academy.binance.com/en/glossary/halving"
+        }
+      ],
       "termSource": "https://academy.binance.com/en/glossary/halving",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4842,7 +5102,16 @@
       "definitionSource": "https://academy.binance.com/en/glossary/hash",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "The output produced by a hash function after a piece of data is mapped. May also be referred to as hash value, hash code, or digest.",
+          "source": "https://academy.binance.com/en/glossary/hash"
+        },
+        {
+          "definition": "A digital fingerprint of a sequence of bytes.",
+          "source": "https://solana.com/docs/references/terminology#hash"
+        }
+      ],
       "termSource": "https://academy.binance.com/en/glossary/hash",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5080,7 +5349,12 @@
       "definitionSource": "https://academy.binance.com/en/glossary/immutability",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "The inability to change or be changed. One of the core features behind Bitcoin and blockchain technology.",
+          "source": "https://academy.binance.com/en/glossary/immutability"
+        }
+      ],
       "termSource": "https://academy.binance.com/en/glossary/immutability",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5248,7 +5522,12 @@
       "definitionSource": "https://academy.binance.com/en/glossary/interoperability",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "A concept of allowing blockchains to be compatible with each other and build upon each other's features and use-cases.",
+          "source": "https://academy.binance.com/en/glossary/interoperability"
+        }
+      ],
       "termSource": "https://academy.binance.com/en/glossary/interoperability",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5430,7 +5709,12 @@
       "definitionSource": "https://academy.binance.com/en/glossary/know-your-customer",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "A standard procedure in the finance industry which allows companies to identify their customers and comply with KYC AML laws",
+          "source": "https://academy.binance.com/en/glossary/know-your-customer"
+        }
+      ],
       "termSource": "https://academy.binance.com/en/glossary/know-your-customer",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5514,7 +5798,12 @@
       "definitionSource": "https://academy.binance.com/en/glossary/latency",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "The time between submitting a transaction to a network and the first confirmation of acceptance by the network.",
+          "source": "https://academy.binance.com/en/glossary/latency"
+        }
+      ],
       "termSource": "https://academy.binance.com/en/glossary/latency",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5598,7 +5887,12 @@
       "definitionSource": "https://academy.binance.com/en/glossary/layer-2",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "A secondary framework or protocol that is built on top of an existing blockchain system to provide increased scalability.",
+          "source": "https://academy.binance.com/en/glossary/layer-2"
+        }
+      ],
       "termSource": "https://academy.binance.com/en/glossary/layer-2",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5612,7 +5906,12 @@
       "definitionSource": "https://academy.binance.com/en/glossary/ledger",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "A list of entries containing transactions signed by clients. Conceptually, this can be traced back to the genesis block, but an actual validator's ledger may have only newer blocks to reduce storage, as older ones are not needed for validation of future blocks by design.",
+          "source": "https://solana.com/docs/references/terminology#ledger"
+        }
+      ],
       "termSource": "https://academy.binance.com/en/glossary/ledger",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5668,7 +5967,12 @@
       "definitionSource": "https://academy.binance.com/en/glossary/library",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "A collection of stable resources, which may include executable files, documentation, message templates, and written code.",
+          "source": "https://academy.binance.com/en/glossary/library"
+        }
+      ],
       "termSource": "https://academy.binance.com/en/glossary/library",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5696,7 +6000,12 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "A type of client that can verify it's pointing to a valid cluster. It performs more ledger verification than a thin client and less than a validator.",
+          "source": "https://solana.com/docs/references/terminology#light-client"
+        }
+      ],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5710,7 +6019,12 @@
       "definitionSource": "https://academy.binance.com/en/glossary/lightning-network",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "A second layer operating on top of a blockchain, enabling increased transaction speed among participating nodes.",
+          "source": "https://academy.binance.com/en/glossary/lightning-network"
+        }
+      ],
       "termSource": "https://academy.binance.com/en/glossary/lightning-network",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5822,7 +6136,12 @@
       "definitionSource": "https://academy.binance.com/en/glossary/liquidity",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "The ability to sell or buy any given asset without causing significant fluctuations in the market price for that asset.",
+          "source": "https://academy.binance.com/en/glossary/liquidity"
+        }
+      ],
       "termSource": "https://academy.binance.com/en/glossary/liquidity",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5920,7 +6239,12 @@
       "definitionSource": "https://academy.binance.com/en/glossary/mainnet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "A blockchain protocol which is fully developed and deployed where transactions are being broadcasted, verified, and recorded.",
+          "source": "https://academy.binance.com/en/glossary/mainnet"
+        }
+      ],
       "termSource": "https://academy.binance.com/en/glossary/mainnet",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5976,7 +6300,12 @@
       "definitionSource": "https://academy.binance.com/en/glossary/malware",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "Any software program or code that is created to infiltrate and intentionally cause damage to computer systems and networks.",
+          "source": "https://academy.binance.com/en/glossary/malware"
+        }
+      ],
       "termSource": "https://academy.binance.com/en/glossary/malware",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6144,7 +6473,12 @@
       "definitionSource": "https://academy.binance.com/en/glossary/mempool",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "A node’s mechanism for keeping track of unconfirmed transactions that the node has seen (but have not yet been added to a block).",
+          "source": "https://academy.binance.com/en/glossary/mempool"
+        }
+      ],
       "termSource": "https://academy.binance.com/en/glossary/mempool",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6242,7 +6576,12 @@
       "definitionSource": "https://academy.binance.com/en/glossary/metadata",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "Data that includes information about other data, such as information about features of a specific transaction.",
+          "source": "https://academy.binance.com/en/glossary/metadata"
+        }
+      ],
       "termSource": "https://academy.binance.com/en/glossary/metadata",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6326,7 +6665,12 @@
       "definitionSource": "https://academy.binance.com/en/glossary/metaverse",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "The metaverse is a concept of a persistent, online, 3D virtual environment that many believe will be a key element of future digital experiences.",
+          "source": "https://academy.binance.com/en/glossary/metaverse"
+        }
+      ],
       "termSource": "https://academy.binance.com/en/glossary/metaverse",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6410,7 +6754,12 @@
       "definitionSource": "https://academy.binance.com/en/glossary/mining",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "The verification of transactions on a blockchain network, in which transactions are added as entries into the blockchain ledger.",
+          "source": "https://academy.binance.com/en/glossary/mining"
+        }
+      ],
       "termSource": "https://academy.binance.com/en/glossary/mining",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6438,7 +6787,12 @@
       "definitionSource": "https://academy.binance.com/en/glossary/mint",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "Minting adds fresh tokens into the crypto ecosystem, enabling them to be traded or used within its network. Minting is similar to mining, with some key differences.",
+          "source": "https://academy.binance.com/en/glossary/mint"
+        }
+      ],
       "termSource": "https://academy.binance.com/en/glossary/mint",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6830,7 +7184,16 @@
       "definitionSource": "https://academy.binance.com/en/glossary/node",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "A participant on a blockchain network that communicates with other participants to ensure the security and integrity of the system.",
+          "source": "https://academy.binance.com/en/glossary/node"
+        },
+        {
+          "definition": "A computer participating in a cluster.",
+          "source": "https://solana.com/docs/references/terminology#node"
+        }
+      ],
       "termSource": "https://academy.binance.com/en/glossary/node",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6872,7 +7235,12 @@
       "definitionSource": "https://academy.binance.com/en/glossary/nonce",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "A single-use arbitrary string or number generated for verification purposes to prevent replaying past transactions.",
+          "source": "https://academy.binance.com/en/glossary/nonce"
+        }
+      ],
       "termSource": "https://academy.binance.com/en/glossary/nonce",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6900,7 +7268,12 @@
       "definitionSource": "https://academy.binance.com/en/glossary/off-chain",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "Discover how off-chain transactions in crypto enhance scalability and speed. Explore their use in Layer 2 solutions, reducing transaction costs.",
+          "source": "https://academy.binance.com/en/glossary/off-chain"
+        }
+      ],
       "termSource": "https://academy.binance.com/en/glossary/off-chain",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6970,7 +7343,12 @@
       "definitionSource": "https://academy.binance.com/en/glossary/on-chain",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "On-chain refers to transactions and activities directly recorded on the blockchain, ensuring data transparency, security, and immutability.",
+          "source": "https://academy.binance.com/en/glossary/on-chain"
+        }
+      ],
       "termSource": "https://academy.binance.com/en/glossary/on-chain",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7110,7 +7488,12 @@
       "definitionSource": "https://academy.binance.com/en/glossary/oracle",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "A data source or feed from a third party used for determining outcomes for smart contracts.",
+          "source": "https://academy.binance.com/en/glossary/oracle"
+        }
+      ],
       "termSource": "https://academy.binance.com/en/glossary/oracle",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7418,7 +7801,12 @@
       "definitionSource": "https://academy.binance.com/en/glossary/phishing",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "A malicious attack where a bad actor will attempt to obtain the credentials of a user in order to gain unauthorised access into their account.",
+          "source": "https://academy.binance.com/en/glossary/phishing"
+        }
+      ],
       "termSource": "https://academy.binance.com/en/glossary/phishing",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7446,7 +7834,12 @@
       "definitionSource": "https://academy.binance.com/en/glossary/plasma",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "An Ethereum off-chain scaling solution which may allow Etherum to greatly increase the transactions per second capablities.",
+          "source": "https://academy.binance.com/en/glossary/plasma"
+        }
+      ],
       "termSource": "https://academy.binance.com/en/glossary/plasma",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7642,7 +8035,16 @@
       "definitionSource": "https://academy.binance.com/en/glossary/private-key",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "In the context of cryptocurrency, a private key is a number that allows users to sign transactions and to generate receiving addresses.",
+          "source": "https://academy.binance.com/en/glossary/private-key"
+        },
+        {
+          "definition": "The private key of a keypair.",
+          "source": "https://solana.com/docs/references/terminology#private-key"
+        }
+      ],
       "termSource": "https://academy.binance.com/en/glossary/private-key",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7712,7 +8114,12 @@
       "definitionSource": "https://academy.binance.com/en/glossary/proof-of-stake",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "A consensus mechanism that reward block validators according to the amount of coins they have at stake.",
+          "source": "https://academy.binance.com/en/glossary/proof-of-stake"
+        }
+      ],
       "termSource": "https://academy.binance.com/en/glossary/proof-of-stake",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7740,7 +8147,12 @@
       "definitionSource": "https://academy.binance.com/en/glossary/proof-of-work",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "Proof of Work is a crypto consensus mechanism where miners use special equipment to solve cryptographic puzzles to validate transactions and create new blocks.",
+          "source": "https://academy.binance.com/en/glossary/proof-of-work"
+        }
+      ],
       "termSource": "https://academy.binance.com/en/glossary/proof-of-work",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7838,7 +8250,16 @@
       "definitionSource": "https://academy.binance.com/en/glossary/public-key",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "A public key is one-half of a key pair used to encrypt messages or verify digital signatures. In the crypto space, it essentially works as your wallet address.",
+          "source": "https://academy.binance.com/en/glossary/public-key"
+        },
+        {
+          "definition": "The public key of a keypair.",
+          "source": "https://solana.com/docs/references/terminology#public-key-pubkey"
+        }
+      ],
       "termSource": "https://academy.binance.com/en/glossary/public-key",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8160,7 +8581,12 @@
       "definitionSource": "https://academy.binance.com/en/glossary/roadmap",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "A business planning technique which lays out the short and long term goals of a company within a flexible estimated timeline.",
+          "source": "https://academy.binance.com/en/glossary/roadmap"
+        }
+      ],
       "termSource": "https://academy.binance.com/en/glossary/roadmap",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8244,7 +8670,12 @@
       "definitionSource": "https://academy.binance.com/en/glossary/rug-pull",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "A rug pull in the crypto industry is when a development team suddenly abandons a project and sells or removes all its liquidity.",
+          "source": "https://academy.binance.com/en/glossary/rug-pull"
+        }
+      ],
       "termSource": "https://academy.binance.com/en/glossary/rug-pull",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8356,7 +8787,12 @@
       "definitionSource": "https://academy.binance.com/en/glossary/satoshi-nakamoto",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "Satoshi Nakamoto was the pseudonym of the creator or creators of the bitcoin protocol and whitepaper.",
+          "source": "https://academy.binance.com/en/glossary/satoshi-nakamoto"
+        }
+      ],
       "termSource": "https://academy.binance.com/en/glossary/satoshi-nakamoto",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8552,7 +8988,12 @@
       "definitionSource": "https://academy.binance.com/en/glossary/seed-phrase",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "A seed phrase or menmonic seed is a collection of words that can be used to access your cryptocurrency wallet.",
+          "source": "https://academy.binance.com/en/glossary/seed-phrase"
+        }
+      ],
       "termSource": "https://academy.binance.com/en/glossary/seed-phrase",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8720,7 +9161,12 @@
       "definitionSource": "https://academy.binance.com/en/glossary/sharding",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "Sharding is a method of splitting blockchains ( or other types of databases) into smaller, partitioned blockchains that manage specific data segments.",
+          "source": "https://academy.binance.com/en/glossary/sharding"
+        }
+      ],
       "termSource": "https://academy.binance.com/en/glossary/sharding",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8790,7 +9236,12 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "A 64-byte ed25519 signature of R (32-bytes) and S (32-bytes). With the requirement that R is a packed Edwards point not of small order and S is a scalar in the range of 0 <= S < L. This requirement ensures no signature malleability. Each transaction must have at least one signature for fee account. Thus, the first signature in transaction can be treated as transaction id",
+          "source": "https://solana.com/docs/references/terminology#signature"
+        }
+      ],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8846,7 +9297,12 @@
       "definitionSource": "https://academy.binance.com/en/glossary/slippage",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "Slippage occurs when a trade settles at a different price than originally requested or expected, usually in low-liquidity markets and when using market orders.",
+          "source": "https://academy.binance.com/en/glossary/slippage"
+        }
+      ],
       "termSource": "https://academy.binance.com/en/glossary/slippage",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8860,7 +9316,12 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "The period of time for which each leader ingests transactions and produces a block. Collectively, slots create a logical clock. Slots are ordered sequentially and non-overlapping, comprising roughly equal real-world time as per PoH.",
+          "source": "https://solana.com/docs/references/terminology#slot"
+        }
+      ],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8874,7 +9335,16 @@
       "definitionSource": "https://academy.binance.com/en/glossary/smart-contract",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "Smart contracts are self-executing contracts that exist on certain blockchain networks. Their conditions and terms are written directly into lines of code.",
+          "source": "https://academy.binance.com/en/glossary/smart-contract"
+        },
+        {
+          "definition": "See onchain program.",
+          "source": "https://solana.com/docs/references/terminology#smart-contract"
+        }
+      ],
       "termSource": "https://academy.binance.com/en/glossary/smart-contract",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8986,7 +9456,12 @@
       "definitionSource": "https://academy.binance.com/en/glossary/solidity",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "Solidity is a programming language created in 2014 that was specifically designed to write and implement smart contracts on the Ethereum blockchain.",
+          "source": "https://academy.binance.com/en/glossary/solidity"
+        }
+      ],
       "termSource": "https://academy.binance.com/en/glossary/solidity",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9042,7 +9517,12 @@
       "definitionSource": "https://academy.binance.com/en/glossary/stablecoin",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "A type of cryptocurrency that is designed to maintain a stable value, rather than experiencing significant price changes.",
+          "source": "https://academy.binance.com/en/glossary/stablecoin"
+        }
+      ],
       "termSource": "https://academy.binance.com/en/glossary/stablecoin",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9070,7 +9550,12 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "Tokens forfeit to the cluster if malicious validator behavior can be proven.",
+          "source": "https://solana.com/docs/references/terminology#stake"
+        }
+      ],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9364,7 +9849,12 @@
       "definitionSource": "https://academy.binance.com/en/glossary/testnet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "Testnets are replicas of the mainnet, offering risk-free, secure environments for exploring and testing blockchain features.",
+          "source": "https://academy.binance.com/en/glossary/testnet"
+        }
+      ],
       "termSource": "https://academy.binance.com/en/glossary/testnet",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9448,7 +9938,16 @@
       "definitionSource": "https://academy.binance.com/en/glossary/token",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "Tokens (not to be confused with coins) are digital units issued on a blockchain. They can hold value or be redeemed for assets.",
+          "source": "https://academy.binance.com/en/glossary/token"
+        },
+        {
+          "definition": "A digitally transferable asset.",
+          "source": "https://solana.com/docs/references/terminology#token"
+        }
+      ],
       "termSource": "https://academy.binance.com/en/glossary/token",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9476,7 +9975,12 @@
       "definitionSource": "https://academy.binance.com/en/glossary/token-lockup",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "Token lockup or vesting period refers to the time span in which tokens or coins are not allowed to be transferred or traded.",
+          "source": "https://academy.binance.com/en/glossary/token-lockup"
+        }
+      ],
       "termSource": "https://academy.binance.com/en/glossary/token-lockup",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9616,7 +10120,12 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "One or more instructions signed by a client using one or more keypairs and executed atomically with only two possible outcomes: success or failure.",
+          "source": "https://solana.com/docs/references/terminology#transaction"
+        }
+      ],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9658,7 +10167,16 @@
       "definitionSource": "https://academy.binance.com/en/glossary/transaction-id",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "A transaction ID (TXID) is a unique string of characters that labels each transaction on the blockchain.",
+          "source": "https://academy.binance.com/en/glossary/transaction-id"
+        },
+        {
+          "definition": "The first signature in a transaction, which can be used to uniquely identify the transaction across the complete ledger.",
+          "source": "https://solana.com/docs/references/terminology#transaction-id"
+        }
+      ],
       "termSource": "https://academy.binance.com/en/glossary/transaction-id",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9770,7 +10288,12 @@
       "definitionSource": "https://academy.binance.com/en/glossary/trustless",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "No single entity has authority over the system and consensus is achieved between participants who do not have to trust each other.",
+          "source": "https://academy.binance.com/en/glossary/trustless"
+        }
+      ],
       "termSource": "https://academy.binance.com/en/glossary/trustless",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9784,7 +10307,12 @@
       "definitionSource": "https://academy.binance.com/en/glossary/turing-complete",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "A machine that, given enough time and memory along with the necessary instructions, can solve any computational problem.",
+          "source": "https://academy.binance.com/en/glossary/turing-complete"
+        }
+      ],
       "termSource": "https://academy.binance.com/en/glossary/turing-complete",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -10022,7 +10550,12 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "A full participant in a Solana network cluster that produces new blocks. A validator validates the transactions added to the ledger",
+          "source": "https://solana.com/docs/references/terminology#validator"
+        }
+      ],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10176,7 +10709,16 @@
       "definitionSource": "https://academy.binance.com/en/glossary/wallet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "Used to send and receive cryptocurrencies. Different types include software wallets, hardware wallets, and paper wallets.",
+          "source": "https://academy.binance.com/en/glossary/wallet"
+        },
+        {
+          "definition": "A collection of keypairs that allows users to manage their funds.",
+          "source": "https://solana.com/docs/references/terminology#wallet"
+        }
+      ],
       "termSource": "https://academy.binance.com/en/glossary/wallet",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -10344,7 +10886,12 @@
       "definitionSource": "https://academy.binance.com/en/glossary/wei",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "The smallest possible denomination of ether (ETH), the currency used on the Ethereum network. Often used when referring to gas prices.",
+          "source": "https://academy.binance.com/en/glossary/wei"
+        }
+      ],
       "termSource": "https://academy.binance.com/en/glossary/wei",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -10554,7 +11101,12 @@
       "definitionSource": "https://academy.binance.com/en/glossary/yield-farming",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "Yield farming is a high-risk practice in DeFi where investors lock up assets to provide liquidity, lend or stake in return for rewards or interest.",
+          "source": "https://academy.binance.com/en/glossary/yield-farming"
+        }
+      ],
       "termSource": "https://academy.binance.com/en/glossary/yield-farming",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -10638,7 +11190,12 @@
       "definitionSource": "https://academy.binance.com/en/glossary/zk-snarks",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "alternate": [
+        {
+          "definition": "“Zero-Knowledge Succinct Non-Interactive Argument of Knowledge” - an approach to zero-knowledge proofs.",
+          "source": "https://academy.binance.com/en/glossary/zk-snarks"
+        }
+      ],
       "termSource": "https://academy.binance.com/en/glossary/zk-snarks",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -10655,6 +11212,1042 @@
       "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/zk-starks",
       "dateFirstRecorded": "2025-01-31",
+      "commentary": ""
+    },
+    "account-owner": {
+      "term": "account owner",
+      "partOfSpeech": "",
+      "termCategory": "",
+      "phonetic": "",
+      "definition": "The address of the program that owns the account. Only the owning program is capable of modifying the account. See also authority.",
+      "definitionSource": "https://solana.com/docs/references/terminology#account-owner",
+      "sampleSentence": "",
+      "extended": "",
+      "alternate": [],
+      "termSource": "Solana Glossary",
+      "dateFirstRecorded": "2025-02-14",
+      "commentary": ""
+    },
+    "app": {
+      "term": "app",
+      "partOfSpeech": "",
+      "termCategory": "",
+      "phonetic": "",
+      "definition": "A front-end application that interacts with a Solana cluster.",
+      "definitionSource": "https://solana.com/docs/references/terminology#app",
+      "sampleSentence": "",
+      "extended": "",
+      "alternate": [],
+      "termSource": "Solana Glossary",
+      "dateFirstRecorded": "2025-02-14",
+      "commentary": ""
+    },
+    "authority": {
+      "term": "authority",
+      "partOfSpeech": "",
+      "termCategory": "",
+      "phonetic": "",
+      "definition": "The address of a user that has some kind of permission over an account. For example: - The ability to mint new tokens is given to the account that is the 'mint authority' for the token mint. - The ability to upgrade a program is given to the account that is the 'upgrade authority' of a program.",
+      "definitionSource": "https://solana.com/docs/references/terminology#authority",
+      "sampleSentence": "",
+      "extended": "",
+      "alternate": [],
+      "termSource": "Solana Glossary",
+      "dateFirstRecorded": "2025-02-14",
+      "commentary": ""
+    },
+    "bank-state": {
+      "term": "bank state",
+      "partOfSpeech": "",
+      "termCategory": "",
+      "phonetic": "",
+      "definition": "The result of interpreting all programs on the ledger at a given tick height. It includes at least the set of all accounts holding nonzero native tokens.",
+      "definitionSource": "https://solana.com/docs/references/terminology#bank-state",
+      "sampleSentence": "",
+      "extended": "",
+      "alternate": [],
+      "termSource": "Solana Glossary",
+      "dateFirstRecorded": "2025-02-14",
+      "commentary": ""
+    },
+    "blockhash": {
+      "term": "blockhash",
+      "partOfSpeech": "",
+      "termCategory": "",
+      "phonetic": "",
+      "definition": "A unique value (hash) that identifies a record (block). Solana computes a blockhash from the last entry id of the block.",
+      "definitionSource": "https://solana.com/docs/references/terminology#blockhash",
+      "sampleSentence": "",
+      "extended": "",
+      "alternate": [],
+      "termSource": "Solana Glossary",
+      "dateFirstRecorded": "2025-02-14",
+      "commentary": ""
+    },
+    "bootstrap-validator": {
+      "term": "bootstrap validator",
+      "partOfSpeech": "",
+      "termCategory": "",
+      "phonetic": "",
+      "definition": "The validator that produces the genesis (first) block of a block chain.",
+      "definitionSource": "https://solana.com/docs/references/terminology#bootstrap-validator",
+      "sampleSentence": "",
+      "extended": "",
+      "alternate": [],
+      "termSource": "Solana Glossary",
+      "dateFirstRecorded": "2025-02-14",
+      "commentary": ""
+    },
+    "BPF-loader": {
+      "term": "BPF loader",
+      "partOfSpeech": "",
+      "termCategory": "",
+      "phonetic": "",
+      "definition": "The Solana program that owns and loads BPF onchain programs, allowing the program to interface with the runtime.",
+      "definitionSource": "https://solana.com/docs/references/terminology#bpf-loader",
+      "sampleSentence": "",
+      "extended": "",
+      "alternate": [],
+      "termSource": "Solana Glossary",
+      "dateFirstRecorded": "2025-02-14",
+      "commentary": ""
+    },
+    "commitment": {
+      "term": "commitment",
+      "partOfSpeech": "",
+      "termCategory": "",
+      "phonetic": "",
+      "definition": "A measure of the network confirmation for the block.",
+      "definitionSource": "https://solana.com/docs/references/terminology#commitment",
+      "sampleSentence": "",
+      "extended": "",
+      "alternate": [],
+      "termSource": "Solana Glossary",
+      "dateFirstRecorded": "2025-02-14",
+      "commentary": ""
+    },
+    "cluster": {
+      "term": "cluster",
+      "partOfSpeech": "",
+      "termCategory": "",
+      "phonetic": "",
+      "definition": "A set of validators maintaining a single ledger.",
+      "definitionSource": "https://solana.com/docs/references/terminology#cluster",
+      "sampleSentence": "",
+      "extended": "",
+      "alternate": [],
+      "termSource": "Solana Glossary",
+      "dateFirstRecorded": "2025-02-14",
+      "commentary": ""
+    },
+    "compute-budget": {
+      "term": "compute budget",
+      "partOfSpeech": "",
+      "termCategory": "",
+      "phonetic": "",
+      "definition": "The maximum number of compute units consumed per transaction.",
+      "definitionSource": "https://solana.com/docs/references/terminology#compute-budget",
+      "sampleSentence": "",
+      "extended": "",
+      "alternate": [],
+      "termSource": "Solana Glossary",
+      "dateFirstRecorded": "2025-02-14",
+      "commentary": ""
+    },
+    "compute-units": {
+      "term": "compute units",
+      "partOfSpeech": "",
+      "termCategory": "",
+      "phonetic": "",
+      "definition": "The smallest unit of measure for consumption of computational resources of the blockchain.",
+      "definitionSource": "https://solana.com/docs/references/terminology#compute-units",
+      "sampleSentence": "",
+      "extended": "",
+      "alternate": [],
+      "termSource": "Solana Glossary",
+      "dateFirstRecorded": "2025-02-14",
+      "commentary": ""
+    },
+    "confirmed-block": {
+      "term": "confirmed block",
+      "partOfSpeech": "",
+      "termCategory": "",
+      "phonetic": "",
+      "definition": "A block that has received a super majority of ledger votes.",
+      "definitionSource": "https://solana.com/docs/references/terminology#confirmed-block",
+      "sampleSentence": "",
+      "extended": "",
+      "alternate": [],
+      "termSource": "Solana Glossary",
+      "dateFirstRecorded": "2025-02-14",
+      "commentary": ""
+    },
+    "control-plane": {
+      "term": "control plane",
+      "partOfSpeech": "",
+      "termCategory": "",
+      "phonetic": "",
+      "definition": "A gossip network connecting all nodes of a cluster.",
+      "definitionSource": "https://solana.com/docs/references/terminology#control-plane",
+      "sampleSentence": "",
+      "extended": "",
+      "alternate": [],
+      "termSource": "Solana Glossary",
+      "dateFirstRecorded": "2025-02-14",
+      "commentary": ""
+    },
+    "cooldown-period": {
+      "term": "cooldown period",
+      "partOfSpeech": "",
+      "termCategory": "",
+      "phonetic": "",
+      "definition": "Some number of epochs after stake has been deactivated while it progressively becomes available for withdrawal. During this period, the stake is considered to be \"deactivating\". More info about: warmup and cooldown",
+      "definitionSource": "https://solana.com/docs/references/terminology#cooldown-period",
+      "sampleSentence": "",
+      "extended": "",
+      "alternate": [],
+      "termSource": "Solana Glossary",
+      "dateFirstRecorded": "2025-02-14",
+      "commentary": ""
+    },
+    "credit": {
+      "term": "credit",
+      "partOfSpeech": "",
+      "termCategory": "",
+      "phonetic": "",
+      "definition": "See vote credit.",
+      "definitionSource": "https://solana.com/docs/references/terminology#credit",
+      "sampleSentence": "",
+      "extended": "",
+      "alternate": [],
+      "termSource": "Solana Glossary",
+      "dateFirstRecorded": "2025-02-14",
+      "commentary": ""
+    },
+    "cross-program-invocation-CPI": {
+      "term": "cross-program invocation (CPI)",
+      "partOfSpeech": "",
+      "termCategory": "",
+      "phonetic": "",
+      "definition": "A call from one onchain program to another. For more information, see calling between programs.",
+      "definitionSource": "https://solana.com/docs/references/terminology#cross-program-invocation-cpi",
+      "sampleSentence": "",
+      "extended": "",
+      "alternate": [],
+      "termSource": "Solana Glossary",
+      "dateFirstRecorded": "2025-02-14",
+      "commentary": ""
+    },
+    "data-plane": {
+      "term": "data plane",
+      "partOfSpeech": "",
+      "termCategory": "",
+      "phonetic": "",
+      "definition": "A multicast network used to efficiently validate entries and gain consensus.",
+      "definitionSource": "https://solana.com/docs/references/terminology#data-plane",
+      "sampleSentence": "",
+      "extended": "",
+      "alternate": [],
+      "termSource": "Solana Glossary",
+      "dateFirstRecorded": "2025-02-14",
+      "commentary": ""
+    },
+    "drone": {
+      "term": "drone",
+      "partOfSpeech": "",
+      "termCategory": "",
+      "phonetic": "",
+      "definition": "An offchain service that acts as a custodian for a user's private key. It typically serves to validate and sign transactions.",
+      "definitionSource": "https://solana.com/docs/references/terminology#drone",
+      "sampleSentence": "",
+      "extended": "",
+      "alternate": [],
+      "termSource": "Solana Glossary",
+      "dateFirstRecorded": "2025-02-14",
+      "commentary": ""
+    },
+    "entry": {
+      "term": "entry",
+      "partOfSpeech": "",
+      "termCategory": "",
+      "phonetic": "",
+      "definition": "An entry on the ledger either a tick or a transaction's entry.",
+      "definitionSource": "https://solana.com/docs/references/terminology#entry",
+      "sampleSentence": "",
+      "extended": "",
+      "alternate": [],
+      "termSource": "Solana Glossary",
+      "dateFirstRecorded": "2025-02-14",
+      "commentary": ""
+    },
+    "entry-id": {
+      "term": "entry id",
+      "partOfSpeech": "",
+      "termCategory": "",
+      "phonetic": "",
+      "definition": "A preimage resistant hash over the final contents of an entry, which acts as the entry's globally unique identifier. The hash serves as evidence of: - The entry being generated after a duration of time - The specified transactions are those included in the entry - The entry's position with respect to other entries in ledger See proof of history.",
+      "definitionSource": "https://solana.com/docs/references/terminology#entry-id",
+      "sampleSentence": "",
+      "extended": "",
+      "alternate": [],
+      "termSource": "Solana Glossary",
+      "dateFirstRecorded": "2025-02-14",
+      "commentary": ""
+    },
+    "fee-account": {
+      "term": "fee account",
+      "partOfSpeech": "",
+      "termCategory": "",
+      "phonetic": "",
+      "definition": "The fee account in the transaction is the account that pays for the cost of including the transaction in the ledger. This is the first account in the transaction. This account must be declared as Read-Write (writable) in the transaction since paying for the transaction reduces the account balance.",
+      "definitionSource": "https://solana.com/docs/references/terminology#fee-account",
+      "sampleSentence": "",
+      "extended": "",
+      "alternate": [],
+      "termSource": "Solana Glossary",
+      "dateFirstRecorded": "2025-02-14",
+      "commentary": ""
+    },
+    "genesis-config": {
+      "term": "genesis config",
+      "partOfSpeech": "",
+      "termCategory": "",
+      "phonetic": "",
+      "definition": "The configuration file that prepares the ledger for the genesis block.",
+      "definitionSource": "https://solana.com/docs/references/terminology#genesis-config",
+      "sampleSentence": "",
+      "extended": "",
+      "alternate": [],
+      "termSource": "Solana Glossary",
+      "dateFirstRecorded": "2025-02-14",
+      "commentary": ""
+    },
+    "inflation": {
+      "term": "inflation",
+      "partOfSpeech": "",
+      "termCategory": "",
+      "phonetic": "",
+      "definition": "An increase in token supply over time used to fund rewards for validation and to fund continued development of Solana.",
+      "definitionSource": "https://solana.com/docs/references/terminology#inflation",
+      "sampleSentence": "",
+      "extended": "",
+      "alternate": [],
+      "termSource": "Solana Glossary",
+      "dateFirstRecorded": "2025-02-14",
+      "commentary": ""
+    },
+    "inner-instruction": {
+      "term": "inner instruction",
+      "partOfSpeech": "",
+      "termCategory": "",
+      "phonetic": "",
+      "definition": "See cross-program invocation.",
+      "definitionSource": "https://solana.com/docs/references/terminology#inner-instruction",
+      "sampleSentence": "",
+      "extended": "",
+      "alternate": [],
+      "termSource": "Solana Glossary",
+      "dateFirstRecorded": "2025-02-14",
+      "commentary": ""
+    },
+    "instruction": {
+      "term": "instruction",
+      "partOfSpeech": "",
+      "termCategory": "",
+      "phonetic": "",
+      "definition": "A call to invoke a specific instruction handler in a program. An instruction also specifies which accounts it wants to read or modify, and additional data that serves as auxiliary input to the instruction handler. A client must include at least one instruction in a transaction, and all instructions must complete for the transaction to be considered successful.",
+      "definitionSource": "https://solana.com/docs/references/terminology#instruction",
+      "sampleSentence": "",
+      "extended": "",
+      "alternate": [],
+      "termSource": "Solana Glossary",
+      "dateFirstRecorded": "2025-02-14",
+      "commentary": ""
+    },
+    "instruction-handler": {
+      "term": "instruction handler",
+      "partOfSpeech": "",
+      "termCategory": "",
+      "phonetic": "",
+      "definition": "Instruction handlers are program functions that process instructions from transactions. An instruction handler may contain one or more cross-program invocations.",
+      "definitionSource": "https://solana.com/docs/references/terminology#instruction-handler",
+      "sampleSentence": "",
+      "extended": "",
+      "alternate": [],
+      "termSource": "Solana Glossary",
+      "dateFirstRecorded": "2025-02-14",
+      "commentary": ""
+    },
+    "keypair": {
+      "term": "keypair",
+      "partOfSpeech": "",
+      "termCategory": "",
+      "phonetic": "",
+      "definition": "A public key and corresponding private key for accessing an account.",
+      "definitionSource": "https://solana.com/docs/references/terminology#keypair",
+      "sampleSentence": "",
+      "extended": "",
+      "alternate": [],
+      "termSource": "Solana Glossary",
+      "dateFirstRecorded": "2025-02-14",
+      "commentary": ""
+    },
+    "lamport": {
+      "term": "lamport",
+      "partOfSpeech": "",
+      "termCategory": "",
+      "phonetic": "",
+      "definition": "A fractional native token with the value of 0.000000001 sol.",
+      "definitionSource": "https://solana.com/docs/references/terminology#lamport",
+      "sampleSentence": "",
+      "extended": "",
+      "alternate": [],
+      "termSource": "Solana Glossary",
+      "dateFirstRecorded": "2025-02-14",
+      "commentary": ""
+    },
+    "leader": {
+      "term": "leader",
+      "partOfSpeech": "",
+      "termCategory": "",
+      "phonetic": "",
+      "definition": "The role of a validator when it is appending entries to the ledger.",
+      "definitionSource": "https://solana.com/docs/references/terminology#leader",
+      "sampleSentence": "",
+      "extended": "",
+      "alternate": [],
+      "termSource": "Solana Glossary",
+      "dateFirstRecorded": "2025-02-14",
+      "commentary": ""
+    },
+    "leader-schedule": {
+      "term": "leader schedule",
+      "partOfSpeech": "",
+      "termCategory": "",
+      "phonetic": "",
+      "definition": "A sequence of validator public keys mapped to slots. The cluster uses the leader schedule to determine which validator is the leader at any moment in time.",
+      "definitionSource": "https://solana.com/docs/references/terminology#leader-schedule",
+      "sampleSentence": "",
+      "extended": "",
+      "alternate": [],
+      "termSource": "Solana Glossary",
+      "dateFirstRecorded": "2025-02-14",
+      "commentary": ""
+    },
+    "ledger-vote": {
+      "term": "ledger vote",
+      "partOfSpeech": "",
+      "termCategory": "",
+      "phonetic": "",
+      "definition": "A hash of the validator's state at a given tick height. It comprises a validator's affirmation that a block it has received has been verified, as well as a promise not to vote for a conflicting block (i.e. fork) for a specific amount of time, the lockout period.",
+      "definitionSource": "https://solana.com/docs/references/terminology#ledger-vote",
+      "sampleSentence": "",
+      "extended": "",
+      "alternate": [],
+      "termSource": "Solana Glossary",
+      "dateFirstRecorded": "2025-02-14",
+      "commentary": ""
+    },
+    "loader": {
+      "term": "loader",
+      "partOfSpeech": "",
+      "termCategory": "",
+      "phonetic": "",
+      "definition": "A program with the ability to interpret the binary encoding of other onchain programs.",
+      "definitionSource": "https://solana.com/docs/references/terminology#loader",
+      "sampleSentence": "",
+      "extended": "",
+      "alternate": [],
+      "termSource": "Solana Glossary",
+      "dateFirstRecorded": "2025-02-14",
+      "commentary": ""
+    },
+    "lockout": {
+      "term": "lockout",
+      "partOfSpeech": "",
+      "termCategory": "",
+      "phonetic": "",
+      "definition": "The duration of time for which a validator is unable to vote on another fork.",
+      "definitionSource": "https://solana.com/docs/references/terminology#lockout",
+      "sampleSentence": "",
+      "extended": "",
+      "alternate": [],
+      "termSource": "Solana Glossary",
+      "dateFirstRecorded": "2025-02-14",
+      "commentary": ""
+    },
+    "message": {
+      "term": "message",
+      "partOfSpeech": "",
+      "termCategory": "",
+      "phonetic": "",
+      "definition": "The structured contents of a transaction. Generally containing a header, array of account addresses, recent blockhash, and an array of instructions. Learn more about the message formatting inside of transactions here.",
+      "definitionSource": "https://solana.com/docs/references/terminology#message",
+      "sampleSentence": "",
+      "extended": "",
+      "alternate": [],
+      "termSource": "Solana Glossary",
+      "dateFirstRecorded": "2025-02-14",
+      "commentary": ""
+    },
+    "Nakamoto-coefficient": {
+      "term": "Nakamoto coefficient",
+      "partOfSpeech": "",
+      "termCategory": "",
+      "phonetic": "",
+      "definition": "A measure of decentralization, the Nakamoto Coefficient is the smallest number of independent entities that can act collectively to shut down a blockchain. The term was coined by Balaji S. Srinivasan and Leland Lee in Quantifying Decentralization.",
+      "definitionSource": "https://solana.com/docs/references/terminology#nakamoto-coefficient",
+      "sampleSentence": "",
+      "extended": "",
+      "alternate": [],
+      "termSource": "Solana Glossary",
+      "dateFirstRecorded": "2025-02-14",
+      "commentary": ""
+    },
+    "native-token": {
+      "term": "native token",
+      "partOfSpeech": "",
+      "termCategory": "",
+      "phonetic": "",
+      "definition": "The token used to track work done by nodes in a cluster.",
+      "definitionSource": "https://solana.com/docs/references/terminology#native-token",
+      "sampleSentence": "",
+      "extended": "",
+      "alternate": [],
+      "termSource": "Solana Glossary",
+      "dateFirstRecorded": "2025-02-14",
+      "commentary": ""
+    },
+    "node-count": {
+      "term": "node count",
+      "partOfSpeech": "",
+      "termCategory": "",
+      "phonetic": "",
+      "definition": "The number of validators participating in a cluster.",
+      "definitionSource": "https://solana.com/docs/references/terminology#node-count",
+      "sampleSentence": "",
+      "extended": "",
+      "alternate": [],
+      "termSource": "Solana Glossary",
+      "dateFirstRecorded": "2025-02-14",
+      "commentary": ""
+    },
+    "onchain-program": {
+      "term": "onchain program",
+      "partOfSpeech": "",
+      "termCategory": "",
+      "phonetic": "",
+      "definition": "The executable code on Solana blockchain that interprets the instructions sent inside of each transaction to read and modify accounts over which it has control. These programs are often referred to as \"smart contracts\" on other blockchains.",
+      "definitionSource": "https://solana.com/docs/references/terminology#onchain-program",
+      "sampleSentence": "",
+      "extended": "",
+      "alternate": [],
+      "termSource": "Solana Glossary",
+      "dateFirstRecorded": "2025-02-14",
+      "commentary": ""
+    },
+    "PoH": {
+      "term": "PoH",
+      "partOfSpeech": "",
+      "termCategory": "",
+      "phonetic": "",
+      "definition": "See Proof of History.",
+      "definitionSource": "https://solana.com/docs/references/terminology#poh",
+      "sampleSentence": "",
+      "extended": "",
+      "alternate": [],
+      "termSource": "Solana Glossary",
+      "dateFirstRecorded": "2025-02-14",
+      "commentary": ""
+    },
+    "point": {
+      "term": "point",
+      "partOfSpeech": "",
+      "termCategory": "",
+      "phonetic": "",
+      "definition": "A weighted credit in a rewards regime. In the validator rewards regime, the number of points owed to a stake during redemption is the product of the vote credits earned and the number of lamports staked.",
+      "definitionSource": "https://solana.com/docs/references/terminology#point",
+      "sampleSentence": "",
+      "extended": "",
+      "alternate": [],
+      "termSource": "Solana Glossary",
+      "dateFirstRecorded": "2025-02-14",
+      "commentary": ""
+    },
+    "program": {
+      "term": "program",
+      "partOfSpeech": "",
+      "termCategory": "",
+      "phonetic": "",
+      "definition": "See onchain program.",
+      "definitionSource": "https://solana.com/docs/references/terminology#program",
+      "sampleSentence": "",
+      "extended": "",
+      "alternate": [],
+      "termSource": "Solana Glossary",
+      "dateFirstRecorded": "2025-02-14",
+      "commentary": ""
+    },
+    "program-derived-account-PDA": {
+      "term": "program derived account (PDA)",
+      "partOfSpeech": "",
+      "termCategory": "",
+      "phonetic": "",
+      "definition": "An account whose signing authority is a program and thus is not controlled by a private key like other accounts.",
+      "definitionSource": "https://solana.com/docs/references/terminology#program-derived-account-pda",
+      "sampleSentence": "",
+      "extended": "",
+      "alternate": [],
+      "termSource": "Solana Glossary",
+      "dateFirstRecorded": "2025-02-14",
+      "commentary": ""
+    },
+    "program-id": {
+      "term": "program id",
+      "partOfSpeech": "",
+      "termCategory": "",
+      "phonetic": "",
+      "definition": "The public key of the account containing a program.",
+      "definitionSource": "https://solana.com/docs/references/terminology#program-id",
+      "sampleSentence": "",
+      "extended": "",
+      "alternate": [],
+      "termSource": "Solana Glossary",
+      "dateFirstRecorded": "2025-02-14",
+      "commentary": ""
+    },
+    "proof-of-history-PoH": {
+      "term": "proof of history (PoH)",
+      "partOfSpeech": "",
+      "termCategory": "",
+      "phonetic": "",
+      "definition": "A stack of proofs, each of which proves that some data existed before the proof was created and that a precise duration of time passed before the previous proof. Like a VDF, a Proof of History can be verified in less time than it took to produce.",
+      "definitionSource": "https://solana.com/docs/references/terminology#proof-of-history-poh",
+      "sampleSentence": "",
+      "extended": "",
+      "alternate": [],
+      "termSource": "Solana Glossary",
+      "dateFirstRecorded": "2025-02-14",
+      "commentary": ""
+    },
+    "prioritization-fee": {
+      "term": "prioritization fee",
+      "partOfSpeech": "",
+      "termCategory": "",
+      "phonetic": "",
+      "definition": "An additional fee user can specify in the compute budget instruction to prioritize their transactions. The prioritization fee is calculated by multiplying the requested maximum compute units by the compute-unit price (specified in increments of 0.000001 lamports per compute unit) rounded up to the nearest lamport. Transactions should request the minimum amount of compute units required for execution to minimize fees.",
+      "definitionSource": "https://solana.com/docs/references/terminology#prioritization-fee",
+      "sampleSentence": "",
+      "extended": "",
+      "alternate": [],
+      "termSource": "Solana Glossary",
+      "dateFirstRecorded": "2025-02-14",
+      "commentary": ""
+    },
+    "rent": {
+      "term": "rent",
+      "partOfSpeech": "",
+      "termCategory": "",
+      "phonetic": "",
+      "definition": "Fee paid by Accounts and Programs to store data on the blockchain. When accounts do not have enough balance to pay rent, they may be Garbage Collected. See also rent exempt below. Learn more about rent here: What is rent?.",
+      "definitionSource": "https://solana.com/docs/references/terminology#rent",
+      "sampleSentence": "",
+      "extended": "",
+      "alternate": [],
+      "termSource": "Solana Glossary",
+      "dateFirstRecorded": "2025-02-14",
+      "commentary": ""
+    },
+    "rent-exempt": {
+      "term": "rent exempt",
+      "partOfSpeech": "",
+      "termCategory": "",
+      "phonetic": "",
+      "definition": "Accounts that maintain a minimum lamport balance that is proportional to the amount of data stored on the account. All newly created accounts are stored on-chain permanently until the account is closed. It is not possible to create an account that falls below the rent exemption threshold.",
+      "definitionSource": "https://solana.com/docs/references/terminology#rent-exempt",
+      "sampleSentence": "",
+      "extended": "",
+      "alternate": [],
+      "termSource": "Solana Glossary",
+      "dateFirstRecorded": "2025-02-14",
+      "commentary": ""
+    },
+    "root": {
+      "term": "root",
+      "partOfSpeech": "",
+      "termCategory": "",
+      "phonetic": "",
+      "definition": "A block or slot that has reached maximum lockout on a validator. The root is the highest block that is an ancestor of all active forks on a validator. All ancestor blocks of a root are also transitively a root. Blocks that are not an ancestor and not a descendant of the root are excluded from consideration for consensus and can be discarded.",
+      "definitionSource": "https://solana.com/docs/references/terminology#root",
+      "sampleSentence": "",
+      "extended": "",
+      "alternate": [],
+      "termSource": "Solana Glossary",
+      "dateFirstRecorded": "2025-02-14",
+      "commentary": ""
+    },
+    "runtime": {
+      "term": "runtime",
+      "partOfSpeech": "",
+      "termCategory": "",
+      "phonetic": "",
+      "definition": "The component of a validator responsible for program execution.",
+      "definitionSource": "https://solana.com/docs/references/terminology#runtime",
+      "sampleSentence": "",
+      "extended": "",
+      "alternate": [],
+      "termSource": "Solana Glossary",
+      "dateFirstRecorded": "2025-02-14",
+      "commentary": ""
+    },
+    "Sealevel": {
+      "term": "Sealevel",
+      "partOfSpeech": "",
+      "termCategory": "",
+      "phonetic": "",
+      "definition": "Solana's parallel run-time for onchain programs.",
+      "definitionSource": "https://solana.com/docs/references/terminology#sealevel",
+      "sampleSentence": "",
+      "extended": "",
+      "alternate": [],
+      "termSource": "Solana Glossary",
+      "dateFirstRecorded": "2025-02-14",
+      "commentary": ""
+    },
+    "shred": {
+      "term": "shred",
+      "partOfSpeech": "",
+      "termCategory": "",
+      "phonetic": "",
+      "definition": "A fraction of a block; the smallest unit sent between validators.",
+      "definitionSource": "https://solana.com/docs/references/terminology#shred",
+      "sampleSentence": "",
+      "extended": "",
+      "alternate": [],
+      "termSource": "Solana Glossary",
+      "dateFirstRecorded": "2025-02-14",
+      "commentary": ""
+    },
+    "skip-rate": {
+      "term": "skip rate",
+      "partOfSpeech": "",
+      "termCategory": "",
+      "phonetic": "",
+      "definition": "The percentage of skipped slots out of the total leader slots in the current epoch. This metric can be misleading as it has high variance after the epoch boundary when the sample size is small, as well as for validators with a low number of leader slots, however can also be useful in identifying node misconfigurations at times.",
+      "definitionSource": "https://solana.com/docs/references/terminology#skip-rate",
+      "sampleSentence": "",
+      "extended": "",
+      "alternate": [],
+      "termSource": "Solana Glossary",
+      "dateFirstRecorded": "2025-02-14",
+      "commentary": ""
+    },
+    "skipped-slot": {
+      "term": "skipped slot",
+      "partOfSpeech": "",
+      "termCategory": "",
+      "phonetic": "",
+      "definition": "A past slot that did not produce a block, because the leader was offline or the fork containing the slot was abandoned for a better alternative by cluster consensus. A skipped slot will not appear as an ancestor for blocks at subsequent slots, nor increment the block height, nor expire the oldest recent_blockhash. Whether a slot has been skipped can only be determined when it becomes older than the latest rooted (thus not-skipped) slot.",
+      "definitionSource": "https://solana.com/docs/references/terminology#skipped-slot",
+      "sampleSentence": "",
+      "extended": "",
+      "alternate": [],
+      "termSource": "Solana Glossary",
+      "dateFirstRecorded": "2025-02-14",
+      "commentary": ""
+    },
+    "SOL": {
+      "term": "SOL",
+      "partOfSpeech": "",
+      "termCategory": "",
+      "phonetic": "",
+      "definition": "The native token of a Solana cluster.",
+      "definitionSource": "https://solana.com/docs/references/terminology#sol",
+      "sampleSentence": "",
+      "extended": "",
+      "alternate": [],
+      "termSource": "Solana Glossary",
+      "dateFirstRecorded": "2025-02-14",
+      "commentary": ""
+    },
+    "Solana-Program-Library": {
+      "term": "Solana Program Library (SPL)",
+      "partOfSpeech": "",
+      "termCategory": "",
+      "phonetic": "",
+      "definition": "A library of programs on Solana such as spl-token that facilitates tasks such as creating and using tokens.",
+      "definitionSource": "https://solana.com/docs/references/terminology#solana-program-library-spl",
+      "sampleSentence": "",
+      "extended": "",
+      "alternate": [],
+      "termSource": "Solana Glossary",
+      "dateFirstRecorded": "2025-02-14",
+      "commentary": ""
+    },
+    "stake-weighted-quality-of-service": {
+      "term": "stake-weighted quality of service (SWQoS)",
+      "partOfSpeech": "",
+      "termCategory": "",
+      "phonetic": "",
+      "definition": "SWQoS allows preferential treatment for transactions that come from staked validators.",
+      "definitionSource": "https://solana.com/docs/references/terminology#stake-weighted-quality-of-service-swqos",
+      "sampleSentence": "",
+      "extended": "",
+      "alternate": [],
+      "termSource": "Solana Glossary",
+      "dateFirstRecorded": "2025-02-14",
+      "commentary": ""
+    },
+    "supermajority": {
+      "term": "supermajority",
+      "partOfSpeech": "",
+      "termCategory": "",
+      "phonetic": "",
+      "definition": "2/3 of a cluster.",
+      "definitionSource": "https://solana.com/docs/references/terminology#supermajority",
+      "sampleSentence": "",
+      "extended": "",
+      "alternate": [],
+      "termSource": "Solana Glossary",
+      "dateFirstRecorded": "2025-02-14",
+      "commentary": ""
+    },
+    "sysvar": {
+      "term": "sysvar",
+      "partOfSpeech": "",
+      "termCategory": "",
+      "phonetic": "",
+      "definition": "A system account. Sysvars provide cluster state information such as current tick height, rewards points values, etc. Programs can access Sysvars via a Sysvar account (pubkey) or by querying via a syscall.",
+      "definitionSource": "https://solana.com/docs/references/terminology#sysvar",
+      "sampleSentence": "",
+      "extended": "",
+      "alternate": [],
+      "termSource": "Solana Glossary",
+      "dateFirstRecorded": "2025-02-14",
+      "commentary": ""
+    },
+    "thin-client": {
+      "term": "thin client",
+      "partOfSpeech": "",
+      "termCategory": "",
+      "phonetic": "",
+      "definition": "A type of client that trusts it is communicating with a valid cluster.",
+      "definitionSource": "https://solana.com/docs/references/terminology#thin-client",
+      "sampleSentence": "",
+      "extended": "",
+      "alternate": [],
+      "termSource": "Solana Glossary",
+      "dateFirstRecorded": "2025-02-14",
+      "commentary": ""
+    },
+    "tick": {
+      "term": "tick",
+      "partOfSpeech": "",
+      "termCategory": "",
+      "phonetic": "",
+      "definition": "A ledger entry that estimates wallclock duration.",
+      "definitionSource": "https://solana.com/docs/references/terminology#tick",
+      "sampleSentence": "",
+      "extended": "",
+      "alternate": [],
+      "termSource": "Solana Glossary",
+      "dateFirstRecorded": "2025-02-14",
+      "commentary": ""
+    },
+    "tick-height": {
+      "term": "tick height",
+      "partOfSpeech": "",
+      "termCategory": "",
+      "phonetic": "",
+      "definition": "The Nth tick in the ledger.",
+      "definitionSource": "https://solana.com/docs/references/terminology#tick-height",
+      "sampleSentence": "",
+      "extended": "",
+      "alternate": [],
+      "termSource": "Solana Glossary",
+      "dateFirstRecorded": "2025-02-14",
+      "commentary": ""
+    },
+    "Token-Extensions-Program": {
+      "term": "Token Extensions Program",
+      "partOfSpeech": "",
+      "termCategory": "",
+      "phonetic": "",
+      "definition": "The Token Extensions Program has the program ID TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb and includes all the same features as the Token Program, but comes with extensions such as confidential transfers, custom transfer logic, extended metadata, and much more.",
+      "definitionSource": "https://solana.com/docs/references/terminology#token-extensions-program",
+      "sampleSentence": "",
+      "extended": "",
+      "alternate": [],
+      "termSource": "Solana Glossary",
+      "dateFirstRecorded": "2025-02-14",
+      "commentary": ""
+    },
+    "token-mint": {
+      "term": "token mint",
+      "partOfSpeech": "",
+      "termCategory": "",
+      "phonetic": "",
+      "definition": "An account that can produce (or 'mint') tokens. Different tokens are distinguished by their unique token mint addresses.",
+      "definitionSource": "https://solana.com/docs/references/terminology#token-mint",
+      "sampleSentence": "",
+      "extended": "",
+      "alternate": [],
+      "termSource": "Solana Glossary",
+      "dateFirstRecorded": "2025-02-14",
+      "commentary": ""
+    },
+    "Token-Program": {
+      "term": "Token Program",
+      "partOfSpeech": "",
+      "termCategory": "",
+      "phonetic": "",
+      "definition": "The Token Program has the program ID TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA, and provides the basic capabilities of transferring, freezing, and minting tokens.",
+      "definitionSource": "https://solana.com/docs/references/terminology#token-program",
+      "sampleSentence": "",
+      "extended": "",
+      "alternate": [],
+      "termSource": "Solana Glossary",
+      "dateFirstRecorded": "2025-02-14",
+      "commentary": ""
+    },
+    "tps": {
+      "term": "tps",
+      "partOfSpeech": "",
+      "termCategory": "",
+      "phonetic": "",
+      "definition": "Transactions per second.",
+      "definitionSource": "https://solana.com/docs/references/terminology#tps",
+      "sampleSentence": "",
+      "extended": "",
+      "alternate": [],
+      "termSource": "Solana Glossary",
+      "dateFirstRecorded": "2025-02-14",
+      "commentary": ""
+    },
+    "tpu": {
+      "term": "tpu",
+      "partOfSpeech": "",
+      "termCategory": "",
+      "phonetic": "",
+      "definition": "Transaction processing unit.",
+      "definitionSource": "https://solana.com/docs/references/terminology#tpu",
+      "sampleSentence": "",
+      "extended": "",
+      "alternate": [],
+      "termSource": "Solana Glossary",
+      "dateFirstRecorded": "2025-02-14",
+      "commentary": ""
+    },
+    "transaction-confirmations": {
+      "term": "transaction confirmations",
+      "partOfSpeech": "",
+      "termCategory": "",
+      "phonetic": "",
+      "definition": "The number of confirmed blocks since the transaction was accepted onto the ledger. A transaction is finalized when its block becomes a root.",
+      "definitionSource": "https://solana.com/docs/references/terminology#transaction-confirmations",
+      "sampleSentence": "",
+      "extended": "",
+      "alternate": [],
+      "termSource": "Solana Glossary",
+      "dateFirstRecorded": "2025-02-14",
+      "commentary": ""
+    },
+    "transactions-entry": {
+      "term": "transactions entry",
+      "partOfSpeech": "",
+      "termCategory": "",
+      "phonetic": "",
+      "definition": "A set of transactions that may be executed in parallel.",
+      "definitionSource": "https://solana.com/docs/references/terminology#transactions-entry",
+      "sampleSentence": "",
+      "extended": "",
+      "alternate": [],
+      "termSource": "Solana Glossary",
+      "dateFirstRecorded": "2025-02-14",
+      "commentary": ""
+    },
+    "TVU": {
+      "term": "tvu",
+      "partOfSpeech": "",
+      "termCategory": "",
+      "phonetic": "",
+      "definition": "Transaction validation unit.",
+      "definitionSource": "https://solana.com/docs/references/terminology#tvu",
+      "sampleSentence": "",
+      "extended": "",
+      "alternate": [],
+      "termSource": "Solana Glossary",
+      "dateFirstRecorded": "2025-02-14",
+      "commentary": ""
+    },
+    "VDF": {
+      "term": "VDF",
+      "partOfSpeech": "",
+      "termCategory": "",
+      "phonetic": "",
+      "definition": "See verifiable delay function.",
+      "definitionSource": "https://solana.com/docs/references/terminology#vdf",
+      "sampleSentence": "",
+      "extended": "",
+      "alternate": [],
+      "termSource": "Solana Glossary",
+      "dateFirstRecorded": "2025-02-14",
+      "commentary": ""
+    },
+    "verifiable-delay-function": {
+      "term": "verifiable delay function (VDF)",
+      "partOfSpeech": "",
+      "termCategory": "",
+      "phonetic": "",
+      "definition": "A function that takes a fixed amount of time to execute that produces a proof that it ran, which can then be verified in less time than it took to produce.",
+      "definitionSource": "https://solana.com/docs/references/terminology#verifiable-delay-function-vdf",
+      "sampleSentence": "",
+      "extended": "",
+      "alternate": [],
+      "termSource": "Solana Glossary",
+      "dateFirstRecorded": "2025-02-14",
+      "commentary": ""
+    },
+    "vote": {
+      "term": "vote",
+      "partOfSpeech": "",
+      "termCategory": "",
+      "phonetic": "",
+      "definition": "See ledger vote.",
+      "definitionSource": "https://solana.com/docs/references/terminology#vote",
+      "sampleSentence": "",
+      "extended": "",
+      "alternate": [],
+      "termSource": "Solana Glossary",
+      "dateFirstRecorded": "2025-02-14",
+      "commentary": ""
+    },
+    "vote credit": {
+      "term": "vote credit",
+      "partOfSpeech": "",
+      "termCategory": "",
+      "phonetic": "",
+      "definition": "A reward tally for validators. A vote credit is awarded to a validator in its vote account when the validator reaches a root.",
+      "definitionSource": "https://solana.com/docs/references/terminology#vote-credit",
+      "sampleSentence": "",
+      "extended": "",
+      "alternate": [],
+      "termSource": "Solana Glossary",
+      "dateFirstRecorded": "2025-02-14",
+      "commentary": ""
+    },
+    "warmup-period": {
+      "term": "warmup period",
+      "partOfSpeech": "",
+      "termCategory": "",
+      "phonetic": "",
+      "definition": "Some number of epochs after stake has been delegated while it progressively becomes effective. During this period, the stake is considered to be \"activating\". More info about: warmup and cooldown",
+      "definitionSource": "https://solana.com/docs/references/terminology#warmup-period",
+      "sampleSentence": "",
+      "extended": "",
+      "alternate": [],
+      "termSource": "Solana Glossary",
+      "dateFirstRecorded": "2025-02-14",
       "commentary": ""
     }
   }

--- a/locales/en-US/en-US.json
+++ b/locales/en-US/en-US.json
@@ -628,7 +628,7 @@
       "commentary": ""
     },
     "assets-under-management-aum": {
-      "term": "Assets Under Management (AUM)",
+      "term": "assets under management (AUM)",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -642,7 +642,7 @@
       "commentary": ""
     },
     "asynchronous": {
-      "term": "Asynchronous",
+      "term": "asynchronous",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -656,7 +656,7 @@
       "commentary": ""
     },
     "atomic-swap": {
-      "term": "Atomic Swap",
+      "term": "atomic swap",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -670,7 +670,7 @@
       "commentary": ""
     },
     "attack-surface": {
-      "term": "Attack surface",
+      "term": "attack surface",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -698,7 +698,7 @@
       "commentary": ""
     },
     "auction": {
-      "term": "Auction",
+      "term": "auction",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -726,7 +726,7 @@
       "commentary": ""
     },
     "automated-market-maker-amm": {
-      "term": "Automated Market Maker (AMM)",
+      "term": "automated market maker (AMM)",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -796,7 +796,7 @@
       "commentary": ""
     },
     "bags": {
-      "term": "Bags",
+      "term": "bags",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -857,7 +857,7 @@
       "commentary": ""
     },
     "bear-market": {
-      "term": "Bear Market",
+      "term": "bear market",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -871,7 +871,7 @@
       "commentary": ""
     },
     "benchmark": {
-      "term": "Benchmark",
+      "term": "benchmark",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -955,7 +955,7 @@
       "commentary": ""
     },
     "beta-coefficient": {
-      "term": "Beta (Coefficient)",
+      "term": "beta (coefficient)",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -969,7 +969,7 @@
       "commentary": ""
     },
     "beta-release": {
-      "term": "Beta (Release)",
+      "term": "beta (release)",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -983,9 +983,9 @@
       "commentary": ""
     },
     "bid-ask-spread": {
-      "term": "Bid-Ask Spread",
-      "partOfSpeech": "",
-      "termCategory": "",
+      "term": "bid-ask spread",
+      "partOfSpeech": "noun phrase",
+      "termCategory": "finance",
       "phonetic": "",
       "definition": "The difference in price between the lowest asking price and highest bid price on the order book for an asset.",
       "definitionSource": "https://academy.binance.com/en/glossary/bid-ask-spread",
@@ -997,9 +997,9 @@
       "commentary": ""
     },
     "bid-price": {
-      "term": "Bid Price",
-      "partOfSpeech": "",
-      "termCategory": "",
+      "term": "bid price",
+      "partOfSpeech": "noun phrase",
+      "termCategory": "finance",
       "phonetic": "",
       "definition": "In the context of financial markets, it is the value buyers offer for an asset, such as a commodity, security, or cryptocurrency.",
       "definitionSource": "https://academy.binance.com/en/glossary/bid-price",
@@ -1026,8 +1026,8 @@
     },
     "binance-blockchain-charity-foundation": {
       "term": "Blockchain Charity Foundation",
-      "partOfSpeech": "",
-      "termCategory": "",
+      "partOfSpeech": "proper noun",
+      "termCategory": "web3",
       "phonetic": "",
       "definition": "The world's first decentralized charity platform to advocate the concept of 'blockchain for social good'.",
       "definitionSource": "https://academy.binance.com/en/glossary/binance-blockchain-charity-foundation",
@@ -1067,12 +1067,12 @@
       "commentary": ""
     },
     "bitcoin": {
-      "term": "Bitcoin",
+      "term": "bitcoin",
       "partOfSpeech": "noun",
       "termCategory": "",
       "phonetic": "/ˈbɪtkɔɪn/",
       "definition": "Bitcoin is a decentralized digital currency or cryptocurrency, which was created in 2009 by an unknown person or group using the name Satoshi Nakamoto. Bitcoin transactions are recorded on a public digital ledger called the blockchain, which is maintained by a network of computers worldwide. Bitcoin transactions are made directly between users without the need for intermediaries like banks or financial institutions. Users can send and receive bitcoins using digital wallets. One of the key features of Bitcoin is its limited supply. There will only ever be 21 million Bitcoins in existence, which helps to prevent inflation and maintain the value of the currency. When referring to the overall network, capitalization is appropriate (Bitcoin), whereas when referring to the tokens themselves, lower-case is more appropriate (bitcoin). The plural of bitcoin is just bitcoin; the abbreviation is BTC, with a space: I have 250 BTC.",
-      "definitionSource": "https://academy.binance.com/en/glossary/bitcoin",
+      "definitionSource": "James Beck, Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
       "alternate": [
@@ -1100,7 +1100,7 @@
       "commentary": ""
     },
     "bitcoin-dominance": {
-      "term": "Bitcoin Dominance",
+      "term": "bitcoin dominance",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -1114,7 +1114,7 @@
       "commentary": ""
     },
     "bitcoin-maximalists": {
-      "term": "Bitcoin Maximalists",
+      "term": "bitcoin maximalist",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -1128,23 +1128,23 @@
       "commentary": ""
     },
     "bitcoin-pizza": {
-      "term": "Bitcoin Pizza",
+      "term": "bitcoin pizza",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
       "definition": "The first known transaction where Bitcoin was exchanged for a physical good. Laszlo Hanyecz paid 10,000 BTC for two pizzas.",
       "definitionSource": "https://academy.binance.com/en/glossary/bitcoin-pizza",
       "sampleSentence": "",
-      "extended": "",
+      "extended": "See also Pizza DAO: https://x.com/Pizza_DAO",
       "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/bitcoin-pizza",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
     "black-swan-event": {
-      "term": "Black Swan Event",
-      "partOfSpeech": "",
-      "termCategory": "",
+      "term": "black swan event",
+      "partOfSpeech": "noun phrase",
+      "termCategory": "metaphor",
       "phonetic": "",
       "definition": "An event that is often entirely unexpected and deviates from the expected result causing widespread ramifications.",
       "definitionSource": "https://academy.binance.com/en/glossary/black-swan-event",
@@ -1161,7 +1161,7 @@
       "termCategory": "",
       "phonetic": "/blɑk/",
       "definition": "A discrete, unique set of transactions sent on a public distributed ledger network, immutably recorded in a certain order.",
-      "definitionSource": "https://academy.binance.com/en/glossary/block",
+      "definitionSource": "Consensys Software Inc., Blockchain Glossary for Beginners",
       "sampleSentence": "",
       "extended": "Imagine a ledger that is being constantly synced between any number of exact copies of itself. People keep sending requests to add new entries to the ledger; these requests are transactions. When there are enough transactions ready, they get put into a specific order, and the *nodes*, each of which is keeping a copy of that ledger, reach consensus that the transactions are valid. Then, the transactions are cryptographically locked, in that order, into a 'block' and added forever to the ledger. This 'block' forms the starting point for the next one; in this way, they are all linked together in a chain, hence–blockchain.",
       "alternate": [
@@ -1179,21 +1179,21 @@
       "commentary": ""
     },
     "block-explorer": {
-      "term": "Block Explorer",
+      "term": "block explorer",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
       "definition": "Online Blockchain webpage which allows users to browse information about blocks, transactions, balances and more.",
       "definitionSource": "https://academy.binance.com/en/glossary/block-explorer",
       "sampleSentence": "",
-      "extended": "",
+      "extended": "See also blockchain explorer.",
       "alternate": [],
       "termSource": "https://academy.binance.com/en/glossary/block-explorer",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
     "block-header": {
-      "term": "Block header",
+      "term": "block header",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -1212,7 +1212,7 @@
       "termCategory": "",
       "phonetic": "/blɑk haɪt/",
       "definition": "The number of blocks connected together in a blockchain.",
-      "definitionSource": "https://academy.binance.com/en/glossary/block-height",
+      "definitionSource": "Consensys Software Inc., Blockchain Glossary for Beginners",
       "sampleSentence": "",
       "extended": "For example, Height 0 would be the very first block, which is also called the Genesis Block.",
       "alternate": [
@@ -1324,7 +1324,7 @@
       "commentary": ""
     },
     "bloom-filter": {
-      "term": "Bloom Filter",
+      "term": "bloom filter",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",

--- a/locales/es-419/directoryContents.json
+++ b/locales/es-419/directoryContents.json
@@ -1756,7 +1756,7 @@
     "link": "rbol-de-merkle.html"
   },
   {
-    "name": "Mesh",
+    "name": "Consensys Mesh",
     "link": "mesh.html"
   },
   {

--- a/locales/es-419/directoryContents.json
+++ b/locales/es-419/directoryContents.json
@@ -1496,7 +1496,7 @@
     "link": "sistema-de-archivos-interplanetario-ipfs.html"
   },
   {
-    "name": "InterPlanetary File System (IPFS)",
+    "name": "InterPlanetary File System",
     "link": "interplanetary-file-system-ipfs.html"
   },
   {

--- a/locales/es-419/es-419.json
+++ b/locales/es-419/es-419.json
@@ -6146,8 +6146,8 @@
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
     },
-    "mesh": {
-      "term": "Mesh",
+    "consensys-mesh": {
+      "term": "Consensys Mesh",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",

--- a/locales/es-419/es-419.json
+++ b/locales/es-419/es-419.json
@@ -5222,7 +5222,7 @@
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
     },
-    "interplanetary-file-system-(ipfs)": {
+    "interplanetary-file-system": {
       "term": "Sistema de archivos interplanetario (IPFS)",
       "partOfSpeech": "",
       "termCategory": "",
@@ -5237,7 +5237,7 @@
       "commentary": ""
     },
     "interplanetary-file-system-ipfs": {
-      "term": "InterPlanetary File System (IPFS)",
+      "term": "InterPlanetary File System",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",

--- a/locales/es-419/es-419.json
+++ b/locales/es-419/es-419.json
@@ -8064,8 +8064,8 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "rollups": {
-      "term": "rollups",
+    "rollup": {
+      "term": "rollup",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",

--- a/locales/es-419/translation.json
+++ b/locales/es-419/translation.json
@@ -191,7 +191,7 @@
       "Inter-Blockchain Communication (IBC) Protocol": "Protocolo de comunicación entre cadenas de bloques (IBC)",
       "internal transaction": "transacción interna",
       "Interoperability": "interoperabilidad",
-      "InterPlanetary File System (IPFS)": "sistema de archivos interplanetario (IPFS)",
+      "InterPlanetary File System": "sistema de archivos interplanetario (IPFS)",
       "IP address": "dirección IP",
       "JSON file": "archivo JSON",
       "JSON-RPC": "JSON-RPC",

--- a/locales/es-419/translation.json
+++ b/locales/es-419/translation.json
@@ -229,7 +229,7 @@
       "memory pool; mempool": "grupo de memoria; mempool",
       "Merge (noun)": "fusión",
       "Merkle Patricia trie": "árbol de Merkle Patricia trie",
-      "Mesh": "Mesh",
+      "Consensys Mesh": "Consensys Mesh",
       "Metadata": "metadatos",
       "MetaMask": "MetaMask",
       "MetaMask Bridge": "puente de MetaMask",

--- a/locales/es-419/translation.json
+++ b/locales/es-419/translation.json
@@ -306,7 +306,7 @@
       "Rinkeby": "Rinkeby",
       "Roadmap": "Hoja de ruta",
       "Rocket Pool": "Rocket Pool",
-      "rollups": "rollups",
+      "rollup": "rollups",
       "Ropsten": "Ropsten",
       "RPC": "RPC",
       "rug pull": "tirón de alfombra",

--- a/locales/fa-AF/directoryContents.json
+++ b/locales/fa-AF/directoryContents.json
@@ -924,7 +924,7 @@
     "link": ".html"
   },
   {
-    "name": "Mesh",
+    "name": "Consensys Mesh",
     "link": "mesh.html"
   },
   {

--- a/locales/fa-AF/directoryContents.json
+++ b/locales/fa-AF/directoryContents.json
@@ -772,7 +772,7 @@
     "link": ".html"
   },
   {
-    "name": "InterPlanetary File System (IPFS)",
+    "name": "InterPlanetary File System",
     "link": "interplanetary-file-system-ipfs.html"
   },
   {

--- a/locales/fa-AF/fa-AF.json
+++ b/locales/fa-AF/fa-AF.json
@@ -3234,8 +3234,8 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "mesh": {
-      "term": "Mesh",
+    "consensys-mesh": {
+      "term": "Consensys Mesh",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",

--- a/locales/fa-AF/fa-AF.json
+++ b/locales/fa-AF/fa-AF.json
@@ -4312,7 +4312,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "rollups": {
+    "rollup": {
       "term": "رول‌آپ‌ها",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/fa-AF/fa-AF.json
+++ b/locales/fa-AF/fa-AF.json
@@ -2702,8 +2702,8 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "interplanetary-file-system-(ipfs)": {
-      "term": "InterPlanetary File System (IPFS)",
+    "interplanetary-file-system": {
+      "term": "InterPlanetary File System",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",

--- a/locales/fr-FR/directoryContents.json
+++ b/locales/fr-FR/directoryContents.json
@@ -1492,11 +1492,11 @@
     "link": "interoprabilit.html"
   },
   {
-    "name": "InterPlanetary File System (IPFS)",
+    "name": "InterPlanetary File System",
     "link": "interplanetary-file-system-ipfs.html"
   },
   {
-    "name": "InterPlanetary File System (IPFS)",
+    "name": "InterPlanetary File System",
     "link": "interplanetary-file-system-ipfs.html"
   },
   {

--- a/locales/fr-FR/directoryContents.json
+++ b/locales/fr-FR/directoryContents.json
@@ -1756,7 +1756,7 @@
     "link": "arbres-de-merkle.html"
   },
   {
-    "name": "Mesh",
+    "name": "Consensys Mesh",
     "link": "mesh.html"
   },
   {

--- a/locales/fr-FR/fr-FR.json
+++ b/locales/fr-FR/fr-FR.json
@@ -6146,8 +6146,8 @@
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
     },
-    "mesh": {
-      "term": "Mesh",
+    "consensys-mesh": {
+      "term": "Consensys Mesh",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",

--- a/locales/fr-FR/fr-FR.json
+++ b/locales/fr-FR/fr-FR.json
@@ -8064,8 +8064,8 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "rollups": {
-      "term": "rollups",
+    "rollup": {
+      "term": "rollup",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",

--- a/locales/fr-FR/fr-FR.json
+++ b/locales/fr-FR/fr-FR.json
@@ -5222,8 +5222,8 @@
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
     },
-    "interplanetary-file-system-(ipfs)": {
-      "term": "InterPlanetary File System (IPFS)",
+    "interplanetary-file-system": {
+      "term": "InterPlanetary File System",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -5237,7 +5237,7 @@
       "commentary": ""
     },
     "interplanetary-file-system-ipfs": {
-      "term": "InterPlanetary File System (IPFS)",
+      "term": "InterPlanetary File System",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",

--- a/locales/ha-NG/directoryContents.json
+++ b/locales/ha-NG/directoryContents.json
@@ -924,7 +924,7 @@
     "link": "merkle-patricia-trie.html"
   },
   {
-    "name": "Mesh",
+    "name": "Consensys Mesh",
     "link": "mesh.html"
   },
   {

--- a/locales/ha-NG/ha-NG.json
+++ b/locales/ha-NG/ha-NG.json
@@ -3234,8 +3234,8 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "mesh": {
-      "term": "Mesh",
+    "consensys-mesh": {
+      "term": "Consensys Mesh",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",

--- a/locales/ha-NG/ha-NG.json
+++ b/locales/ha-NG/ha-NG.json
@@ -4312,8 +4312,8 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "rollups": {
-      "term": "rollups",
+    "rollup": {
+      "term": "rollup",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",

--- a/locales/ha-NG/ha-NG.json
+++ b/locales/ha-NG/ha-NG.json
@@ -2702,7 +2702,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "interplanetary-file-system-(ipfs)": {
+    "interplanetary-file-system": {
       "term": "Tsarin Fayil na InterPlanetary (IPFS)",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/hi-IN/directoryContents.json
+++ b/locales/hi-IN/directoryContents.json
@@ -924,7 +924,7 @@
     "link": ".html"
   },
   {
-    "name": "Mesh",
+    "name": "Consensys Mesh",
     "link": "mesh.html"
   },
   {

--- a/locales/hi-IN/hi-IN.json
+++ b/locales/hi-IN/hi-IN.json
@@ -3234,8 +3234,8 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "mesh": {
-      "term": "Mesh",
+    "consensys-mesh": {
+      "term": "Consensys Mesh",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",

--- a/locales/hi-IN/hi-IN.json
+++ b/locales/hi-IN/hi-IN.json
@@ -2702,7 +2702,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "interplanetary-file-system-(ipfs)": {
+    "interplanetary-file-system": {
       "term": "इंटरप्लेनेटरी फाइल सिस्टम (IPFS)",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/hi-IN/hi-IN.json
+++ b/locales/hi-IN/hi-IN.json
@@ -4312,7 +4312,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "rollups": {
+    "rollup": {
       "term": "रॉलअप्स",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/hu-HU/directoryContents.json
+++ b/locales/hu-HU/directoryContents.json
@@ -1492,11 +1492,11 @@
     "link": "interoperabilits.html"
   },
   {
-    "name": "Interplanetary File System (IPFS)",
+    "name": "Interplanetary File System",
     "link": "interplanetary-file-system-ipfs.html"
   },
   {
-    "name": "InterPlanetary File System (IPFS)",
+    "name": "InterPlanetary File System",
     "link": "interplanetary-file-system-ipfs.html"
   },
   {

--- a/locales/hu-HU/hu-HU.json
+++ b/locales/hu-HU/hu-HU.json
@@ -6146,7 +6146,7 @@
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
     },
-    "mesh": {
+    "consensys-mesh": {
       "term": "háló",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/hu-HU/hu-HU.json
+++ b/locales/hu-HU/hu-HU.json
@@ -5222,8 +5222,8 @@
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
     },
-    "interplanetary-file-system-(ipfs)": {
-      "term": "Interplanetary File System (IPFS)",
+    "interplanetary-file-system": {
+      "term": "Interplanetary File System",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -5237,7 +5237,7 @@
       "commentary": ""
     },
     "interplanetary-file-system-ipfs": {
-      "term": "InterPlanetary File System (IPFS)",
+      "term": "InterPlanetary File System",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",

--- a/locales/hu-HU/hu-HU.json
+++ b/locales/hu-HU/hu-HU.json
@@ -8064,7 +8064,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "rollups": {
+    "rollup": {
       "term": "rollupok",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/id-ID/directoryContents.json
+++ b/locales/id-ID/directoryContents.json
@@ -1756,7 +1756,7 @@
     "link": "merkle-tree.html"
   },
   {
-    "name": "Mesh",
+    "name": "Consensys Mesh",
     "link": "mesh.html"
   },
   {

--- a/locales/id-ID/directoryContents.json
+++ b/locales/id-ID/directoryContents.json
@@ -1496,7 +1496,7 @@
     "link": "sistem-file-interplanetary-ipfs.html"
   },
   {
-    "name": "InterPlanetary File System (IPFS)",
+    "name": "InterPlanetary File System",
     "link": "interplanetary-file-system-ipfs.html"
   },
   {

--- a/locales/id-ID/id-ID.json
+++ b/locales/id-ID/id-ID.json
@@ -6146,8 +6146,8 @@
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
     },
-    "mesh": {
-      "term": "Mesh",
+    "consensys-mesh": {
+      "term": "Consensys Mesh",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",

--- a/locales/id-ID/id-ID.json
+++ b/locales/id-ID/id-ID.json
@@ -5222,7 +5222,7 @@
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
     },
-    "interplanetary-file-system-(ipfs)": {
+    "interplanetary-file-system": {
       "term": "Sistem File Interplanetary (IPFS)",
       "partOfSpeech": "",
       "termCategory": "",
@@ -5237,7 +5237,7 @@
       "commentary": ""
     },
     "interplanetary-file-system-ipfs": {
-      "term": "InterPlanetary File System (IPFS)",
+      "term": "InterPlanetary File System",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",

--- a/locales/id-ID/id-ID.json
+++ b/locales/id-ID/id-ID.json
@@ -8064,7 +8064,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "rollups": {
+    "rollup": {
       "term": "rollup",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/it-IT/directoryContents.json
+++ b/locales/it-IT/directoryContents.json
@@ -1492,11 +1492,11 @@
     "link": "interoperabilit.html"
   },
   {
-    "name": "InterPlanetary File System (IPFS)",
+    "name": "InterPlanetary File System",
     "link": "interplanetary-file-system-ipfs.html"
   },
   {
-    "name": "InterPlanetary File System (IPFS)",
+    "name": "InterPlanetary File System",
     "link": "interplanetary-file-system-ipfs.html"
   },
   {

--- a/locales/it-IT/directoryContents.json
+++ b/locales/it-IT/directoryContents.json
@@ -1756,7 +1756,7 @@
     "link": "merkle-tree.html"
   },
   {
-    "name": "Mesh",
+    "name": "Consensys Mesh",
     "link": "mesh.html"
   },
   {

--- a/locales/it-IT/it-IT.json
+++ b/locales/it-IT/it-IT.json
@@ -6146,8 +6146,8 @@
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
     },
-    "mesh": {
-      "term": "Mesh",
+    "consensys-mesh": {
+      "term": "Consensys Mesh",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",

--- a/locales/it-IT/it-IT.json
+++ b/locales/it-IT/it-IT.json
@@ -8050,7 +8050,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "rollups": {
+    "rollup": {
       "term": "rollup",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/it-IT/it-IT.json
+++ b/locales/it-IT/it-IT.json
@@ -5222,8 +5222,8 @@
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
     },
-    "interplanetary-file-system-(ipfs)": {
-      "term": "InterPlanetary File System (IPFS)",
+    "interplanetary-file-system": {
+      "term": "InterPlanetary File System",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -5237,7 +5237,7 @@
       "commentary": ""
     },
     "interplanetary-file-system-ipfs": {
-      "term": "InterPlanetary File System (IPFS)",
+      "term": "InterPlanetary File System",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",

--- a/locales/ja-JP/directoryContents.json
+++ b/locales/ja-JP/directoryContents.json
@@ -924,7 +924,7 @@
     "link": ".html"
   },
   {
-    "name": "Mesh",
+    "name": "Consensys Mesh",
     "link": "mesh.html"
   },
   {

--- a/locales/ja-JP/ja-JP.json
+++ b/locales/ja-JP/ja-JP.json
@@ -3234,8 +3234,8 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "mesh": {
-      "term": "Mesh",
+    "consensys-mesh": {
+      "term": "Consensys Mesh",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",

--- a/locales/ja-JP/ja-JP.json
+++ b/locales/ja-JP/ja-JP.json
@@ -4312,7 +4312,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "rollups": {
+    "rollup": {
       "term": "ロールアップ",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/ja-JP/ja-JP.json
+++ b/locales/ja-JP/ja-JP.json
@@ -2702,7 +2702,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "interplanetary-file-system-(ipfs)": {
+    "interplanetary-file-system": {
       "term": "インタープラネタリーファイルシステム (IPFS)",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/ko-KR/directoryContents.json
+++ b/locales/ko-KR/directoryContents.json
@@ -924,7 +924,7 @@
     "link": ".html"
   },
   {
-    "name": "Mesh",
+    "name": "Consensys Mesh",
     "link": "mesh.html"
   },
   {

--- a/locales/ko-KR/ko-KR.json
+++ b/locales/ko-KR/ko-KR.json
@@ -3234,8 +3234,8 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "mesh": {
-      "term": "Mesh",
+    "consensys-mesh": {
+      "term": "Consensys Mesh",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",

--- a/locales/ko-KR/ko-KR.json
+++ b/locales/ko-KR/ko-KR.json
@@ -4312,7 +4312,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "rollups": {
+    "rollup": {
       "term": "롤업",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/ko-KR/ko-KR.json
+++ b/locales/ko-KR/ko-KR.json
@@ -2702,7 +2702,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "interplanetary-file-system-(ipfs)": {
+    "interplanetary-file-system": {
       "term": "행성 간 파일 시스템(IPFS)",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/ms-MY/directoryContents.json
+++ b/locales/ms-MY/directoryContents.json
@@ -924,7 +924,7 @@
     "link": "merkle-patricia-trie.html"
   },
   {
-    "name": "Mesh",
+    "name": "Consensys Mesh",
     "link": "mesh.html"
   },
   {

--- a/locales/ms-MY/ms-MY.json
+++ b/locales/ms-MY/ms-MY.json
@@ -3234,8 +3234,8 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "mesh": {
-      "term": "Mesh",
+    "consensys-mesh": {
+      "term": "Consensys Mesh",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",

--- a/locales/ms-MY/ms-MY.json
+++ b/locales/ms-MY/ms-MY.json
@@ -4312,7 +4312,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "rollups": {
+    "rollup": {
       "term": "penggulungan",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/ms-MY/ms-MY.json
+++ b/locales/ms-MY/ms-MY.json
@@ -2702,7 +2702,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "interplanetary-file-system-(ipfs)": {
+    "interplanetary-file-system": {
       "term": "Sistem Fail Antara Planet (IPFS)",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/nl-NL/directoryContents.json
+++ b/locales/nl-NL/directoryContents.json
@@ -924,7 +924,7 @@
     "link": "merkle-patriciatrie.html"
   },
   {
-    "name": "Mesh",
+    "name": "Consensys Mesh",
     "link": "mesh.html"
   },
   {

--- a/locales/nl-NL/nl-NL.json
+++ b/locales/nl-NL/nl-NL.json
@@ -3234,8 +3234,8 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "mesh": {
-      "term": "Mesh",
+    "consensys-mesh": {
+      "term": "Consensys Mesh",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",

--- a/locales/nl-NL/nl-NL.json
+++ b/locales/nl-NL/nl-NL.json
@@ -4312,8 +4312,8 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "rollups": {
-      "term": "rollups",
+    "rollup": {
+      "term": "rollup",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",

--- a/locales/nl-NL/nl-NL.json
+++ b/locales/nl-NL/nl-NL.json
@@ -2702,7 +2702,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "interplanetary-file-system-(ipfs)": {
+    "interplanetary-file-system": {
       "term": "IPFS (InterPlanetary File System)",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/pcm-NG/directoryContents.json
+++ b/locales/pcm-NG/directoryContents.json
@@ -772,7 +772,7 @@
     "link": "different-crypto-networks-fit-wok-together.html"
   },
   {
-    "name": "InterPlanetary File System (IPFS)",
+    "name": "InterPlanetary File System",
     "link": "interplanetary-file-system-ipfs.html"
   },
   {

--- a/locales/pcm-NG/pcm-NG.json
+++ b/locales/pcm-NG/pcm-NG.json
@@ -2702,8 +2702,8 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "interplanetary-file-system-(ipfs)": {
-      "term": "InterPlanetary File System (IPFS)",
+    "interplanetary-file-system": {
+      "term": "InterPlanetary File System",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",

--- a/locales/pcm-NG/pcm-NG.json
+++ b/locales/pcm-NG/pcm-NG.json
@@ -4312,7 +4312,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "rollups": {
+    "rollup": {
       "term": "express lane for internet",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/pcm-NG/pcm-NG.json
+++ b/locales/pcm-NG/pcm-NG.json
@@ -3234,7 +3234,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "mesh": {
+    "consensys-mesh": {
       "term": "Mesh Network",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/pl-PL/directoryContents.json
+++ b/locales/pl-PL/directoryContents.json
@@ -924,7 +924,7 @@
     "link": "drzewo-merkle.html"
   },
   {
-    "name": "Mesh",
+    "name": "Consensys Mesh",
     "link": "mesh.html"
   },
   {

--- a/locales/pl-PL/directoryContents.json
+++ b/locales/pl-PL/directoryContents.json
@@ -772,7 +772,7 @@
     "link": "interoperacyjno.html"
   },
   {
-    "name": "InterPlanetary File System (IPFS)",
+    "name": "InterPlanetary File System",
     "link": "interplanetary-file-system-ipfs.html"
   },
   {

--- a/locales/pl-PL/pl-PL.json
+++ b/locales/pl-PL/pl-PL.json
@@ -3234,8 +3234,8 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "mesh": {
-      "term": "Mesh",
+    "consensys-mesh": {
+      "term": "Consensys Mesh",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",

--- a/locales/pl-PL/pl-PL.json
+++ b/locales/pl-PL/pl-PL.json
@@ -4312,7 +4312,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "rollups": {
+    "rollup": {
       "term": "Rollupy",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/pl-PL/pl-PL.json
+++ b/locales/pl-PL/pl-PL.json
@@ -2702,8 +2702,8 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "interplanetary-file-system-(ipfs)": {
-      "term": "InterPlanetary File System (IPFS)",
+    "interplanetary-file-system": {
+      "term": "InterPlanetary File System",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",

--- a/locales/pt-BR/directoryContents.json
+++ b/locales/pt-BR/directoryContents.json
@@ -924,7 +924,7 @@
     "link": "merkle-patricia-trie.html"
   },
   {
-    "name": "Mesh",
+    "name": "Consensys Mesh",
     "link": "mesh.html"
   },
   {

--- a/locales/pt-BR/pt-BR.json
+++ b/locales/pt-BR/pt-BR.json
@@ -3234,8 +3234,8 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "mesh": {
-      "term": "Mesh",
+    "consensys-mesh": {
+      "term": "Consensys Mesh",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",

--- a/locales/pt-BR/pt-BR.json
+++ b/locales/pt-BR/pt-BR.json
@@ -4312,8 +4312,8 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "rollups": {
-      "term": "rollups",
+    "rollup": {
+      "term": "rollup",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",

--- a/locales/pt-BR/pt-BR.json
+++ b/locales/pt-BR/pt-BR.json
@@ -2702,7 +2702,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "interplanetary-file-system-(ipfs)": {
+    "interplanetary-file-system": {
       "term": "Sistema de Arquivos Interplanetário (IPFS)",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/ro-RO/directoryContents.json
+++ b/locales/ro-RO/directoryContents.json
@@ -1756,7 +1756,7 @@
     "link": "arborele-merkle.html"
   },
   {
-    "name": "Mesh",
+    "name": "Consensys Mesh",
     "link": "mesh.html"
   },
   {

--- a/locales/ro-RO/directoryContents.json
+++ b/locales/ro-RO/directoryContents.json
@@ -1492,11 +1492,11 @@
     "link": "interoperabilitate.html"
   },
   {
-    "name": "InterPlanetary File System (IPFS)",
+    "name": "InterPlanetary File System",
     "link": "interplanetary-file-system-ipfs.html"
   },
   {
-    "name": "InterPlanetary File System (IPFS)",
+    "name": "InterPlanetary File System",
     "link": "interplanetary-file-system-ipfs.html"
   },
   {

--- a/locales/ro-RO/ro-RO.json
+++ b/locales/ro-RO/ro-RO.json
@@ -6146,8 +6146,8 @@
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
     },
-    "mesh": {
-      "term": "Mesh",
+    "consensys-mesh": {
+      "term": "Consensys Mesh",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",

--- a/locales/ro-RO/ro-RO.json
+++ b/locales/ro-RO/ro-RO.json
@@ -5222,8 +5222,8 @@
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
     },
-    "interplanetary-file-system-(ipfs)": {
-      "term": "InterPlanetary File System (IPFS)",
+    "interplanetary-file-system": {
+      "term": "InterPlanetary File System",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",
@@ -5237,7 +5237,7 @@
       "commentary": ""
     },
     "interplanetary-file-system-ipfs": {
-      "term": "InterPlanetary File System (IPFS)",
+      "term": "InterPlanetary File System",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",

--- a/locales/ro-RO/ro-RO.json
+++ b/locales/ro-RO/ro-RO.json
@@ -8064,8 +8064,8 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "rollups": {
-      "term": "rollups",
+    "rollup": {
+      "term": "rollup",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",

--- a/locales/ru-RU/directoryContents.json
+++ b/locales/ru-RU/directoryContents.json
@@ -924,7 +924,7 @@
     "link": ".html"
   },
   {
-    "name": "Mesh",
+    "name": "Consensys Mesh",
     "link": "mesh.html"
   },
   {

--- a/locales/ru-RU/directoryContents.json
+++ b/locales/ru-RU/directoryContents.json
@@ -772,7 +772,7 @@
     "link": ".html"
   },
   {
-    "name": "InterPlanetary File System (IPFS)",
+    "name": "InterPlanetary File System",
     "link": "interplanetary-file-system-ipfs.html"
   },
   {

--- a/locales/ru-RU/ru-RU.json
+++ b/locales/ru-RU/ru-RU.json
@@ -3234,8 +3234,8 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "mesh": {
-      "term": "Mesh",
+    "consensys-mesh": {
+      "term": "Consensys Mesh",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",

--- a/locales/ru-RU/ru-RU.json
+++ b/locales/ru-RU/ru-RU.json
@@ -4312,7 +4312,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "rollups": {
+    "rollup": {
       "term": "роллапы",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/ru-RU/ru-RU.json
+++ b/locales/ru-RU/ru-RU.json
@@ -2702,8 +2702,8 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "interplanetary-file-system-(ipfs)": {
-      "term": "InterPlanetary File System (IPFS)",
+    "interplanetary-file-system": {
+      "term": "InterPlanetary File System",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",

--- a/locales/th-TH/directoryContents.json
+++ b/locales/th-TH/directoryContents.json
@@ -924,7 +924,7 @@
     "link": "merkle-patricia.html"
   },
   {
-    "name": "Mesh",
+    "name": "Consensys Mesh",
     "link": "mesh.html"
   },
   {

--- a/locales/th-TH/th-TH.json
+++ b/locales/th-TH/th-TH.json
@@ -3234,8 +3234,8 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "mesh": {
-      "term": "Mesh",
+    "consensys-mesh": {
+      "term": "Consensys Mesh",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",

--- a/locales/th-TH/th-TH.json
+++ b/locales/th-TH/th-TH.json
@@ -2702,7 +2702,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "interplanetary-file-system-(ipfs)": {
+    "interplanetary-file-system": {
       "term": "ระบบไฟล์ InterPlanetary (IPFS)",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/th-TH/th-TH.json
+++ b/locales/th-TH/th-TH.json
@@ -4312,7 +4312,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "rollups": {
+    "rollup": {
       "term": "โรลล์อัป",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/tl-PH/directoryContents.json
+++ b/locales/tl-PH/directoryContents.json
@@ -772,7 +772,7 @@
     "link": "interoperability.html"
   },
   {
-    "name": "InterPlanetary File System (IPFS)",
+    "name": "InterPlanetary File System",
     "link": "interplanetary-file-system-ipfs.html"
   },
   {

--- a/locales/tl-PH/directoryContents.json
+++ b/locales/tl-PH/directoryContents.json
@@ -924,7 +924,7 @@
     "link": "merkle-patricia-trie.html"
   },
   {
-    "name": "Mesh",
+    "name": "Consensys Mesh",
     "link": "mesh.html"
   },
   {

--- a/locales/tl-PH/tl-PH.json
+++ b/locales/tl-PH/tl-PH.json
@@ -3234,8 +3234,8 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "mesh": {
-      "term": "Mesh",
+    "consensys-mesh": {
+      "term": "Consensys Mesh",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",

--- a/locales/tl-PH/tl-PH.json
+++ b/locales/tl-PH/tl-PH.json
@@ -4312,8 +4312,8 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "rollups": {
-      "term": "rollups",
+    "rollup": {
+      "term": "rollup",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",

--- a/locales/tl-PH/tl-PH.json
+++ b/locales/tl-PH/tl-PH.json
@@ -2702,8 +2702,8 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "interplanetary-file-system-(ipfs)": {
-      "term": "InterPlanetary File System (IPFS)",
+    "interplanetary-file-system": {
+      "term": "InterPlanetary File System",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",

--- a/locales/tr-TR/directoryContents.json
+++ b/locales/tr-TR/directoryContents.json
@@ -924,7 +924,7 @@
     "link": "merkle-patricia-trie.html"
   },
   {
-    "name": "Mesh",
+    "name": "Consensys Mesh",
     "link": "mesh.html"
   },
   {

--- a/locales/tr-TR/tr-TR.json
+++ b/locales/tr-TR/tr-TR.json
@@ -3234,8 +3234,8 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "mesh": {
-      "term": "Mesh",
+    "consensys-mesh": {
+      "term": "Consensys Mesh",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",

--- a/locales/tr-TR/tr-TR.json
+++ b/locales/tr-TR/tr-TR.json
@@ -2702,7 +2702,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "interplanetary-file-system-(ipfs)": {
+    "interplanetary-file-system": {
       "term": "Gezegenler Arası Dosya Sistemi (IPFS)",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/tr-TR/tr-TR.json
+++ b/locales/tr-TR/tr-TR.json
@@ -4312,7 +4312,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "rollups": {
+    "rollup": {
       "term": "rolluplar",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/uk-UA/directoryContents.json
+++ b/locales/uk-UA/directoryContents.json
@@ -1756,7 +1756,7 @@
     "link": ".html"
   },
   {
-    "name": "Mesh",
+    "name": "Consensys Mesh",
     "link": "mesh.html"
   },
   {

--- a/locales/uk-UA/directoryContents.json
+++ b/locales/uk-UA/directoryContents.json
@@ -1496,7 +1496,7 @@
     "link": "ipfs.html"
   },
   {
-    "name": "InterPlanetary File System (IPFS)",
+    "name": "InterPlanetary File System",
     "link": "interplanetary-file-system-ipfs.html"
   },
   {

--- a/locales/uk-UA/translation.json
+++ b/locales/uk-UA/translation.json
@@ -229,7 +229,7 @@
     "memory pool; mempool": "пул пам'яті; мемпул",
     "Merge (noun)": "Злиття",
     "Merkle Patricia trie": "Merkle Patricia trie",
-    "Mesh": "Mesh",
+    "Consensys Mesh": "Consensys Mesh",
     "Metadata": "Метадані",
     "MetaMask": "MetaMask",
     "MetaMask Bridge": "Мост MetaMask",

--- a/locales/uk-UA/translation.json
+++ b/locales/uk-UA/translation.json
@@ -306,7 +306,7 @@
     "Rinkeby": "Rinkeby",
     "Roadmap": "Дорожня карта",
     "Rocket Pool": "Rocket Pool",
-    "rollups": "роллапи",
+    "rollup": "роллапи",
     "Ropsten": "Ropsten",
     "RPC": "RPC",
     "rug pull": "«витягування килимка»",

--- a/locales/uk-UA/translation.json
+++ b/locales/uk-UA/translation.json
@@ -191,7 +191,7 @@
     "Inter-Blockchain Communication (IBC) Protocol": "Протокол міжблочного зв'язку (IBC)",
     "internal transaction": "внутрішня транзакція",
     "Interoperability": "Інтероперабельність",
-    "InterPlanetary File System (IPFS)": "Міжпланетна файлова система (IPFS)",
+    "InterPlanetary File System": "Міжпланетна файлова система (IPFS)",
     "IP address": "IP-адреса",
     "JSON file": "Файл JSON",
     "JSON-RPC": "JSON-RPC",

--- a/locales/uk-UA/uk-UA.json
+++ b/locales/uk-UA/uk-UA.json
@@ -6146,8 +6146,8 @@
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
     },
-    "mesh": {
-      "term": "Mesh",
+    "consensys-mesh": {
+      "term": "Consensys Mesh",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",

--- a/locales/uk-UA/uk-UA.json
+++ b/locales/uk-UA/uk-UA.json
@@ -5222,7 +5222,7 @@
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
     },
-    "interplanetary-file-system-(ipfs)": {
+    "interplanetary-file-system": {
       "term": "Міжпланетна файлова система (IPFS)",
       "partOfSpeech": "",
       "termCategory": "",
@@ -5237,7 +5237,7 @@
       "commentary": ""
     },
     "interplanetary-file-system-ipfs": {
-      "term": "InterPlanetary File System (IPFS)",
+      "term": "InterPlanetary File System",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",

--- a/locales/uk-UA/uk-UA.json
+++ b/locales/uk-UA/uk-UA.json
@@ -8064,7 +8064,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "rollups": {
+    "rollup": {
       "term": "роллапи",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/vi-VN/directoryContents.json
+++ b/locales/vi-VN/directoryContents.json
@@ -1496,7 +1496,7 @@
     "link": "h-thng-tp-phn-tn-ngang-hng-ipfs.html"
   },
   {
-    "name": "InterPlanetary File System (IPFS)",
+    "name": "InterPlanetary File System",
     "link": "interplanetary-file-system-ipfs.html"
   },
   {

--- a/locales/vi-VN/directoryContents.json
+++ b/locales/vi-VN/directoryContents.json
@@ -1756,7 +1756,7 @@
     "link": "cy-merkle.html"
   },
   {
-    "name": "Mesh",
+    "name": "Consensys Mesh",
     "link": "mesh.html"
   },
   {

--- a/locales/vi-VN/vi-VN.json
+++ b/locales/vi-VN/vi-VN.json
@@ -8064,7 +8064,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "rollups": {
+    "rollup": {
       "term": "tổng hợp",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/vi-VN/vi-VN.json
+++ b/locales/vi-VN/vi-VN.json
@@ -6146,8 +6146,8 @@
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
     },
-    "mesh": {
-      "term": "Mesh",
+    "consensys-mesh": {
+      "term": "Consensys Mesh",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",

--- a/locales/vi-VN/vi-VN.json
+++ b/locales/vi-VN/vi-VN.json
@@ -5222,7 +5222,7 @@
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
     },
-    "interplanetary-file-system-(ipfs)": {
+    "interplanetary-file-system": {
       "term": "Hệ thống tệp phân tán ngang hàng (IPFS)",
       "partOfSpeech": "",
       "termCategory": "",
@@ -5237,7 +5237,7 @@
       "commentary": ""
     },
     "interplanetary-file-system-ipfs": {
-      "term": "InterPlanetary File System (IPFS)",
+      "term": "InterPlanetary File System",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",

--- a/locales/zh-CN/directoryContents.json
+++ b/locales/zh-CN/directoryContents.json
@@ -1756,7 +1756,7 @@
     "link": ".html"
   },
   {
-    "name": "Mesh",
+    "name": "Consensys Mesh",
     "link": "mesh.html"
   },
   {

--- a/locales/zh-CN/directoryContents.json
+++ b/locales/zh-CN/directoryContents.json
@@ -1496,7 +1496,7 @@
     "link": "ipfs.html"
   },
   {
-    "name": "InterPlanetary File System (IPFS)",
+    "name": "InterPlanetary File System",
     "link": "interplanetary-file-system-ipfs.html"
   },
   {

--- a/locales/zh-CN/zh-CN.json
+++ b/locales/zh-CN/zh-CN.json
@@ -5222,7 +5222,7 @@
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
     },
-    "interplanetary-file-system-(ipfs)": {
+    "interplanetary-file-system": {
       "term": "星际文件系统（IPFS）",
       "partOfSpeech": "",
       "termCategory": "",
@@ -5237,7 +5237,7 @@
       "commentary": ""
     },
     "interplanetary-file-system-ipfs": {
-      "term": "InterPlanetary File System (IPFS)",
+      "term": "InterPlanetary File System",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",

--- a/locales/zh-CN/zh-CN.json
+++ b/locales/zh-CN/zh-CN.json
@@ -6146,8 +6146,8 @@
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
     },
-    "mesh": {
-      "term": "Mesh",
+    "consensys-mesh": {
+      "term": "Consensys Mesh",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",

--- a/locales/zh-CN/zh-CN.json
+++ b/locales/zh-CN/zh-CN.json
@@ -8064,7 +8064,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "rollups": {
+    "rollup": {
       "term": "扩容方案",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/zh-TW/directoryContents.json
+++ b/locales/zh-TW/directoryContents.json
@@ -1756,7 +1756,7 @@
     "link": ".html"
   },
   {
-    "name": "Mesh",
+    "name": "Consensys Mesh",
     "link": "mesh.html"
   },
   {

--- a/locales/zh-TW/directoryContents.json
+++ b/locales/zh-TW/directoryContents.json
@@ -1496,7 +1496,7 @@
     "link": "ipfs.html"
   },
   {
-    "name": "InterPlanetary File System (IPFS)",
+    "name": "InterPlanetary File System",
     "link": "interplanetary-file-system-ipfs.html"
   },
   {

--- a/locales/zh-TW/zh-TW.json
+++ b/locales/zh-TW/zh-TW.json
@@ -6146,8 +6146,8 @@
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
     },
-    "mesh": {
-      "term": "Mesh",
+    "consensys-mesh": {
+      "term": "Consensys Mesh",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",

--- a/locales/zh-TW/zh-TW.json
+++ b/locales/zh-TW/zh-TW.json
@@ -5222,7 +5222,7 @@
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
     },
-    "interplanetary-file-system-(ipfs)": {
+    "interplanetary-file-system": {
       "term": "星際檔案系統 (IPFS)",
       "partOfSpeech": "",
       "termCategory": "",
@@ -5237,7 +5237,7 @@
       "commentary": ""
     },
     "interplanetary-file-system-ipfs": {
-      "term": "InterPlanetary File System (IPFS)",
+      "term": "InterPlanetary File System",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",

--- a/locales/zh-TW/zh-TW.json
+++ b/locales/zh-TW/zh-TW.json
@@ -8064,7 +8064,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "rollups": {
+    "rollup": {
       "term": "交易卷",
       "partOfSpeech": "",
       "termCategory": "",


### PR DESCRIPTION
The Binance definitions all came through with title case, so every word in the term is capitalized, regardless of whether it's a proper noun or not. This does not align with our stylistic practices.

Additionally, I think some Education DAO definitions accidentally got the Binance glossary URL assigned to them as their source while I was still figuring out how to do the imports properly. This branch will track these corrections, although I might merge it and start another just to make incremental improvements.
