### PR TITLE
copy over the social banner on build

### DIFF
--- a/utils/build.js
+++ b/utils/build.js
@@ -193,7 +193,7 @@ async function build() {
     }
 
     // Copy other public assets (e.g., images, favicon) directly to 'assets'
-    ["favicon.ico", "education-dao-circle.png", "language-codes.json"].forEach(
+    ["favicon.ico", "education-dao-circle.png", "social-banner.png","language-codes.json"].forEach(
       (file) => {
         const filePath = path.join(publicDir, `assets/${file}`);
         if (fs.existsSync(filePath)) {


### PR DESCRIPTION
We need to actually copy the social banner over to the public assets directory on build, if we want it to show. still not sure this is going to work, but fingers crossed!