### PR TITLE
Less opinionated, more credibly neutral, iteration 1

### DIFF
--- a/locales/ar-001/ar-001.json
+++ b/locales/ar-001/ar-001.json
@@ -9,7 +9,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -23,7 +23,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -37,7 +37,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -51,7 +51,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -65,7 +65,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -79,7 +79,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -93,7 +93,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -107,7 +107,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/absolute-advantage",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/absolute-advantage",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -121,7 +121,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -135,7 +135,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -149,7 +149,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/active-management",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/active-management",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -163,7 +163,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/actively-validated-services-avs",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/actively-validated-services-avs",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -177,7 +177,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/ad-hoc",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/ad-hoc",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -191,7 +191,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/address",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/address",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -205,7 +205,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -219,7 +219,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -233,7 +233,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -247,7 +247,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/airdrop",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/airdrop",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -261,7 +261,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -275,7 +275,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -289,7 +289,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/algorithm",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/algorithm",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -303,7 +303,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/all-or-none-order",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/all-or-none-order",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -317,7 +317,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/all-time-high",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/all-time-high",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -331,7 +331,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/allocation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/allocation",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -345,7 +345,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/alpha",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/alpha",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -359,7 +359,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/altcoin",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/altcoin",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -373,7 +373,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -387,7 +387,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/angel-investor",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/angel-investor",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -401,7 +401,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/anti-money-laundering",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/anti-money-laundering",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -415,7 +415,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -429,7 +429,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -443,7 +443,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -457,7 +457,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/application-programming-interface",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/application-programming-interface",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -471,7 +471,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/application-specific-integrated-circuit",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/application-specific-integrated-circuit",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -485,7 +485,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/arbitrage",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/arbitrage",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -499,7 +499,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -513,7 +513,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/arc-20",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/arc-20",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -527,7 +527,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/artificial-intelligence-ai",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/artificial-intelligence-ai",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -541,7 +541,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -555,7 +555,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/asic-resistant",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/asic-resistant",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -569,7 +569,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/asking-price",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/asking-price",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -583,7 +583,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/asset-management",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/asset-management",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -597,7 +597,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -611,7 +611,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/assets-under-management-aum",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/assets-under-management-aum",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -625,7 +625,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/asynchronous",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/asynchronous",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -639,7 +639,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/atomic-swap",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/atomic-swap",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -653,7 +653,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/attack-surface",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/attack-surface",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -667,7 +667,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -681,7 +681,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/auction",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/auction",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -695,7 +695,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -709,7 +709,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/automated-market-maker-amm",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/automated-market-maker-amm",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -723,7 +723,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -737,7 +737,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -751,7 +751,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -765,7 +765,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/b-tokens",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/b-tokens",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -779,7 +779,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/bags",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/bags",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -793,7 +793,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -807,7 +807,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/beacon-chain",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/beacon-chain",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -821,7 +821,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/bear-market",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/bear-market",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -835,7 +835,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/benchmark",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/benchmark",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -849,7 +849,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/bep-1155",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/bep-1155",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -863,7 +863,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/bep-20",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/bep-20",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -877,7 +877,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/bep-721",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/bep-721",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -891,7 +891,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/bep-95",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/bep-95",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -905,7 +905,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -919,7 +919,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/beta-coefficient",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/beta-coefficient",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -933,7 +933,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/beta-release",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/beta-release",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -947,7 +947,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/bid-ask-spread",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/bid-ask-spread",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -961,7 +961,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/bid-price",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/bid-price",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -975,7 +975,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -989,7 +989,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/binance-blockchain-charity-foundation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/binance-blockchain-charity-foundation",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1003,7 +1003,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/binance-ecosystem-fund",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/binance-ecosystem-fund",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1017,7 +1017,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/binancian",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/binancian",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1031,7 +1031,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/bitcoin",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/bitcoin",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1045,7 +1045,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/bitcoin-core",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/bitcoin-core",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1059,7 +1059,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/bitcoin-dominance",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/bitcoin-dominance",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1073,7 +1073,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/bitcoin-maximalists",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/bitcoin-maximalists",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1087,7 +1087,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/bitcoin-pizza",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/bitcoin-pizza",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1101,7 +1101,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/black-swan-event",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/black-swan-event",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1115,7 +1115,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/block",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/block",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1129,7 +1129,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/block-explorer",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/block-explorer",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1143,7 +1143,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/block-header",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/block-header",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1157,7 +1157,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/block-height",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/block-height",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1171,7 +1171,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/block-reward",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/block-reward",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1185,7 +1185,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1199,7 +1199,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1213,7 +1213,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/blockchain",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/blockchain",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1227,7 +1227,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1241,7 +1241,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1255,7 +1255,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/bloom-filter",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/bloom-filter",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1269,7 +1269,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/blue-chip-token",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/blue-chip-token",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1283,7 +1283,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/bnb",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/bnb",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1297,7 +1297,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1311,7 +1311,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/bnsol",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/bnsol",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1325,7 +1325,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/bollinger-bands",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/bollinger-bands",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1339,7 +1339,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/bond",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/bond",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1353,7 +1353,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/bounty",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/bounty",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1367,7 +1367,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1381,7 +1381,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1395,7 +1395,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/brc-20-tokens",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/brc-20-tokens",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1409,7 +1409,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/break-even-point",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/break-even-point",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1423,7 +1423,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/breakeven-multiple",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/breakeven-multiple",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1437,7 +1437,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/breakout",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/breakout",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1451,7 +1451,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1465,7 +1465,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/bscscan",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/bscscan",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1479,7 +1479,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1493,7 +1493,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/btc-wallet-address",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/btc-wallet-address",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1507,7 +1507,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/buidl",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/buidl",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1521,7 +1521,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/bull-market",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/bull-market",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1535,7 +1535,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/burner-wallet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/burner-wallet",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1549,7 +1549,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/buy-wall",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/buy-wall",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1563,7 +1563,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1577,7 +1577,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1591,7 +1591,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1605,7 +1605,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/candidate-block",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/candidate-block",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1619,7 +1619,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/candlestick",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/candlestick",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1633,7 +1633,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/capitulation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/capitulation",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1647,7 +1647,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1661,7 +1661,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/censorship-resistance",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/censorship-resistance",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1675,7 +1675,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/central-bank",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/central-bank",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1689,7 +1689,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/central-bank-digital-currency-cbdc",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/central-bank-digital-currency-cbdc",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1703,7 +1703,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/central-processing-unit",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/central-processing-unit",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1717,7 +1717,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/centralized",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/centralized",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1731,7 +1731,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/centralized-exchange",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/centralized-exchange",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1745,7 +1745,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1759,7 +1759,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1773,7 +1773,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/chatgpt",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/chatgpt",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1787,7 +1787,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1801,7 +1801,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/cipher",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/cipher",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1815,7 +1815,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/circulating-supply",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/circulating-supply",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1829,7 +1829,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1843,7 +1843,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/cloud",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/cloud",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1857,7 +1857,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1871,7 +1871,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/coin",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/coin",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1885,7 +1885,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1899,7 +1899,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1913,7 +1913,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/cold-storage",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/cold-storage",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1927,7 +1927,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1941,7 +1941,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/collateral",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/collateral",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1955,7 +1955,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/colocation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/colocation",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1969,7 +1969,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/commodity-futures-trading-commission",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/commodity-futures-trading-commission",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1983,7 +1983,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1997,7 +1997,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2011,7 +2011,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/compound-interest",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/compound-interest",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2025,7 +2025,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2039,7 +2039,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/confirmation-time",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/confirmation-time",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2053,7 +2053,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/confluence",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/confluence",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2067,7 +2067,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2081,7 +2081,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/consensus-algorithm",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/consensus-algorithm",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2095,7 +2095,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2109,7 +2109,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2123,7 +2123,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2137,7 +2137,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2151,7 +2151,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2165,7 +2165,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/consumer-price-index-(cpi)",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/consumer-price-index-(cpi)",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2179,7 +2179,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/contango-and-backwardation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/contango-and-backwardation",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2193,7 +2193,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2207,7 +2207,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2221,7 +2221,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2235,7 +2235,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/copy-trading",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/copy-trading",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2249,7 +2249,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/counterparty-risk",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/counterparty-risk",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2263,7 +2263,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/credentials",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/credentials",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2277,7 +2277,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/cross-chain-bridges",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/cross-chain-bridges",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2291,7 +2291,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2305,7 +2305,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2319,7 +2319,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2333,7 +2333,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2347,7 +2347,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/crypto-etfs",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/crypto-etfs",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2361,7 +2361,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/crypto-fear-and-greed-index",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/crypto-fear-and-greed-index",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2375,7 +2375,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2389,7 +2389,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/crypto-protocol",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/crypto-protocol",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2403,7 +2403,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2417,7 +2417,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/crypto-winter",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/crypto-winter",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2431,7 +2431,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2445,7 +2445,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/cryptocurrency",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/cryptocurrency",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2459,7 +2459,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2473,7 +2473,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/cryptography",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/cryptography",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2487,7 +2487,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2501,7 +2501,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/custody",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/custody",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2515,7 +2515,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2529,7 +2529,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/daemon",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/daemon",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2543,7 +2543,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2557,7 +2557,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/danksharding",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/danksharding",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2571,7 +2571,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2585,7 +2585,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2599,7 +2599,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2613,7 +2613,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/dead-cat-bounce",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/dead-cat-bounce",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2627,7 +2627,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/death-cross",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/death-cross",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2641,7 +2641,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2655,7 +2655,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/decentralized-application",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/decentralized-application",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2669,7 +2669,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/decentralized-autonomous-cooperative",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/decentralized-autonomous-cooperative",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2683,7 +2683,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/decentralized-autonomous-organization",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/decentralized-autonomous-organization",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2697,7 +2697,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/decentralized-exchange",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/decentralized-exchange",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2711,7 +2711,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2725,7 +2725,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/decentralized-indexes",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/decentralized-indexes",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2739,7 +2739,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2753,7 +2753,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/decryption",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/decryption",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2767,7 +2767,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/deep-web",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/deep-web",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2781,7 +2781,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2795,7 +2795,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2809,7 +2809,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/delisting",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/delisting",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2823,7 +2823,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2837,7 +2837,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/depeg",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/depeg",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2851,7 +2851,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2865,7 +2865,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/depression",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/depression",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2879,7 +2879,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2893,7 +2893,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/design-flaw-attack",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/design-flaw-attack",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2907,7 +2907,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2921,7 +2921,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2935,7 +2935,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2949,7 +2949,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2963,7 +2963,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/diamond-hands",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/diamond-hands",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2977,7 +2977,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/difficulty",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/difficulty",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2991,7 +2991,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/difficulty-bomb",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/difficulty-bomb",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3005,7 +3005,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3019,7 +3019,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3033,7 +3033,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/digital-signature",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/digital-signature",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3047,7 +3047,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3061,7 +3061,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/direct-market-access-dma",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/direct-market-access-dma",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3075,7 +3075,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3089,7 +3089,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/divergence",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/divergence",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3103,7 +3103,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/diversification",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/diversification",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3117,7 +3117,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3131,7 +3131,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/do-your-own-research",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/do-your-own-research",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3145,7 +3145,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/dollar-cost-averaging",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/dollar-cost-averaging",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3159,7 +3159,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/dot-plot",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/dot-plot",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3173,7 +3173,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3187,7 +3187,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/double-spending",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/double-spending",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3201,7 +3201,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/eclipse-attack",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/eclipse-attack",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3215,7 +3215,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3229,7 +3229,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3243,7 +3243,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/efficient-market-hypothesis-emh",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/efficient-market-hypothesis-emh",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3257,7 +3257,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/eigenlayer",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/eigenlayer",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3271,7 +3271,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/eip",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/eip",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3285,7 +3285,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3299,7 +3299,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/eip-3074",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/eip-3074",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3313,7 +3313,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/eip-4844",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/eip-4844",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3327,7 +3327,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/eip-7251",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/eip-7251",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3341,7 +3341,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/eip-7702",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/eip-7702",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3355,7 +3355,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/elasticity",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/elasticity",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3369,7 +3369,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3383,7 +3383,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/encryption",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/encryption",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3397,7 +3397,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/endogenous-variable",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/endogenous-variable",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3411,7 +3411,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3425,7 +3425,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3439,7 +3439,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3453,7 +3453,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3467,7 +3467,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/erc-1155",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/erc-1155",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3481,7 +3481,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/erc-20",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/erc-20",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3495,7 +3495,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/erc-404",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/erc-404",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3509,7 +3509,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/erc-721",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/erc-721",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3523,7 +3523,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/etf",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/etf",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3537,7 +3537,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3551,7 +3551,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3565,7 +3565,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3579,7 +3579,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3593,7 +3593,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/ethereum-classic",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/ethereum-classic",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3607,7 +3607,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/ethereum-foundation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/ethereum-foundation",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3621,7 +3621,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3635,7 +3635,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3649,7 +3649,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3663,7 +3663,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3677,7 +3677,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/ethereum-virtual-machine-evm",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/ethereum-virtual-machine-evm",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3691,7 +3691,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3705,7 +3705,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3719,7 +3719,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3733,7 +3733,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/exchange",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/exchange",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3747,7 +3747,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3761,7 +3761,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3775,7 +3775,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/exogenous-variable",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/exogenous-variable",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3789,7 +3789,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/exponential-moving-average-ema",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/exponential-moving-average-ema",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3803,7 +3803,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/externally-owned-account-eoa",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/externally-owned-account-eoa",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3817,7 +3817,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/fakeout",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/fakeout",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3831,7 +3831,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/falling-knife",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/falling-knife",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3845,7 +3845,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/fan-tokens",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/fan-tokens",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3859,7 +3859,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3873,7 +3873,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3887,7 +3887,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3901,7 +3901,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/fear-of-missing-out",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/fear-of-missing-out",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3915,7 +3915,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/fear-uncertainty-and-doubt",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/fear-uncertainty-and-doubt",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3929,7 +3929,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/fiat",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/fiat",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3943,7 +3943,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3957,7 +3957,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/fibonacci-retracement",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/fibonacci-retracement",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3971,7 +3971,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/fill-or-kill-order",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/fill-or-kill-order",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3985,7 +3985,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/finality",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/finality",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3999,7 +3999,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4013,7 +4013,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4027,7 +4027,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4041,7 +4041,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4055,7 +4055,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4069,7 +4069,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4083,7 +4083,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/first-mover-advantage",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/first-mover-advantage",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4097,7 +4097,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/fiscal-policy",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/fiscal-policy",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4111,7 +4111,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/flappening",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/flappening",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4125,7 +4125,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/flashbots",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/flashbots",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4139,7 +4139,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/flippening",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/flippening",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4153,7 +4153,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/flow-variable",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/flow-variable",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4167,7 +4167,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/forced-liquidation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/forced-liquidation",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4181,7 +4181,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/forex-fx",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/forex-fx",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4195,7 +4195,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/fork",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/fork",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4209,7 +4209,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/formal-verification",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/formal-verification",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4223,7 +4223,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4237,7 +4237,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/fraud-proof",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/fraud-proof",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4251,7 +4251,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/fren",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/fren",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4265,7 +4265,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4279,7 +4279,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/full-node",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/full-node",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4293,7 +4293,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/fully-diluted-valuation-fdv",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/fully-diluted-valuation-fdv",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4307,7 +4307,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/fundamental-analysis",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/fundamental-analysis",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4321,7 +4321,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/funding-fees",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/funding-fees",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4335,7 +4335,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/fungibility",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/fungibility",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4349,7 +4349,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/futures-contract",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/futures-contract",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4363,7 +4363,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/gamefi",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/gamefi",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4377,7 +4377,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4391,7 +4391,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/gas",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/gas",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4405,7 +4405,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4419,7 +4419,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/gas-limit",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/gas-limit",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4433,7 +4433,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4447,7 +4447,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4461,7 +4461,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4475,7 +4475,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/gdp-deflator",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/gdp-deflator",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4489,7 +4489,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/general-public-license",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/general-public-license",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4503,7 +4503,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/genesis-block",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/genesis-block",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4517,7 +4517,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4531,7 +4531,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/github",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/github",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4545,7 +4545,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/gm-good-morning",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/gm-good-morning",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4559,7 +4559,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4573,7 +4573,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/golden-cross",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/golden-cross",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4587,7 +4587,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/golden-ratio",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/golden-ratio",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4601,7 +4601,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/goldilocks",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/goldilocks",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4615,7 +4615,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/gossip-protocol",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/gossip-protocol",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4629,7 +4629,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4643,7 +4643,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/gross-domestic-product-gdp",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/gross-domestic-product-gdp",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4657,7 +4657,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4671,7 +4671,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/gwei",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/gwei",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4685,7 +4685,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/hackathon",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/hackathon",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4699,7 +4699,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/hacker",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/hacker",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4713,7 +4713,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/haha-money-printer-go-brrrrr",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/haha-money-printer-go-brrrrr",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4727,7 +4727,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/halving",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/halving",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4741,7 +4741,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/hard-cap",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/hard-cap",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4755,7 +4755,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4769,7 +4769,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/hard-landing",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/hard-landing",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4783,7 +4783,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4797,7 +4797,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4811,7 +4811,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/hash",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/hash",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4825,7 +4825,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/hash-rate",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/hash-rate",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4839,7 +4839,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/hashed-timelock-contract",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/hashed-timelock-contract",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4853,7 +4853,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4867,7 +4867,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/herd-instinct",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/herd-instinct",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4881,7 +4881,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4895,7 +4895,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/high-frequency-trading-hft",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/high-frequency-trading-hft",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4909,7 +4909,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/hodl",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/hodl",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4923,7 +4923,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/honeypot",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/honeypot",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4937,7 +4937,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4951,7 +4951,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4965,7 +4965,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4979,7 +4979,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4993,7 +4993,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5007,7 +5007,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/iceberg-order",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/iceberg-order",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5021,7 +5021,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5035,7 +5035,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5049,7 +5049,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/immutability",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/immutability",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5063,7 +5063,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/index-funds",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/index-funds",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5077,7 +5077,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5091,7 +5091,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/initial-coin-offering",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/initial-coin-offering",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5105,7 +5105,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/initial-dex-offering-ido",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/initial-dex-offering-ido",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5119,7 +5119,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/initial-exchange-offering",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/initial-exchange-offering",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5133,7 +5133,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/initial-public-offering",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/initial-public-offering",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5147,7 +5147,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/inscription",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/inscription",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5161,7 +5161,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5175,7 +5175,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/integrated-circuit",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/integrated-circuit",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5189,7 +5189,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/interest-rates",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/interest-rates",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5203,7 +5203,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5217,7 +5217,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/interoperability",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/interoperability",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5231,7 +5231,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5245,7 +5245,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/interplanetary-file-system-ipfs",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/interplanetary-file-system-ipfs",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5259,7 +5259,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/iou",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/iou",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5273,7 +5273,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5287,7 +5287,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5301,7 +5301,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5315,7 +5315,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/isolated-margin",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/isolated-margin",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5329,7 +5329,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/issuance",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/issuance",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5343,7 +5343,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5357,7 +5357,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5371,7 +5371,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/keccak",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/keccak",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5385,7 +5385,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5399,7 +5399,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/know-your-customer",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/know-your-customer",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5413,7 +5413,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5427,7 +5427,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5441,7 +5441,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5455,7 +5455,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5469,7 +5469,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/laspeyres-index",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/laspeyres-index",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5483,7 +5483,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/latency",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/latency",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5497,7 +5497,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5511,7 +5511,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5525,7 +5525,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/law-of-demand",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/law-of-demand",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5539,7 +5539,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5553,7 +5553,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/layer-2",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/layer-2",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5567,7 +5567,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/ledger",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/ledger",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5581,7 +5581,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5595,7 +5595,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5609,7 +5609,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/leveraged-tokens",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/leveraged-tokens",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5623,7 +5623,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/library",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/library",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5637,7 +5637,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5651,7 +5651,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5665,7 +5665,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/lightning-network",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/lightning-network",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5679,7 +5679,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/limit-order",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/limit-order",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5693,7 +5693,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5707,7 +5707,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/linux",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/linux",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5721,7 +5721,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/liquid-staking",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/liquid-staking",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5735,7 +5735,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/liquid-staking-token-lst",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/liquid-staking-token-lst",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5749,7 +5749,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5763,7 +5763,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/liquidity",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/liquidity",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5777,7 +5777,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/liquidity-crisis",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/liquidity-crisis",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5791,7 +5791,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5805,7 +5805,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/liquidity-provider",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/liquidity-provider",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5819,7 +5819,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/liquidity-ratios",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/liquidity-ratios",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5833,7 +5833,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5847,7 +5847,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/listing",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/listing",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5861,7 +5861,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/mainnet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/mainnet",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5875,7 +5875,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/mainnet-swap",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/mainnet-swap",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5889,7 +5889,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/maker",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/maker",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5903,7 +5903,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5917,7 +5917,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/malware",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/malware",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5931,7 +5931,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/margin-trading",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/margin-trading",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5945,7 +5945,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5959,7 +5959,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/market-capitalization",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/market-capitalization",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5973,7 +5973,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/market-momentum",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/market-momentum",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5987,7 +5987,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/market-order",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/market-order",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6001,7 +6001,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/masternode",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/masternode",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6015,7 +6015,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/matching-engine",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/matching-engine",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6029,7 +6029,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6043,7 +6043,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/maximum-supply",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/maximum-supply",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6057,7 +6057,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6071,7 +6071,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/mempool",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/mempool",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6085,7 +6085,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6099,7 +6099,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6113,7 +6113,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/merged-mining",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/merged-mining",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6127,7 +6127,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6141,7 +6141,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/merkle-tree",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/merkle-tree",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6155,7 +6155,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6169,7 +6169,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/metadata",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/metadata",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6183,7 +6183,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6197,7 +6197,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6211,7 +6211,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6225,7 +6225,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6239,7 +6239,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6253,7 +6253,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/metaverse",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/metaverse",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6267,7 +6267,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6281,7 +6281,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6295,7 +6295,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/microtransactions",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/microtransactions",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6309,7 +6309,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6323,7 +6323,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6337,7 +6337,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/mining",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/mining",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6351,7 +6351,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/mining-farm",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/mining-farm",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6365,7 +6365,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/mint",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/mint",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6379,7 +6379,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6393,7 +6393,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6407,7 +6407,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6421,7 +6421,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/monetary-policy",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/monetary-policy",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6435,7 +6435,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/money-markets",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/money-markets",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6449,7 +6449,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/monitoring-tag",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/monitoring-tag",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6463,7 +6463,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/moon",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/moon",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6477,7 +6477,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6491,7 +6491,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/moving-average-envelopes",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/moving-average-envelopes",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6505,7 +6505,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/moving-average-ribbon",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/moving-average-ribbon",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6519,7 +6519,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/mt-gox",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/mt-gox",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6533,7 +6533,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6547,7 +6547,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6561,7 +6561,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/multisignature",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/multisignature",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6575,7 +6575,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/nakamoto-consensus",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/nakamoto-consensus",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6589,7 +6589,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6603,7 +6603,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/net-asset-value-nav",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/net-asset-value-nav",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6617,7 +6617,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6631,7 +6631,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6645,7 +6645,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6659,7 +6659,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6673,7 +6673,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6687,7 +6687,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6701,7 +6701,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/nft-floor-prices",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/nft-floor-prices",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6715,7 +6715,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/nft-mystery-boxes",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/nft-mystery-boxes",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6729,7 +6729,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/ngmi",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/ngmi",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6743,7 +6743,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6757,7 +6757,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/node",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/node",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6771,7 +6771,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6785,7 +6785,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/non-fungible-token-nft",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/non-fungible-token-nft",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6799,7 +6799,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/nonce",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/nonce",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6813,7 +6813,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/oco-order",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/oco-order",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6827,7 +6827,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/off-chain",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/off-chain",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6841,7 +6841,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6855,7 +6855,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/offline-signing-orchestrator-oso",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/offline-signing-orchestrator-oso",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6869,7 +6869,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/offshore-account",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/offshore-account",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6883,7 +6883,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6897,7 +6897,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/on-chain",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/on-chain",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6911,7 +6911,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6925,7 +6925,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6939,7 +6939,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/opbnb",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/opbnb",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6953,7 +6953,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/open-source-software-oss",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/open-source-software-oss",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6967,7 +6967,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6981,7 +6981,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6995,7 +6995,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/opportunity-cost",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/opportunity-cost",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7009,7 +7009,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7023,7 +7023,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7037,7 +7037,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/oracle",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/oracle",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7051,7 +7051,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/orc-20-tokens",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/orc-20-tokens",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7065,7 +7065,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/order-book",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/order-book",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7079,7 +7079,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/ordinals",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/ordinals",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7093,7 +7093,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/orphan-block",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/orphan-block",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7107,7 +7107,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7121,7 +7121,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7135,7 +7135,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/pancakeswap",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/pancakeswap",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7149,7 +7149,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/paper-wallet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/paper-wallet",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7163,7 +7163,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/parallelization",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/parallelization",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7177,7 +7177,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7191,7 +7191,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7205,7 +7205,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/passive-management",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/passive-management",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7219,7 +7219,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7233,7 +7233,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7247,7 +7247,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7261,7 +7261,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7275,7 +7275,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/peer-to-peer",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/peer-to-peer",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7289,7 +7289,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/pegged-currency",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/pegged-currency",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7303,7 +7303,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7317,7 +7317,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/permissionless-blockchain",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/permissionless-blockchain",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7331,7 +7331,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/phishing",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/phishing",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7345,7 +7345,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7359,7 +7359,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/plasma",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/plasma",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7373,7 +7373,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7387,7 +7387,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/polkadot-crowdloan",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/polkadot-crowdloan",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7401,7 +7401,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7415,7 +7415,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/ponzi-scheme",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/ponzi-scheme",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7429,7 +7429,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7443,7 +7443,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7457,7 +7457,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/premining",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/premining",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7471,7 +7471,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/price-action",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/price-action",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7485,7 +7485,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/prisoners-dilemma",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/prisoners-dilemma",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7499,7 +7499,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7513,7 +7513,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7527,7 +7527,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/private-key",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/private-key",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7541,7 +7541,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/private-sale",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/private-sale",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7555,7 +7555,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/progressive-web-application",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/progressive-web-application",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7569,7 +7569,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/proof-of-attendance-protocol-poap",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/proof-of-attendance-protocol-poap",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7583,7 +7583,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/proof-of-reserves-por",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/proof-of-reserves-por",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7597,7 +7597,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/proof-of-stake",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/proof-of-stake",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7611,7 +7611,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/proof-of-staked-authority-posa",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/proof-of-staked-authority-posa",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7625,7 +7625,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/proof-of-work",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/proof-of-work",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7639,7 +7639,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/proposer-builder-separation-pbs",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/proposer-builder-separation-pbs",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7653,7 +7653,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/proto-danksharding",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/proto-danksharding",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7667,7 +7667,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7681,7 +7681,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/pseudorandom",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/pseudorandom",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7695,7 +7695,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7709,7 +7709,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7723,7 +7723,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/public-key",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/public-key",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7737,7 +7737,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7751,7 +7751,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/pump-and-dump",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/pump-and-dump",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7765,7 +7765,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7779,7 +7779,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/quantitative-easing-qe",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/quantitative-easing-qe",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7793,7 +7793,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/quantitative-tightening-qt",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/quantitative-tightening-qt",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7807,7 +7807,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/quantum-computing",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/quantum-computing",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7821,7 +7821,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7835,7 +7835,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/race-attack",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/race-attack",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7849,7 +7849,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/ransomware",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/ransomware",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7863,7 +7863,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7877,7 +7877,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/real-world-assets-rwas",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/real-world-assets-rwas",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7891,7 +7891,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/recession",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/recession",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7905,7 +7905,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/recursive-inscription",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/recursive-inscription",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7919,7 +7919,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/rekt",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/rekt",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7933,7 +7933,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/relative-strength-index",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/relative-strength-index",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7947,7 +7947,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7961,7 +7961,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7975,7 +7975,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/resistance",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/resistance",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7989,7 +7989,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/return-on-investment",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/return-on-investment",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8003,7 +8003,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/revenge-trading",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/revenge-trading",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8017,7 +8017,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8031,7 +8031,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/risk-premium",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/risk-premium",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8045,7 +8045,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/roadmap",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/roadmap",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8059,7 +8059,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8073,7 +8073,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8087,7 +8087,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8101,7 +8101,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/routing-attack",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/routing-attack",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8115,7 +8115,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8129,7 +8129,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/rug-pull",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/rug-pull",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8143,7 +8143,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8157,7 +8157,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/sahm-rule",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/sahm-rule",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8171,7 +8171,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8185,7 +8185,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8199,7 +8199,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/sandwich-trading",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/sandwich-trading",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8213,7 +8213,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8227,7 +8227,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/satoshi",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/satoshi",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8241,7 +8241,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/satoshi-nakamoto",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/satoshi-nakamoto",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8255,7 +8255,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8269,7 +8269,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8283,7 +8283,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8297,7 +8297,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8311,7 +8311,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8325,7 +8325,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8339,7 +8339,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8353,7 +8353,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/secure-asset-fund-for-users",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/secure-asset-fund-for-users",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8367,7 +8367,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/securities-and-exchange-commission",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/securities-and-exchange-commission",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8381,7 +8381,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/security-audit",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/security-audit",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8395,7 +8395,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8409,7 +8409,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8423,7 +8423,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/security-token-offering-sto",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/security-token-offering-sto",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8437,7 +8437,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/seed-phrase",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/seed-phrase",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8451,7 +8451,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/seed-tag",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/seed-tag",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8465,7 +8465,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/segregated-witness",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/segregated-witness",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8479,7 +8479,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8493,7 +8493,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8507,7 +8507,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/selfish-mining",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/selfish-mining",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8521,7 +8521,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/sell-wall",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/sell-wall",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8535,7 +8535,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/sentiment",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/sentiment",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8549,7 +8549,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8563,7 +8563,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8577,7 +8577,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8591,7 +8591,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8605,7 +8605,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/sharding",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/sharding",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8619,7 +8619,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/sharpe-ratio",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/sharpe-ratio",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8633,7 +8633,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8647,7 +8647,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8661,7 +8661,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/sidechains",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/sidechains",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8675,7 +8675,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/simple-moving-average-sma",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/simple-moving-average-sma",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8689,7 +8689,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/slashing",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/slashing",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8703,7 +8703,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8717,7 +8717,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/slippage",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/slippage",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8731,7 +8731,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8745,7 +8745,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/smart-contract",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/smart-contract",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8759,7 +8759,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/smart-contract-wallet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/smart-contract-wallet",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8773,7 +8773,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/snapshot",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/snapshot",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8787,7 +8787,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/social-recovery-wallet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/social-recovery-wallet",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8801,7 +8801,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/social-trading",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/social-trading",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8815,7 +8815,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/socialfi",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/socialfi",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8829,7 +8829,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8843,7 +8843,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/soft-landing",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/soft-landing",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8857,7 +8857,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/solidity",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/solidity",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8871,7 +8871,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/source-code",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/source-code",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8885,7 +8885,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/spl",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/spl",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8899,7 +8899,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/src-20-tokens",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/src-20-tokens",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8913,7 +8913,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/stablecoin",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/stablecoin",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8927,7 +8927,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/stagflation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/stagflation",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8941,7 +8941,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8955,7 +8955,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8969,7 +8969,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/staking-pool",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/staking-pool",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8983,7 +8983,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8997,7 +8997,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/state-channel",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/state-channel",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9011,7 +9011,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9025,7 +9025,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/steth",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/steth",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9039,7 +9039,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9053,7 +9053,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/stock-variable",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/stock-variable",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9067,7 +9067,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/store-of-value",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/store-of-value",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9081,7 +9081,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9095,7 +9095,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/supercomputer",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/supercomputer",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9109,7 +9109,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/supply-chain",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/supply-chain",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9123,7 +9123,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/support",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/support",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9137,7 +9137,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9151,7 +9151,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/sybil-attack",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/sybil-attack",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9165,7 +9165,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9179,7 +9179,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/taker",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/taker",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9193,7 +9193,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/tank",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/tank",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9207,7 +9207,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9221,7 +9221,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9235,7 +9235,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/testnet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/testnet",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9249,7 +9249,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9263,7 +9263,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9277,7 +9277,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9291,7 +9291,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/ticker",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/ticker",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9305,7 +9305,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/ticker-symbol",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/ticker-symbol",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9319,7 +9319,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/token",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/token",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9333,7 +9333,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/token-generation-event-tge",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/token-generation-event-tge",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9347,7 +9347,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/token-lockup",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/token-lockup",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9361,7 +9361,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/token-merge",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/token-merge",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9375,7 +9375,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/token-sale",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/token-sale",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9389,7 +9389,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9403,7 +9403,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/token-standards",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/token-standards",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9417,7 +9417,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/tokenization",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/tokenization",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9431,7 +9431,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/tokenomics",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/tokenomics",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9445,7 +9445,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/total-supply",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/total-supply",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9459,7 +9459,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/total-value-locked-tvl",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/total-value-locked-tvl",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9473,7 +9473,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/tradfi",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/tradfi",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9487,7 +9487,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9501,7 +9501,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9515,7 +9515,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9529,7 +9529,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/transaction-id",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/transaction-id",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9543,7 +9543,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9557,7 +9557,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/transactions-per-second-tps",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/transactions-per-second-tps",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9571,7 +9571,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9585,7 +9585,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/treasury-bills-t-bills",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/treasury-bills-t-bills",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9599,7 +9599,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9613,7 +9613,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/trueusd-tusd",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/trueusd-tusd",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9627,7 +9627,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9641,7 +9641,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/trustless",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/trustless",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9655,7 +9655,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/turing-complete",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/turing-complete",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9669,7 +9669,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9683,7 +9683,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9697,7 +9697,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9711,7 +9711,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/understanding-cz-s-number-4",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/understanding-cz-s-number-4",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9725,7 +9725,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9739,7 +9739,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9753,7 +9753,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/unit-of-account",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/unit-of-account",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9767,7 +9767,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9781,7 +9781,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/unspent-transaction-output-utxo",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/unspent-transaction-output-utxo",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9795,7 +9795,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9809,7 +9809,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9823,7 +9823,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9837,7 +9837,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9851,7 +9851,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/user-interface",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/user-interface",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9865,7 +9865,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/utility-token",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/utility-token",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9879,7 +9879,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9893,7 +9893,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9907,7 +9907,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9921,7 +9921,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/verification-code",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/verification-code",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9935,7 +9935,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9949,7 +9949,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9963,7 +9963,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/virtual-machine",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/virtual-machine",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9977,7 +9977,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/vladimir-club",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/vladimir-club",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9991,7 +9991,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/volatility",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/volatility",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10005,7 +10005,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/volume",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/volume",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10019,7 +10019,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/wagmi",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/wagmi",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10033,7 +10033,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/wallet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/wallet",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10047,7 +10047,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10061,7 +10061,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10075,7 +10075,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/wash-trading",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/wash-trading",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10089,7 +10089,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/weak-hands",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/weak-hands",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10103,7 +10103,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/weak-subjectivity",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/weak-subjectivity",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10117,7 +10117,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/web-1",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/web-1",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10131,7 +10131,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10145,7 +10145,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10159,7 +10159,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10173,7 +10173,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10187,7 +10187,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10201,7 +10201,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/wei",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/wei",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10215,7 +10215,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/weighted-moving-average-wma",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/weighted-moving-average-wma",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10229,7 +10229,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/whale",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/whale",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10243,7 +10243,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/whiskers",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/whiskers",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10257,7 +10257,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/whitelist",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/whitelist",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10271,7 +10271,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10285,7 +10285,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/wick",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/wick",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10299,7 +10299,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/win-rate",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/win-rate",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10313,7 +10313,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/wrapped-ether",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/wrapped-ether",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10327,7 +10327,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10341,7 +10341,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/wyckoff",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/wyckoff",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10355,7 +10355,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10369,7 +10369,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10383,7 +10383,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10397,7 +10397,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10411,7 +10411,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/yield-farming",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/yield-farming",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10425,7 +10425,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10439,7 +10439,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10453,7 +10453,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/zero-knowledge-proofs",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/zero-knowledge-proofs",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10467,7 +10467,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10481,7 +10481,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/zk-rollup",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/zk-rollup",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10495,7 +10495,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/zk-snarks",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/zk-snarks",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10509,7 +10509,7 @@
       "definitionSource": "https://academy.binance.com/ar/glossary/zk-starks",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ar/glossary/zk-starks",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""

--- a/locales/ar-001/ar-001.json
+++ b/locales/ar-001/ar-001.json
@@ -9576,7 +9576,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "treasury-bills-t-bills": {
+    "treasury-bills": {
       "term": "سندات الخزانة",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/de-DE/de-DE.json
+++ b/locales/de-DE/de-DE.json
@@ -9,7 +9,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -23,7 +23,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -37,7 +37,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -51,7 +51,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -65,7 +65,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -79,7 +79,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -93,7 +93,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -107,7 +107,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -121,7 +121,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -135,7 +135,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -149,7 +149,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -163,7 +163,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -177,7 +177,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -191,7 +191,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -205,7 +205,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -219,7 +219,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -233,7 +233,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -247,7 +247,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -261,7 +261,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -275,7 +275,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -289,7 +289,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -303,7 +303,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -317,7 +317,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -331,7 +331,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -345,7 +345,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -359,7 +359,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -373,7 +373,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -387,7 +387,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -401,7 +401,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -415,7 +415,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -429,7 +429,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -443,7 +443,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -457,7 +457,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -471,7 +471,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -485,7 +485,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -499,7 +499,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -513,7 +513,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -527,7 +527,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -541,7 +541,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -555,7 +555,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -569,7 +569,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -583,7 +583,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -597,7 +597,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -611,7 +611,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -625,7 +625,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -639,7 +639,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -653,7 +653,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -667,7 +667,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -681,7 +681,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -695,7 +695,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -709,7 +709,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -723,7 +723,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -737,7 +737,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -751,7 +751,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -765,7 +765,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -779,7 +779,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -793,7 +793,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -807,7 +807,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -821,7 +821,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -835,7 +835,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -849,7 +849,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -863,7 +863,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -877,7 +877,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -891,7 +891,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -905,7 +905,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -919,7 +919,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -933,7 +933,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -947,7 +947,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -961,7 +961,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -975,7 +975,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -989,7 +989,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1003,7 +1003,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1017,7 +1017,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1031,7 +1031,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1045,7 +1045,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1059,7 +1059,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1073,7 +1073,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1087,7 +1087,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1101,7 +1101,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1115,7 +1115,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1129,7 +1129,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1143,7 +1143,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1157,7 +1157,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1171,7 +1171,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1185,7 +1185,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1199,7 +1199,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1213,7 +1213,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1227,7 +1227,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1241,7 +1241,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1255,7 +1255,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1269,7 +1269,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1283,7 +1283,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1297,7 +1297,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1311,7 +1311,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1325,7 +1325,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1339,7 +1339,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1353,7 +1353,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1367,7 +1367,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1381,7 +1381,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1395,7 +1395,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1409,7 +1409,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1423,7 +1423,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1437,7 +1437,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1451,7 +1451,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1465,7 +1465,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1479,7 +1479,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1493,7 +1493,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1507,7 +1507,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1521,7 +1521,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1535,7 +1535,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1549,7 +1549,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1563,7 +1563,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1577,7 +1577,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1591,7 +1591,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1605,7 +1605,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1619,7 +1619,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1633,7 +1633,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1647,7 +1647,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1661,7 +1661,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1675,7 +1675,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1689,7 +1689,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1703,7 +1703,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1717,7 +1717,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1731,7 +1731,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1745,7 +1745,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1759,7 +1759,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1773,7 +1773,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1787,7 +1787,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1801,7 +1801,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1815,7 +1815,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1829,7 +1829,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1843,7 +1843,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1857,7 +1857,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1871,7 +1871,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1885,7 +1885,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1899,7 +1899,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1913,7 +1913,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1927,7 +1927,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1941,7 +1941,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1955,7 +1955,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1969,7 +1969,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1983,7 +1983,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1997,7 +1997,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2011,7 +2011,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2025,7 +2025,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2039,7 +2039,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2053,7 +2053,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2067,7 +2067,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2081,7 +2081,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2095,7 +2095,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2109,7 +2109,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2123,7 +2123,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2137,7 +2137,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2151,7 +2151,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2165,7 +2165,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2179,7 +2179,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2193,7 +2193,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2207,7 +2207,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2221,7 +2221,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2235,7 +2235,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2249,7 +2249,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2263,7 +2263,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2277,7 +2277,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2291,7 +2291,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2305,7 +2305,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2319,7 +2319,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2333,7 +2333,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2347,7 +2347,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2361,7 +2361,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2375,7 +2375,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2389,7 +2389,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2403,7 +2403,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2417,7 +2417,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2431,7 +2431,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2445,7 +2445,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2459,7 +2459,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2473,7 +2473,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2487,7 +2487,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2501,7 +2501,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2515,7 +2515,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2529,7 +2529,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2543,7 +2543,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2557,7 +2557,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2571,7 +2571,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2585,7 +2585,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2599,7 +2599,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2613,7 +2613,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2627,7 +2627,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2641,7 +2641,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2655,7 +2655,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2669,7 +2669,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2683,7 +2683,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2697,7 +2697,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2711,7 +2711,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2725,7 +2725,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2739,7 +2739,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2753,7 +2753,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2767,7 +2767,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2781,7 +2781,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2795,7 +2795,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2809,7 +2809,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2823,7 +2823,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2837,7 +2837,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2851,7 +2851,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2865,7 +2865,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2879,7 +2879,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2893,7 +2893,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2907,7 +2907,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2921,7 +2921,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2935,7 +2935,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2949,7 +2949,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2963,7 +2963,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2977,7 +2977,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2991,7 +2991,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3005,7 +3005,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3019,7 +3019,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3033,7 +3033,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3047,7 +3047,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3061,7 +3061,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3075,7 +3075,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3089,7 +3089,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3103,7 +3103,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3117,7 +3117,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3131,7 +3131,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3145,7 +3145,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3159,7 +3159,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3173,7 +3173,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3187,7 +3187,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3201,7 +3201,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3215,7 +3215,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3229,7 +3229,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3243,7 +3243,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3257,7 +3257,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3271,7 +3271,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3285,7 +3285,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3299,7 +3299,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3313,7 +3313,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3327,7 +3327,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3341,7 +3341,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3355,7 +3355,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3369,7 +3369,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3383,7 +3383,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3397,7 +3397,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3411,7 +3411,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3425,7 +3425,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3439,7 +3439,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3453,7 +3453,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3467,7 +3467,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3481,7 +3481,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3495,7 +3495,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3509,7 +3509,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3523,7 +3523,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3537,7 +3537,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3551,7 +3551,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3565,7 +3565,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3579,7 +3579,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3593,7 +3593,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3607,7 +3607,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3621,7 +3621,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3635,7 +3635,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3649,7 +3649,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3663,7 +3663,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3677,7 +3677,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3691,7 +3691,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3705,7 +3705,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3719,7 +3719,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3733,7 +3733,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3747,7 +3747,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3761,7 +3761,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3775,7 +3775,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3789,7 +3789,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3803,7 +3803,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3817,7 +3817,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3831,7 +3831,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3845,7 +3845,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3859,7 +3859,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3873,7 +3873,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3887,7 +3887,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3901,7 +3901,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3915,7 +3915,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3929,7 +3929,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3943,7 +3943,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3957,7 +3957,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3971,7 +3971,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3985,7 +3985,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3999,7 +3999,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4013,7 +4013,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4027,7 +4027,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4041,7 +4041,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4055,7 +4055,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4069,7 +4069,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4083,7 +4083,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4097,7 +4097,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4111,7 +4111,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4125,7 +4125,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4139,7 +4139,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4153,7 +4153,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4167,7 +4167,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4181,7 +4181,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4195,7 +4195,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4209,7 +4209,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4223,7 +4223,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4237,7 +4237,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4251,7 +4251,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4265,7 +4265,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4279,7 +4279,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4293,7 +4293,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4307,7 +4307,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4321,7 +4321,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4335,7 +4335,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4349,7 +4349,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4363,7 +4363,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4377,7 +4377,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4391,7 +4391,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4405,7 +4405,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4419,7 +4419,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4433,7 +4433,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4447,7 +4447,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4461,7 +4461,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4475,7 +4475,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4489,7 +4489,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4503,7 +4503,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4517,7 +4517,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4531,7 +4531,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4545,7 +4545,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4559,7 +4559,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4573,7 +4573,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4587,7 +4587,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4601,7 +4601,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4615,7 +4615,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4629,7 +4629,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4643,7 +4643,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4657,7 +4657,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4671,7 +4671,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4685,7 +4685,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4699,7 +4699,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4713,7 +4713,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4727,7 +4727,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4741,7 +4741,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4755,7 +4755,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4769,7 +4769,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4783,7 +4783,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4797,7 +4797,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4811,7 +4811,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4825,7 +4825,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4839,7 +4839,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4853,7 +4853,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4867,7 +4867,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4881,7 +4881,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4895,7 +4895,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4909,7 +4909,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4923,7 +4923,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4937,7 +4937,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4951,7 +4951,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4965,7 +4965,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4979,7 +4979,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4993,7 +4993,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5007,7 +5007,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5021,7 +5021,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5035,7 +5035,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5049,7 +5049,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5063,7 +5063,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5077,7 +5077,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5091,7 +5091,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5105,7 +5105,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5119,7 +5119,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5133,7 +5133,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5147,7 +5147,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5161,7 +5161,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5175,7 +5175,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5189,7 +5189,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5203,7 +5203,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5217,7 +5217,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5231,7 +5231,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5245,7 +5245,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5259,7 +5259,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5273,7 +5273,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5287,7 +5287,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5301,7 +5301,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5315,7 +5315,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5329,7 +5329,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5343,7 +5343,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5357,7 +5357,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5371,7 +5371,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5385,7 +5385,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5399,7 +5399,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5413,7 +5413,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5427,7 +5427,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5441,7 +5441,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5455,7 +5455,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5469,7 +5469,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5483,7 +5483,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5497,7 +5497,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5511,7 +5511,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5525,7 +5525,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5539,7 +5539,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5553,7 +5553,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5567,7 +5567,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5581,7 +5581,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5595,7 +5595,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5609,7 +5609,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5623,7 +5623,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5637,7 +5637,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5651,7 +5651,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5665,7 +5665,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5679,7 +5679,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""

--- a/locales/el-GR/el-GR.json
+++ b/locales/el-GR/el-GR.json
@@ -9,7 +9,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -23,7 +23,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -37,7 +37,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -51,7 +51,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -65,7 +65,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -79,7 +79,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -93,7 +93,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -107,7 +107,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -121,7 +121,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -135,7 +135,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -149,7 +149,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -163,7 +163,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -177,7 +177,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -191,7 +191,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -205,7 +205,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -219,7 +219,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -233,7 +233,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -247,7 +247,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -261,7 +261,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -275,7 +275,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -289,7 +289,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -303,7 +303,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -317,7 +317,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -331,7 +331,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -345,7 +345,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -359,7 +359,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -373,7 +373,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -387,7 +387,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -401,7 +401,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -415,7 +415,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -429,7 +429,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -443,7 +443,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -457,7 +457,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -471,7 +471,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -485,7 +485,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -499,7 +499,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -513,7 +513,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -527,7 +527,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -541,7 +541,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -555,7 +555,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -569,7 +569,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -583,7 +583,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -597,7 +597,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -611,7 +611,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -625,7 +625,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -639,7 +639,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -653,7 +653,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -667,7 +667,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -681,7 +681,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -695,7 +695,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -709,7 +709,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -723,7 +723,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -737,7 +737,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -751,7 +751,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -765,7 +765,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -779,7 +779,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -793,7 +793,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -807,7 +807,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -821,7 +821,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -835,7 +835,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -849,7 +849,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -863,7 +863,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -877,7 +877,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -891,7 +891,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -905,7 +905,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -919,7 +919,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -933,7 +933,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -947,7 +947,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -961,7 +961,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -975,7 +975,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -989,7 +989,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1003,7 +1003,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1017,7 +1017,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1031,7 +1031,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1045,7 +1045,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1059,7 +1059,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1073,7 +1073,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1087,7 +1087,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1101,7 +1101,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1115,7 +1115,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1129,7 +1129,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1143,7 +1143,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1157,7 +1157,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1171,7 +1171,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1185,7 +1185,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1199,7 +1199,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1213,7 +1213,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1227,7 +1227,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1241,7 +1241,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1255,7 +1255,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1269,7 +1269,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1283,7 +1283,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1297,7 +1297,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1311,7 +1311,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1325,7 +1325,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1339,7 +1339,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1353,7 +1353,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1367,7 +1367,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1381,7 +1381,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1395,7 +1395,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1409,7 +1409,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1423,7 +1423,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1437,7 +1437,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1451,7 +1451,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1465,7 +1465,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1479,7 +1479,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1493,7 +1493,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1507,7 +1507,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1521,7 +1521,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1535,7 +1535,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1549,7 +1549,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1563,7 +1563,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1577,7 +1577,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1591,7 +1591,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1605,7 +1605,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1619,7 +1619,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1633,7 +1633,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1647,7 +1647,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1661,7 +1661,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1675,7 +1675,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1689,7 +1689,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1703,7 +1703,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1717,7 +1717,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1731,7 +1731,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1745,7 +1745,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1759,7 +1759,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1773,7 +1773,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1787,7 +1787,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1801,7 +1801,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1815,7 +1815,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1829,7 +1829,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1843,7 +1843,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1857,7 +1857,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1871,7 +1871,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1885,7 +1885,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1899,7 +1899,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1913,7 +1913,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1927,7 +1927,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1941,7 +1941,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1955,7 +1955,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1969,7 +1969,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1983,7 +1983,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1997,7 +1997,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2011,7 +2011,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2025,7 +2025,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2039,7 +2039,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2053,7 +2053,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2067,7 +2067,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2081,7 +2081,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2095,7 +2095,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2109,7 +2109,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2123,7 +2123,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2137,7 +2137,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2151,7 +2151,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2165,7 +2165,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2179,7 +2179,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2193,7 +2193,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2207,7 +2207,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2221,7 +2221,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2235,7 +2235,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2249,7 +2249,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2263,7 +2263,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2277,7 +2277,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2291,7 +2291,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2305,7 +2305,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2319,7 +2319,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2333,7 +2333,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2347,7 +2347,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2361,7 +2361,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2375,7 +2375,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2389,7 +2389,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2403,7 +2403,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2417,7 +2417,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2431,7 +2431,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2445,7 +2445,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2459,7 +2459,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2473,7 +2473,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2487,7 +2487,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2501,7 +2501,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2515,7 +2515,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2529,7 +2529,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2543,7 +2543,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2557,7 +2557,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2571,7 +2571,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2585,7 +2585,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2599,7 +2599,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2613,7 +2613,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2627,7 +2627,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2641,7 +2641,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2655,7 +2655,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2669,7 +2669,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2683,7 +2683,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2697,7 +2697,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2711,7 +2711,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2725,7 +2725,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2739,7 +2739,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2753,7 +2753,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2767,7 +2767,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2781,7 +2781,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2795,7 +2795,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2809,7 +2809,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2823,7 +2823,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2837,7 +2837,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2851,7 +2851,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2865,7 +2865,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2879,7 +2879,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2893,7 +2893,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2907,7 +2907,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2921,7 +2921,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2935,7 +2935,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2949,7 +2949,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2963,7 +2963,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2977,7 +2977,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2991,7 +2991,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3005,7 +3005,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3019,7 +3019,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3033,7 +3033,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3047,7 +3047,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3061,7 +3061,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3075,7 +3075,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3089,7 +3089,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3103,7 +3103,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3117,7 +3117,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3131,7 +3131,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3145,7 +3145,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3159,7 +3159,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3173,7 +3173,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3187,7 +3187,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3201,7 +3201,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3215,7 +3215,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3229,7 +3229,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3243,7 +3243,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3257,7 +3257,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3271,7 +3271,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3285,7 +3285,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3299,7 +3299,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3313,7 +3313,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3327,7 +3327,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3341,7 +3341,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3355,7 +3355,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3369,7 +3369,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3383,7 +3383,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3397,7 +3397,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3411,7 +3411,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3425,7 +3425,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3439,7 +3439,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3453,7 +3453,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3467,7 +3467,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3481,7 +3481,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3495,7 +3495,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3509,7 +3509,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3523,7 +3523,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3537,7 +3537,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3551,7 +3551,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3565,7 +3565,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3579,7 +3579,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3593,7 +3593,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3607,7 +3607,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3621,7 +3621,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3635,7 +3635,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3649,7 +3649,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3663,7 +3663,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3677,7 +3677,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3691,7 +3691,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3705,7 +3705,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3719,7 +3719,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3733,7 +3733,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3747,7 +3747,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3761,7 +3761,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3775,7 +3775,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3789,7 +3789,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3803,7 +3803,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3817,7 +3817,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3831,7 +3831,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3845,7 +3845,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3859,7 +3859,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3873,7 +3873,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3887,7 +3887,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3901,7 +3901,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3915,7 +3915,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3929,7 +3929,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3943,7 +3943,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3957,7 +3957,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3971,7 +3971,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3985,7 +3985,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3999,7 +3999,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4013,7 +4013,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4027,7 +4027,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4041,7 +4041,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4055,7 +4055,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4069,7 +4069,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4083,7 +4083,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4097,7 +4097,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4111,7 +4111,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4125,7 +4125,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4139,7 +4139,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4153,7 +4153,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4167,7 +4167,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4181,7 +4181,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4195,7 +4195,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4209,7 +4209,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4223,7 +4223,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4237,7 +4237,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4251,7 +4251,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4265,7 +4265,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4279,7 +4279,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4293,7 +4293,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4307,7 +4307,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4321,7 +4321,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4335,7 +4335,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4349,7 +4349,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4363,7 +4363,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4377,7 +4377,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4391,7 +4391,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4405,7 +4405,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4419,7 +4419,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4433,7 +4433,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4447,7 +4447,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4461,7 +4461,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4475,7 +4475,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4489,7 +4489,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4503,7 +4503,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4517,7 +4517,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4531,7 +4531,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4545,7 +4545,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4559,7 +4559,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4573,7 +4573,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4587,7 +4587,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4601,7 +4601,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4615,7 +4615,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4629,7 +4629,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4643,7 +4643,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4657,7 +4657,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4671,7 +4671,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4685,7 +4685,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4699,7 +4699,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4713,7 +4713,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4727,7 +4727,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4741,7 +4741,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4755,7 +4755,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4769,7 +4769,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4783,7 +4783,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4797,7 +4797,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4811,7 +4811,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4825,7 +4825,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4839,7 +4839,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4853,7 +4853,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4867,7 +4867,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4881,7 +4881,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4895,7 +4895,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4909,7 +4909,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4923,7 +4923,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4937,7 +4937,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4951,7 +4951,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4965,7 +4965,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4979,7 +4979,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4993,7 +4993,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5007,7 +5007,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5021,7 +5021,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5035,7 +5035,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5049,7 +5049,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5063,7 +5063,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5077,7 +5077,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5091,7 +5091,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5105,7 +5105,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5119,7 +5119,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5133,7 +5133,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5147,7 +5147,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5161,7 +5161,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5175,7 +5175,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5189,7 +5189,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5203,7 +5203,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5217,7 +5217,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5231,7 +5231,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5245,7 +5245,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5259,7 +5259,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5273,7 +5273,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5287,7 +5287,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5301,7 +5301,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5315,7 +5315,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5329,7 +5329,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5343,7 +5343,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5357,7 +5357,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5371,7 +5371,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5385,7 +5385,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5399,7 +5399,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5413,7 +5413,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5427,7 +5427,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5441,7 +5441,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5455,7 +5455,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5469,7 +5469,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5483,7 +5483,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5497,7 +5497,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5511,7 +5511,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5525,7 +5525,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5539,7 +5539,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5553,7 +5553,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5567,7 +5567,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5581,7 +5581,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5595,7 +5595,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5609,7 +5609,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5623,7 +5623,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5637,7 +5637,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5651,7 +5651,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5665,7 +5665,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5679,7 +5679,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""

--- a/locales/en-GB/en-GB.json
+++ b/locales/en-GB/en-GB.json
@@ -9,7 +9,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -23,7 +23,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -37,7 +37,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -51,7 +51,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -65,7 +65,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -79,7 +79,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -93,7 +93,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -107,7 +107,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -121,7 +121,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -135,7 +135,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -149,7 +149,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -163,7 +163,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -177,7 +177,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -191,7 +191,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -205,7 +205,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -219,7 +219,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -233,7 +233,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -247,7 +247,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -261,7 +261,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -275,7 +275,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -289,7 +289,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -303,7 +303,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -317,7 +317,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -331,7 +331,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -345,7 +345,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -359,7 +359,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -373,7 +373,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -387,7 +387,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -401,7 +401,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -415,7 +415,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -429,7 +429,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -443,7 +443,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -457,7 +457,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -471,7 +471,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -485,7 +485,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -499,7 +499,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -513,7 +513,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -527,7 +527,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -541,7 +541,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -555,7 +555,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -569,7 +569,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -583,7 +583,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -597,7 +597,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -611,7 +611,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -625,7 +625,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -639,7 +639,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -653,7 +653,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -667,7 +667,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -681,7 +681,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -695,7 +695,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -709,7 +709,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -723,7 +723,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -737,7 +737,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -751,7 +751,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -765,7 +765,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -779,7 +779,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -793,7 +793,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -807,7 +807,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -821,7 +821,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -835,7 +835,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -849,7 +849,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -863,7 +863,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -877,7 +877,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -891,7 +891,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -905,7 +905,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -919,7 +919,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -933,7 +933,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -947,7 +947,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -961,7 +961,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -975,7 +975,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -989,7 +989,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1003,7 +1003,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1017,7 +1017,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1031,7 +1031,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1045,7 +1045,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1059,7 +1059,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1073,7 +1073,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1087,7 +1087,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1101,7 +1101,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1115,7 +1115,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1129,7 +1129,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1143,7 +1143,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1157,7 +1157,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1171,7 +1171,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1185,7 +1185,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1199,7 +1199,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1213,7 +1213,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1227,7 +1227,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1241,7 +1241,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1255,7 +1255,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1269,7 +1269,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1283,7 +1283,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1297,7 +1297,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1311,7 +1311,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1325,7 +1325,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1339,7 +1339,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1353,7 +1353,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1367,7 +1367,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1381,7 +1381,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1395,7 +1395,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1409,7 +1409,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1423,7 +1423,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1437,7 +1437,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1451,7 +1451,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1465,7 +1465,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1479,7 +1479,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1493,7 +1493,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1507,7 +1507,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1521,7 +1521,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1535,7 +1535,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1549,7 +1549,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1563,7 +1563,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1577,7 +1577,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1591,7 +1591,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1605,7 +1605,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1619,7 +1619,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1633,7 +1633,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1647,7 +1647,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1661,7 +1661,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1675,7 +1675,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1689,7 +1689,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1703,7 +1703,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1717,7 +1717,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1731,7 +1731,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1745,7 +1745,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1759,7 +1759,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1773,7 +1773,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1787,7 +1787,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1801,7 +1801,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1815,7 +1815,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1829,7 +1829,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1843,7 +1843,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1857,7 +1857,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1871,7 +1871,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1885,7 +1885,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1899,7 +1899,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1913,7 +1913,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1927,7 +1927,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1941,7 +1941,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1955,7 +1955,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1969,7 +1969,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1983,7 +1983,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1997,7 +1997,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2011,7 +2011,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2025,7 +2025,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2039,7 +2039,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2053,7 +2053,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2067,7 +2067,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2081,7 +2081,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2095,7 +2095,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2109,7 +2109,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2123,7 +2123,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2137,7 +2137,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2151,7 +2151,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2165,7 +2165,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2179,7 +2179,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2193,7 +2193,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2207,7 +2207,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2221,7 +2221,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2235,7 +2235,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2249,7 +2249,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2263,7 +2263,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2277,7 +2277,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2291,7 +2291,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2305,7 +2305,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2319,7 +2319,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2333,7 +2333,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2347,7 +2347,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2361,7 +2361,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2375,7 +2375,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2389,7 +2389,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2403,7 +2403,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2417,7 +2417,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2431,7 +2431,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2445,7 +2445,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2459,7 +2459,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2473,7 +2473,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2487,7 +2487,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2501,7 +2501,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2515,7 +2515,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2529,7 +2529,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2543,7 +2543,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2557,7 +2557,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2571,7 +2571,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2585,7 +2585,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2599,7 +2599,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2613,7 +2613,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2627,7 +2627,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2641,7 +2641,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2655,7 +2655,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2669,7 +2669,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2683,7 +2683,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2697,7 +2697,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2711,7 +2711,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2725,7 +2725,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2739,7 +2739,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2753,7 +2753,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2767,7 +2767,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2781,7 +2781,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2795,7 +2795,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2809,7 +2809,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2823,7 +2823,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2837,7 +2837,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2851,7 +2851,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2865,7 +2865,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2879,7 +2879,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2893,7 +2893,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2907,7 +2907,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2921,7 +2921,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2935,7 +2935,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2949,7 +2949,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2963,7 +2963,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2977,7 +2977,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2991,7 +2991,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3005,7 +3005,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3019,7 +3019,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3033,7 +3033,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3047,7 +3047,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3061,7 +3061,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3075,7 +3075,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3089,7 +3089,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3103,7 +3103,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3117,7 +3117,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3131,7 +3131,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3145,7 +3145,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3159,7 +3159,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3173,7 +3173,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3187,7 +3187,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3201,7 +3201,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3215,7 +3215,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3229,7 +3229,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3243,7 +3243,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3257,7 +3257,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3271,7 +3271,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3285,7 +3285,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3299,7 +3299,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3313,7 +3313,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3327,7 +3327,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3341,7 +3341,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3355,7 +3355,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3369,7 +3369,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3383,7 +3383,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3397,7 +3397,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3411,7 +3411,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3425,7 +3425,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3439,7 +3439,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3453,7 +3453,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3467,7 +3467,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3481,7 +3481,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3495,7 +3495,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3509,7 +3509,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3523,7 +3523,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3537,7 +3537,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3551,7 +3551,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3565,7 +3565,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3579,7 +3579,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3593,7 +3593,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3607,7 +3607,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3621,7 +3621,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3635,7 +3635,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3649,7 +3649,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3663,7 +3663,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3677,7 +3677,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3691,7 +3691,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3705,7 +3705,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3719,7 +3719,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3733,7 +3733,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3747,7 +3747,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3761,7 +3761,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3775,7 +3775,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3789,7 +3789,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3803,7 +3803,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3817,7 +3817,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3831,7 +3831,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3845,7 +3845,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3859,7 +3859,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3873,7 +3873,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3887,7 +3887,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3901,7 +3901,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3915,7 +3915,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3929,7 +3929,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3943,7 +3943,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3957,7 +3957,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3971,7 +3971,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3985,7 +3985,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3999,7 +3999,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4013,7 +4013,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4027,7 +4027,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4041,7 +4041,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4055,7 +4055,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4069,7 +4069,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4083,7 +4083,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4097,7 +4097,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4111,7 +4111,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4125,7 +4125,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4139,7 +4139,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4153,7 +4153,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4167,7 +4167,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4181,7 +4181,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4195,7 +4195,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4209,7 +4209,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4223,7 +4223,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4237,7 +4237,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4251,7 +4251,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4265,7 +4265,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4279,7 +4279,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4293,7 +4293,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4307,7 +4307,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4321,7 +4321,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4335,7 +4335,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4349,7 +4349,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4363,7 +4363,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4377,7 +4377,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4391,7 +4391,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4405,7 +4405,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4419,7 +4419,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4433,7 +4433,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4447,7 +4447,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4461,7 +4461,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4475,7 +4475,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4489,7 +4489,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4503,7 +4503,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4517,7 +4517,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4531,7 +4531,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4545,7 +4545,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4559,7 +4559,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4573,7 +4573,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4587,7 +4587,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4601,7 +4601,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4615,7 +4615,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4629,7 +4629,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4643,7 +4643,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4657,7 +4657,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4671,7 +4671,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4685,7 +4685,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4699,7 +4699,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4713,7 +4713,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4727,7 +4727,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4741,7 +4741,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4755,7 +4755,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4769,7 +4769,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4783,7 +4783,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4797,7 +4797,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4811,7 +4811,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4825,7 +4825,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4839,7 +4839,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4853,7 +4853,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4867,7 +4867,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4881,7 +4881,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4895,7 +4895,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4909,7 +4909,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4923,7 +4923,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4937,7 +4937,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4951,7 +4951,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4965,7 +4965,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4979,7 +4979,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4993,7 +4993,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5007,7 +5007,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5021,7 +5021,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5035,7 +5035,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5049,7 +5049,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5063,7 +5063,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5077,7 +5077,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5091,7 +5091,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5105,7 +5105,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5119,7 +5119,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5133,7 +5133,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5147,7 +5147,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5161,7 +5161,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5175,7 +5175,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5189,7 +5189,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5203,7 +5203,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5217,7 +5217,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5231,7 +5231,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5245,7 +5245,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5259,7 +5259,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5273,7 +5273,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5287,7 +5287,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5301,7 +5301,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5315,7 +5315,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5329,7 +5329,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5343,7 +5343,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5357,7 +5357,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5371,7 +5371,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5385,7 +5385,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5399,7 +5399,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5413,7 +5413,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5427,7 +5427,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5441,7 +5441,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5455,7 +5455,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5469,7 +5469,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5483,7 +5483,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5497,7 +5497,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5511,7 +5511,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5525,7 +5525,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5539,7 +5539,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5553,7 +5553,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5567,7 +5567,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5581,7 +5581,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5595,7 +5595,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5609,7 +5609,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5623,7 +5623,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5637,7 +5637,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5651,7 +5651,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5665,7 +5665,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5679,7 +5679,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""

--- a/locales/en-US/en-US.json
+++ b/locales/en-US/en-US.json
@@ -3790,10 +3790,10 @@
       "partOfSpeech": "noun",
       "termCategory": "",
       "phonetic": "/ɪˈθɪəriəm ɪmˈpruvmənt prəˈpoʊzəl/",
-      "definition": "",
+      "definition": "EIPs, as they are commonly known, are exactly that: Proposals made with the goal of improving some part of the Ethereum network.",
       "definitionSource": "",
       "sampleSentence": "",
-      "extended": "There are many EIP-related entries in this glossary. See also ERC.",
+      "extended": "There are many EIP-related entries in this glossary. EIPs are often highly technical in nature, dealing with difficult or obscure engineering problems. However, there is no rule in this regard; EIP-2228 established that Ethereum Mainnet should be capitalized. An EIP after our own heart. See also ERC.",
       "additional": [
         {
           "definition": "EIP stands for Ethereum Improvement Proposal. It’s a way for the Ethereum community to suggest upgrades or new ideas for the blockchain.",

--- a/locales/en-US/en-US.json
+++ b/locales/en-US/en-US.json
@@ -9,7 +9,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -23,7 +23,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -37,7 +37,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -51,7 +51,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -65,7 +65,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -79,7 +79,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "Solving for this attack vector is one of the key design decisions in the Bitcoin protocol, as well as Ethereum, and others. In the case of Bitcoin, this was solved through the Proof of Work consensus mechanism, wherein the difficulty involved in mining new blocks effectively prevents any one actor from gaining this sort of control.",
-      "alternate": [],
+      "additional": [],
       "termSource": "Consensys Software Inc., Blockchain Glossary for Beginners",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -93,7 +93,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -107,7 +107,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/absolute-advantage",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/absolute-advantage",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -121,7 +121,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "These public-private key pairs can be generated one at a time, or they can be *derived* from what is known as a **seed phrase** or **secret recovery phrase**; for more on this, see HD wallet.",
-      "alternate": [
+      "additional": [
         {
           "definition": "A record in the Solana ledger that either holds data or is an executable program. Like an account at a traditional bank, a Solana account may hold funds called lamports. Like a file in Linux, it is addressable by a key, often referred to as a public key or pubkey. The key may be one of: - an ed25519 public key - a program-derived account address (32byte value forced off the ed25519 curve) - a hash of an ed25519 public key with a 32 character string",
           "source": "https://solana.com/docs/references/terminology#account"
@@ -140,7 +140,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -154,7 +154,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/active-management",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/active-management",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -168,7 +168,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/actively-validated-services-avs",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/actively-validated-services-avs",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -182,7 +182,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/ad-hoc",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/ad-hoc",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -196,7 +196,7 @@
       "definitionSource": "James Beck, Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "For example, on some networks, particularly EVM-style, every account will have an address, to which tokens could be sent. Smart contracts on those networks also have addresses, so that other contracts or protocols can interact with them. In Ethereum, the address begins with 0x; For example: 0x06A85356DCb5b307096726FB86A78c59D38e08ee",
-      "alternate": [
+      "additional": [
         {
           "definition": "String of text that designates the location of a particular wallet on the blockchain. Often a hashed version of a public key.",
           "source": "https://academy.binance.com/en/glossary/address"
@@ -215,7 +215,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -229,7 +229,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -243,7 +243,7 @@
       "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "Many hardware wallets use air-gapping as a security mechanism to keep users' private keys, or Secret Recovery Phrase offline, and thus safer from any kind of attack. Other, one-way communication methods are sometimes employed in such devices, e.g., QR codes.",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -257,7 +257,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/airdrop",
       "sampleSentence": "",
       "extended": "Sometimes airdrops are used for marketing purposes in exchange for simple tasks like reshares, referrals, or app downloads. The timing, recipient sourcing and inclusion methods, tokenomics and, if applicable, potential market value of tokens received through an airdrop are the subject of extensive debate and discussion.",
-      "alternate": [
+      "additional": [
         {
           "definition": "Distribution of digital assets to the public, by virtue of holding a certain token or by virtue of being an active wallet address.",
           "source": "https://academy.binance.com/en/glossary/airdrop"
@@ -276,7 +276,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -290,7 +290,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -304,7 +304,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/algorithm",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "A sequence of unambiguous instructions used for the purpose of solving a problem.",
           "source": "https://academy.binance.com/en/glossary/algorithm"
@@ -323,7 +323,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/all-or-none-order",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/all-or-none-order",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -337,7 +337,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/all-time-high",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/all-time-high",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -351,7 +351,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/allocation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/allocation",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -365,7 +365,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/alpha",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/alpha",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -379,7 +379,7 @@
       "definitionSource": "James Beck, Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "The term is less used in Ethereum or smart contract-enabled blockchain communities. Many altcoins are forks of Bitcoin with minor changes (e.g., Litecoin). See also 'fork'.",
-      "alternate": [
+      "additional": [
         {
           "definition": "A cryptocurrency that is alternative to Bitcoin. Altcoin is used to describe cryptocurrencies that are not Bitcoin.",
           "source": "https://academy.binance.com/en/glossary/altcoin"
@@ -398,7 +398,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -412,7 +412,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/angel-investor",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/angel-investor",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -426,7 +426,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/anti-money-laundering",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/anti-money-laundering",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -440,7 +440,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -454,7 +454,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "An appchain generally offers an optimized execution environment for the application. Rather than being a 'monolithic' blockchain with its own executioon and consensus mechanisms, it may e.g. still rely on an underlying blockchain for consensus. See also: 'blockchain trilemma', 'modular blockchain', 'Layer 2', 'Layer 3'.",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -468,7 +468,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -482,7 +482,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/application-programming-interface",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/application-programming-interface",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -496,7 +496,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/application-specific-integrated-circuit",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/application-specific-integrated-circuit",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -510,7 +510,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/arbitrage",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/arbitrage",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -524,7 +524,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -538,7 +538,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/arc-20",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/arc-20",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -552,7 +552,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/artificial-intelligence-ai",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/artificial-intelligence-ai",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -566,7 +566,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -580,7 +580,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/asic-resistant",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/asic-resistant",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -594,7 +594,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/asking-price",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/asking-price",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -608,7 +608,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/asset-management",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/asset-management",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -622,7 +622,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "In the crypto context, 'asset provenance' refers to the ability to trace the ownership and transfer of a specific cryptocurrency or token from its creation or minting to its current holder.",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -636,7 +636,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/assets-under-management-aum",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/assets-under-management-aum",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -650,7 +650,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/asynchronous",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/asynchronous",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -664,7 +664,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/atomic-swap",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/atomic-swap",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -678,7 +678,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/attack-surface",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/attack-surface",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -692,7 +692,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "While that may sound vague, that's because attestations are used in a broad range of contexts, and have both been crucial to the development of key blockchain network protocols – such as in Proof of Stake (PoS) mechanisms, in which validators *attest* to the validity of the transactions they're recording in blocks and syncing through the consensus protocol – or in more recent developments, wherein protocols like the Ethereum Attestation Service allow for the creation of custom attestation 'schemata', publicly accessible on a network. Individual 'attestations' can then be written according to the fields and structures defined in each individual schema, stored on-chain by users executing a call to the schema and signing it with a public key.",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -706,7 +706,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/auction",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/auction",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -720,7 +720,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -734,7 +734,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/automated-market-maker-amm",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/automated-market-maker-amm",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -748,7 +748,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -762,7 +762,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -776,7 +776,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -790,7 +790,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/b-tokens",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/b-tokens",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -804,7 +804,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/bags",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/bags",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -818,7 +818,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -832,7 +832,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -846,7 +846,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/beacon-chain",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "The Beacon Chain is Ethereum’s proof-of-stake (PoS) layer where consensus is reached.",
           "source": "https://academy.binance.com/en/glossary/beacon-chain"
@@ -865,7 +865,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/bear-market",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/bear-market",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -879,7 +879,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/benchmark",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/benchmark",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -893,7 +893,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/bep-1155",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/bep-1155",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -907,7 +907,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/bep-20",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/bep-20",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -921,7 +921,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/bep-721",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/bep-721",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -935,7 +935,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/bep-95",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/bep-95",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -949,7 +949,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -963,7 +963,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/beta-coefficient",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/beta-coefficient",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -977,7 +977,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/beta-release",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/beta-release",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -991,7 +991,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/bid-ask-spread",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/bid-ask-spread",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1005,7 +1005,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/bid-price",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/bid-price",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1019,7 +1019,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1033,7 +1033,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/binance-blockchain-charity-foundation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/binance-blockchain-charity-foundation",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1047,7 +1047,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/binance-ecosystem-fund",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/binance-ecosystem-fund",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1061,7 +1061,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/binancian",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/binancian",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1075,7 +1075,7 @@
       "definitionSource": "James Beck, Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "A cryptocurrency created by the pseudonymous developer(s) Satoshi Nakamoto, initially described as a 'Peer-to-Peer e-cash'.",
           "source": "https://academy.binance.com/en/glossary/bitcoin"
@@ -1094,7 +1094,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/bitcoin-core",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/bitcoin-core",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1108,7 +1108,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/bitcoin-dominance",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/bitcoin-dominance",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1122,7 +1122,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/bitcoin-maximalists",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/bitcoin-maximalists",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1136,7 +1136,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/bitcoin-pizza",
       "sampleSentence": "",
       "extended": "See also Pizza DAO: https://x.com/Pizza_DAO",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/bitcoin-pizza",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1150,7 +1150,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/black-swan-event",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/black-swan-event",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1164,7 +1164,7 @@
       "definitionSource": "Consensys Software Inc., Blockchain Glossary for Beginners",
       "sampleSentence": "",
       "extended": "Imagine a ledger that is being constantly synced between any number of exact copies of itself. People keep sending requests to add new entries to the ledger; these requests are transactions. When there are enough transactions ready, they get put into a specific order, and the *nodes*, each of which is keeping a copy of that ledger, reach consensus that the transactions are valid. Then, the transactions are cryptographically locked, in that order, into a 'block' and added forever to the ledger. This 'block' forms the starting point for the next one; in this way, they are all linked together in a chain, hence–blockchain.",
-      "alternate": [
+      "additional": [
         {
           "definition": "A computer file that stores transaction data. These can then be arranged in a linear sequence, which will form a blockchain.",
           "source": "https://academy.binance.com/en/glossary/block"
@@ -1187,7 +1187,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/block-explorer",
       "sampleSentence": "",
       "extended": "See also blockchain explorer.",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/block-explorer",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1201,7 +1201,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/block-header",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/block-header",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1215,7 +1215,7 @@
       "definitionSource": "Consensys Software Inc., Blockchain Glossary for Beginners",
       "sampleSentence": "",
       "extended": "For example, Height 0 would be the very first block, which is also called the Genesis Block.",
-      "alternate": [
+      "additional": [
         {
           "definition": "The number of blocks in the chain between itself and the first block on that blockchain (genesis block or block 0).",
           "source": "https://academy.binance.com/en/glossary/block-height"
@@ -1238,7 +1238,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/block-reward",
       "sampleSentence": "",
       "extended": "Block rewards can be a mixture of coins and transaction fees. The composition depends on the policy used by the cryptocurrency in question, and whether all of the coins have already been successfully mined. The current block reward for the Bitcoin network is 12.5 bitcoins per block.",
-      "alternate": [
+      "additional": [
         {
           "definition": "The sum of coins awarded by the blockchain protocol to cryptocurrency miners for each successfully mined and validated block.",
           "source": "https://academy.binance.com/en/glossary/block-reward"
@@ -1257,7 +1257,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "See also 'Proof of Work', 'Proof of Stake'.",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1271,7 +1271,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1285,7 +1285,7 @@
       "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "What is commonly referred to as a 'blockchain' might be more precisely called 'a public blockchain network', or a 'distributed ledger network'. While they get called 'blockchains' or 'chains', this is essentially a sort of metonymic usage. A public blockchain network consists, usually, of several different parts: 1. The blockchain or ledger itself. Think of this as the 'hard drive' of the network. 2. The consensus mechanism, and the consensus layer; this keeps all the copies of the ledger in sync, and adds new transactions or entries to it. 3. An execution layer: depending on the network in question, this layer or environment may vary from a very few functions built into the same software as the consensus client, to a very complex, Turing-complete, full-on Virtual Machine environment requiring those who run it to consider hardware requirements. There are, additionally, 'downstream' aspects of any one of these blockchain networks, including wallets, private-public key derivation logic, which programming languages can be used in interacting with it, etc. etc.",
-      "alternate": [
+      "additional": [
         {
           "definition": "A decentralized, digitized ledger that records transaction information about a cryptocurrency in a chronological order.",
           "source": "https://academy.binance.com/en/glossary/blockchain"
@@ -1304,7 +1304,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "While a blockchain is designed to keep information forever, and be “readable by anyone”, finding the specific information you’re interested in may require indexing data off the blockchain–that is, sorting it according to given categories (sender address, token type, etc) into a separate database which can then be queried by the user; this essential function is provided by blockchain explorers. A prominent example is etherscan, which also offers explorers on a number of other networks.",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1318,7 +1318,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1332,7 +1332,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/bloom-filter",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/bloom-filter",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1346,7 +1346,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/blue-chip-token",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/blue-chip-token",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1360,7 +1360,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/bnb",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/bnb",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1374,7 +1374,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1388,7 +1388,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/bnsol",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/bnsol",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1402,7 +1402,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/bollinger-bands",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/bollinger-bands",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1416,7 +1416,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/bond",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/bond",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1430,7 +1430,7 @@
       "definitionSource": "Consensys Software Inc., Blockchain Glossary for Beginners, Education DAO",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "A reward posted by a group or individual to incentivize certain work, behavior (such as referrals), or development.",
           "source": "https://academy.binance.com/en/glossary/bounty"
@@ -1449,7 +1449,7 @@
       "definitionSource": "MetaMask - kumavis, Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "Humans are not capable of generating enough entropy, or randomness, and therefore the wallets derived from these phrases are insecure; brain wallets can be brute forced by super fast computers. For this reason, brain wallet are insecure and should not be used. See also 'seed phrase'', 'Secret Recovery Phrase'.",
-      "alternate": [],
+      "additional": [],
       "termSource": "MetaMask Help Center",
       "dateFirstRecorded": "2018",
       "commentary": ""
@@ -1463,7 +1463,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1477,7 +1477,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/brc-20-tokens",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/brc-20-tokens",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1491,7 +1491,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/break-even-point",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/break-even-point",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1505,7 +1505,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/breakeven-multiple",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/breakeven-multiple",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1519,7 +1519,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/breakout",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/breakout",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1533,7 +1533,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "It would be fair to say both that the term 'bridge' is generally accurate, and that it does a lot of heavy lifting. The way that bridges are created, and maintained, varies from one to another, but often involve some sort of 'paired smart contracts', one on each network. These contracts would, e.g., lock, or burn, tokens on one chain, and either mint or somehow disburse an equivalent token, and amount of them, on the destination chain.",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1547,7 +1547,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/bscscan",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/bscscan",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1561,7 +1561,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1575,7 +1575,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/btc-wallet-address",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/btc-wallet-address",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1589,7 +1589,7 @@
       "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "Originally derived from HODL, a term referring to keeping your heads down and focusing on building your product.",
           "source": "https://academy.binance.com/en/glossary/buidl"
@@ -1608,7 +1608,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/bull-market",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/bull-market",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1622,7 +1622,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/burner-wallet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/burner-wallet",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1636,7 +1636,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/buy-wall",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/buy-wall",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1650,7 +1650,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1664,7 +1664,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1678,7 +1678,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1692,7 +1692,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/candidate-block",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/candidate-block",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1706,7 +1706,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/candlestick",
       "sampleSentence": "Did you see that green candlestick on $POO this morning? Someone bought big.",
       "extended": "Often shortened to simply 'candle'.",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/candlestick",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1720,7 +1720,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/capitulation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/capitulation",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1734,7 +1734,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1748,7 +1748,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/censorship-resistance",
       "sampleSentence": "",
       "extended": "While this is the noun phrase, you will often see a protocol or network described as 'censorship resistant'.",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/censorship-resistance",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1762,7 +1762,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/central-bank",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/central-bank",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1776,7 +1776,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/central-bank-digital-currency-cbdc",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/central-bank-digital-currency-cbdc",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1790,7 +1790,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/central-processing-unit",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/central-processing-unit",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1804,7 +1804,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/centralized",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/centralized",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1818,7 +1818,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/centralized-exchange",
       "sampleSentence": "",
       "extended": "Centralized exchanges typically offer a wide range of trading pairs, with many popular cryptocurrencies available for trade. They also usually have high liquidity and offer advanced trading features such as margin trading, order types, and charting tools.\nHowever, centralized exchanges also have several drawbacks. They are often targeted by hackers, as the centralized nature of the exchange makes them a single point of failure. They also require users to trust the exchange to hold their funds securely and execute trades fairly, which can be a source of concern for some users.",
-      "alternate": [
+      "additional": [
         {
           "definition": "Understand the world of centralized exchanges, traditional crypto marketplaces known for high liquidity, advanced trading tools, and risk considerations.",
           "source": "https://academy.binance.com/en/glossary/centralized-exchange"
@@ -1837,7 +1837,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1851,7 +1851,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "Ethereum networks have two identifiers, a network ID and a chain ID. Although they often have the same value, they have different uses. Peer-to-peer communication between nodes uses the network ID, while the transaction signature process uses the chain ID.",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1865,7 +1865,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/chatgpt",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/chatgpt",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1879,7 +1879,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1893,7 +1893,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/cipher",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/cipher",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1907,7 +1907,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/circulating-supply",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/circulating-supply",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1921,7 +1921,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "A computer program that accesses the Solana server network cluster.",
           "source": "https://solana.com/docs/references/terminology#client"
@@ -1940,7 +1940,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/cloud",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/cloud",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -1954,7 +1954,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1968,7 +1968,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/coin",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "A cryptocurrency or digital cash that is independent of any other platform, which is used as exchange of value.",
           "source": "https://academy.binance.com/en/glossary/coin"
@@ -1987,7 +1987,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2001,7 +2001,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2015,7 +2015,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/cold-storage",
       "sampleSentence": "",
       "extended": "See also: airgapping",
-      "alternate": [
+      "additional": [
         {
           "definition": "Discover the essentials of cold storage: learn what it is and how it protects your cryptocurrency holdings.",
           "source": "https://academy.binance.com/en/glossary/cold-storage"
@@ -2034,7 +2034,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2048,7 +2048,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/collateral",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/collateral",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2062,7 +2062,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/colocation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/colocation",
       "dateFirstRecorded": "2025-01-31",
       "commentary": "Not to be confused with 'collocation', referring to common placement of phrases or words together."
@@ -2076,7 +2076,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/commodity-futures-trading-commission",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/commodity-futures-trading-commission",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2090,7 +2090,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2104,7 +2104,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2118,7 +2118,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/compound-interest",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/compound-interest",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2132,7 +2132,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "Under a Proof of Work (PoW) consensus mechanism, this happens through a process known as mining; under Proof of Stake (PoS), the process is known as validation. Once a transaction is successfully confirmed, it theoretically cannot be reversed or double spent. The more confirmations a transaction has, the harder it becomes to perform a double spend attack.",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2146,7 +2146,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/confirmation-time",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "The wallclock duration between a leader creating a tick entry and creating a confirmed block.",
           "source": "https://solana.com/docs/references/terminology#confirmation-time"
@@ -2165,7 +2165,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/confluence",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/confluence",
       "dateFirstRecorded": "2025-01-31",
       "commentary": "Confluence is also the name of a workplace productivity tool, made by software company Atlassian."
@@ -2179,7 +2179,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "In a blockchain network, the consensus layer is implemented by the consensus protocol or algorithm that defines how new blocks are added to the chain, and how the network reaches agreement on the current state of the ledger. There are various types of consensus mechanisms used in blockchain networks, including proof of work (PoW), proof of stake (PoS), and delegated proof of stake (DPoS). The consensus client implements the specific consensus mechanism used by the network and ensures that all nodes follow the rules and reach agreement on the current state of the blockchain.",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2193,7 +2193,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/consensus-algorithm",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/consensus-algorithm",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2207,7 +2207,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2221,7 +2221,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2235,7 +2235,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2249,7 +2249,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2263,7 +2263,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2277,7 +2277,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/consumer-price-index-(cpi)",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/consumer-price-index-(cpi)",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2291,7 +2291,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/contango-and-backwardation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/contango-and-backwardation",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2305,7 +2305,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2319,7 +2319,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "The interplay between accounts and contracts, as public blockchain technology has advanced, has resulted in a particularly dense semantic web. When a smart contract is deployed, the Externally Owned Account, or EOA (controlled by a human), which is used to pay the gas fees required to deploy the contract -- that is, write it to the blockchain and make it available in the first place -- is referred to as the 'contract deploying account'. The resulting smart contract itself has an account as well -- the public address which can be used to 'call', or access its methods -- that's the one we're calling, here, a 'contract account'. But don't worry, it gets significantly worse; at a certain point, new techniques began to be used, to 'abstract away' the difficulties involved in EOAs; this move towards 'account abstraction' resulted in the creation of end user-accessible, shall we say, accounts which are created and controlled by... Smart contracts (which, remember, have their own accounts). There was much soul-searching and hand-wringing in trying to figure out what to call these things; often, they are referred to as... *Smart Contract Accounts*, capitalized; that's SCA, for short.",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2333,7 +2333,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2347,7 +2347,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/copy-trading",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/copy-trading",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2361,7 +2361,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/counterparty-risk",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/counterparty-risk",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2375,7 +2375,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/credentials",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/credentials",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2389,7 +2389,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/cross-chain-bridges",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/cross-chain-bridges",
       "dateFirstRecorded": "2025-01-31",
       "commentary": "This phrasing, as used by Binance, is perhaps redundant. A bridge between blockchains is, by definition, cross-chain."
@@ -2403,7 +2403,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2417,7 +2417,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2431,7 +2431,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2445,7 +2445,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2459,7 +2459,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/crypto-etfs",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/crypto-etfs",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2473,7 +2473,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/crypto-fear-and-greed-index",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/crypto-fear-and-greed-index",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2487,7 +2487,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2501,7 +2501,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/crypto-protocol",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/crypto-protocol",
       "dateFirstRecorded": "2025-01-31",
       "commentary": "This phrasing, as used by Binance, is perhaps implying a differentiation where one does not exist. A protocol is a protocol, regardless of whether it is employed in a crypto context or otherwise."
@@ -2515,7 +2515,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2529,7 +2529,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/crypto-winter",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/crypto-winter",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2543,7 +2543,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2557,7 +2557,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/cryptocurrency",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "A digital currency that is secured by cryptography to work as a medium of exchange within a peer-to-peer (P2P) economic system.",
           "source": "https://academy.binance.com/en/glossary/cryptocurrency"
@@ -2576,7 +2576,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2590,7 +2590,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/cryptography",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "The science of using mathematical theories and computation in order to encrypt and decrypt information.",
           "source": "https://academy.binance.com/en/glossary/cryptography"
@@ -2609,7 +2609,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2623,7 +2623,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/custody",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "Refers to the holding of assets on behalf of a client. Can also refer to the ownership of one's funds or assets.",
           "source": "https://academy.binance.com/en/glossary/custody"
@@ -2642,7 +2642,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2656,7 +2656,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/daemon",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/daemon",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2670,7 +2670,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2684,7 +2684,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/danksharding",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/danksharding",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2698,7 +2698,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2712,7 +2712,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2726,7 +2726,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2740,7 +2740,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/dead-cat-bounce",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/dead-cat-bounce",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2754,7 +2754,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/death-cross",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/death-cross",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2768,7 +2768,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2782,7 +2782,7 @@
       "definitionSource": "Consensys Software Inc., Blockchain Glossary for Beginners, Education DAO",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "DApps are applications that run on a P2P network of computers rather than a central database. Users can freely connect to DApps using crypto wallets.",
           "source": "https://academy.binance.com/en/glossary/decentralized-application"
@@ -2801,7 +2801,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/decentralized-autonomous-cooperative",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/decentralized-autonomous-cooperative",
       "dateFirstRecorded": "2025-01-31",
       "commentary": "Arguably, a DAO is, or often ends up being, simply 'an online cooperative with some smart contracts, maybe'."
@@ -2815,7 +2815,7 @@
       "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "Alternatively, the first known example of a DAO is referred to as The DAO. The DAO served as a form of investor-directed venture capital fund, which sought to provide enterprises with new decentralized business models. Ethereum-based, The DAO’s code was open source. The organization set the record for the most crowdfunded project in 2016. Those funds were partially stolen by hackers. The hack caused an Ethereum hard-fork which lead to the creation of Ethereum Classic.",
-      "alternate": [
+      "additional": [
         {
           "definition": "Definition: A system of hard-coded rules that define which actions a decentralized organization will take.",
           "source": "https://academy.binance.com/en/glossary/decentralized-autonomous-organization"
@@ -2834,7 +2834,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/decentralized-exchange",
       "sampleSentence": "",
       "extended": "This includes familiar concepts like loans and interest-bearing financial instruments, as well as so-called “DeFi primitives”, novel solutions like token swapping and liquidity pools. The trading is peer-to-peer, or between pools of liquidity. This is in contrast with a centralized exchange, which is more akin to a bank or investment firm that specializes in cryptocurrencies. Additionally, there are so-called on-ramp providers, who could be compared to currency brokers, exchanging traditional “fiat” money for cryptocurrencies, and do not hold customer’s funds “on deposit” the way a centralized exchange does. There are important technical and regulatory differences between these, which are constantly evolving.",
-      "alternate": [
+      "additional": [
         {
           "definition": "An exchange which does not require users to deposit funds to start trading and does not hold the funds for the user.",
           "source": "https://academy.binance.com/en/glossary/decentralized-exchange"
@@ -2853,7 +2853,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2867,7 +2867,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/decentralized-indexes",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/decentralized-indexes",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2881,7 +2881,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2895,7 +2895,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/decryption",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/decryption",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2909,7 +2909,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/deep-web",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/deep-web",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2923,7 +2923,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2937,7 +2937,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2951,7 +2951,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/delisting",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/delisting",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2965,7 +2965,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2979,7 +2979,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/depeg",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/depeg",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -2993,7 +2993,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3007,7 +3007,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/depression",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/depression",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3021,7 +3021,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3035,7 +3035,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/design-flaw-attack",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/design-flaw-attack",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3049,7 +3049,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3063,7 +3063,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3077,7 +3077,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3091,7 +3091,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3105,7 +3105,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/diamond-hands",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/diamond-hands",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3119,7 +3119,7 @@
       "definitionSource": "Consensys Software Inc., A Blockchain Glossary for Beginners",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "In cryptocurrency, difficulty indicates the difficulty required to mine a block. Learn more at Binance Academy.",
           "source": "https://academy.binance.com/en/glossary/difficulty"
@@ -3138,7 +3138,7 @@
       "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "The term 'difficulty bomb' denotes the increase in mining difficulty in Ethereum, as part of its migration to Proof of Stake.",
           "source": "https://academy.binance.com/en/glossary/difficulty-bomb"
@@ -3157,7 +3157,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3171,7 +3171,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3185,7 +3185,7 @@
       "definitionSource": "Consensys Software Inc., A Blockchain Glossary for Beginners",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "A cryptographic tool to verify the authenticity and integrity of digital data, ensuring the security of data communication and cryptocurrency transactions.",
           "source": "https://academy.binance.com/en/glossary/digital-signature"
@@ -3204,7 +3204,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3218,7 +3218,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/direct-market-access-dma",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/direct-market-access-dma",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3232,7 +3232,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3246,7 +3246,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/divergence",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/divergence",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3260,7 +3260,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/diversification",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/diversification",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3274,7 +3274,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3288,7 +3288,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/do-your-own-research",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/do-your-own-research",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3302,7 +3302,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/dollar-cost-averaging",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/dollar-cost-averaging",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3316,7 +3316,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/dot-plot",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/dot-plot",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3330,7 +3330,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "When a given amount of coins are spent more than once. Usually as a result of a race attack or a 51% attack.",
           "source": "https://academy.binance.com/en/glossary/double-spending"
@@ -3349,7 +3349,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/eclipse-attack",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/eclipse-attack",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3363,7 +3363,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3377,7 +3377,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3391,7 +3391,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3405,7 +3405,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/efficient-market-hypothesis-emh",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/efficient-market-hypothesis-emh",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3419,7 +3419,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/eigenlayer",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/eigenlayer",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3433,7 +3433,7 @@
       "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3447,7 +3447,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/eip-3074",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/eip-3074",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3461,7 +3461,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/eip-4844",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/eip-4844",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3475,7 +3475,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/eip-7251",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/eip-7251",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3489,7 +3489,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/eip-7702",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/eip-7702",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3503,7 +3503,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/elasticity",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/elasticity",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3517,7 +3517,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3531,7 +3531,7 @@
       "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "Conversion of information or data into a secure code in order to prevent unauthorised access to the information or data.",
           "source": "https://academy.binance.com/en/glossary/encryption"
@@ -3550,7 +3550,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/endogenous-variable",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/endogenous-variable",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3564,7 +3564,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3578,7 +3578,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3592,7 +3592,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "The time, i.e. number of slots, for which a leader schedule is valid.",
           "source": "https://solana.com/docs/references/terminology#epoch"
@@ -3611,7 +3611,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3625,7 +3625,7 @@
       "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "Discover the versatility of ERC-1155 tokens. Ideal for gaming, digital collectibles and managing multiple token types efficiently.",
           "source": "https://academy.binance.com/en/glossary/erc-1155"
@@ -3644,7 +3644,7 @@
       "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "A technical standard used to issue and implement tokens on the Ethereum blockchain proposed in November 2015 by Fabian Vogelsteller.",
           "source": "https://academy.binance.com/en/glossary/erc-20"
@@ -3663,7 +3663,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/erc-404",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/erc-404",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3677,7 +3677,7 @@
       "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "An Ethereum based non-fungible token. This means that each token is unique and as a result, not interchangeable.",
           "source": "https://academy.binance.com/en/glossary/erc-721"
@@ -3696,7 +3696,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/etf",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/etf",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3710,7 +3710,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3724,7 +3724,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3738,7 +3738,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3752,7 +3752,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3766,7 +3766,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/ethereum-classic",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/ethereum-classic",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3780,7 +3780,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/ethereum-foundation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/ethereum-foundation",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3794,7 +3794,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "There are many EIP-related entries in this glossary. See also ERC.",
-      "alternate": [
+      "additional": [
         {
           "definition": "EIP stands for Ethereum Improvement Proposal. It’s a way for the Ethereum community to suggest upgrades or new ideas for the blockchain.",
           "source": "https://academy.binance.com/en/glossary/eip"
@@ -3813,7 +3813,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3827,7 +3827,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3841,7 +3841,7 @@
       "definitionSource": "Consensys Software, Inc., A Blockchain Glossary for Beginners",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "The Ethereum Virtual Machine (EVM) is a Turing-complete programmable machine that executes smart contracts, which are typically coded in Solidity.",
           "source": "https://academy.binance.com/en/glossary/ethereum-virtual-machine-evm"
@@ -3860,7 +3860,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3874,7 +3874,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3888,7 +3888,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3902,7 +3902,7 @@
       "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "A marketplace for cryptocurrencies where users can buy and sell coins.",
           "source": "https://academy.binance.com/en/glossary/exchange"
@@ -3921,7 +3921,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3935,7 +3935,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3949,7 +3949,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/exogenous-variable",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/exogenous-variable",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3963,7 +3963,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/exponential-moving-average-ema",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/exponential-moving-average-ema",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3977,7 +3977,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/externally-owned-account-eoa",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/externally-owned-account-eoa",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -3991,7 +3991,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/fakeout",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/fakeout",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4005,7 +4005,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/falling-knife",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/falling-knife",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4019,7 +4019,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/fan-tokens",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/fan-tokens",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4033,7 +4033,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4047,7 +4047,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4061,7 +4061,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4075,7 +4075,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/fear-of-missing-out",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/fear-of-missing-out",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4089,7 +4089,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/fear-uncertainty-and-doubt",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/fear-uncertainty-and-doubt",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4103,7 +4103,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/fiat",
       "sampleSentence": "",
       "extended": "While it is often referred to simply as 'fiat', the full phrase is 'fiat currency'. The word 'fiat' refers, in Latin, to 'trusting'; hence, a fiat currency is one that trusts in something else to provide it value. For example, we are trusting that a government will maintain the value of a currency, rather than it having some sort of inherent value, or value derived from the things for which it can be exchanged.",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/fiat",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4117,7 +4117,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4131,7 +4131,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/fibonacci-retracement",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/fibonacci-retracement",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4145,7 +4145,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/fill-or-kill-order",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/fill-or-kill-order",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4159,7 +4159,7 @@
       "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "The assurance or guarantee that completed (cryptocurrency) transactions cannot be altered, reversed or canceled.",
           "source": "https://academy.binance.com/en/glossary/finality"
@@ -4182,7 +4182,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4196,7 +4196,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4210,7 +4210,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4224,7 +4224,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4238,7 +4238,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4252,7 +4252,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4266,7 +4266,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4280,7 +4280,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/first-mover-advantage",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/first-mover-advantage",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4294,7 +4294,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/fiscal-policy",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/fiscal-policy",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4308,7 +4308,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/flappening",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/flappening",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4322,7 +4322,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/flashbots",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/flashbots",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4336,7 +4336,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/flippening",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/flippening",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4350,7 +4350,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/flow-variable",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/flow-variable",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4364,7 +4364,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/forced-liquidation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/forced-liquidation",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4378,7 +4378,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/forex-fx",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/forex-fx",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4392,7 +4392,7 @@
       "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "A fork is a divergence in the blockchain network by creating a split in the blockchain's transaction history. There are two types of forks - soft and hard.",
           "source": "https://academy.binance.com/en/glossary/fork"
@@ -4415,7 +4415,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/formal-verification",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/formal-verification",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4429,7 +4429,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4443,7 +4443,7 @@
       "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "A fraud proof is a cryptographical evidence that a verifier submits to challenge a transaction's validity. They are widely used for blockchain scalability.",
           "source": "https://academy.binance.com/en/glossary/fraud-proof"
@@ -4462,7 +4462,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/fren",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/fren",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4476,7 +4476,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4490,7 +4490,7 @@
       "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "Computer that fully implements the entirety of rules of an underlying blockchain network and validates transactions on a blockchain.",
           "source": "https://academy.binance.com/en/glossary/full-node"
@@ -4509,7 +4509,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/fully-diluted-valuation-fdv",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/fully-diluted-valuation-fdv",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4523,7 +4523,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/fundamental-analysis",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/fundamental-analysis",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4537,7 +4537,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/funding-fees",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/funding-fees",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4551,7 +4551,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/fungibility",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/fungibility",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4565,7 +4565,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/futures-contract",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/futures-contract",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4579,7 +4579,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/gamefi",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/gamefi",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4593,7 +4593,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4607,7 +4607,7 @@
       "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "The pricing mechanism employed  on the Ethereum blockchain to calculate the costs of smart contracts operations and transaction fees.",
           "source": "https://academy.binance.com/en/glossary/gas"
@@ -4626,7 +4626,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4640,7 +4640,7 @@
       "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "Maximum price a cryptocurrency user is willing to pay as a fee when sending a transaction, or performing a smart contract function.",
           "source": "https://academy.binance.com/en/glossary/gas-limit"
@@ -4659,7 +4659,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4673,7 +4673,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4687,7 +4687,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4701,7 +4701,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/gdp-deflator",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/gdp-deflator",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4715,7 +4715,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/general-public-license",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/general-public-license",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4729,7 +4729,7 @@
       "definitionSource": "wordsofweb3",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "The first ever block recorded on its respective blockchain network, also referred to as Block 0 or Block 1.",
           "source": "https://academy.binance.com/en/glossary/genesis-block"
@@ -4752,7 +4752,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4766,7 +4766,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4780,7 +4780,7 @@
       "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "A site/system/folder/repository where a team can share, collaborate, and save their open source or proprietary code.",
           "source": "https://academy.binance.com/en/glossary/github"
@@ -4799,7 +4799,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/gm-good-morning",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/gm-good-morning",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4813,7 +4813,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4827,7 +4827,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/golden-cross",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/golden-cross",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4841,7 +4841,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/golden-ratio",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/golden-ratio",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4855,7 +4855,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/goldilocks",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/goldilocks",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4869,7 +4869,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/gossip-protocol",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/gossip-protocol",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4883,7 +4883,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4897,7 +4897,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/gross-domestic-product-gdp",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/gross-domestic-product-gdp",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4911,7 +4911,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4925,7 +4925,7 @@
       "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "A small denomination of ether. It is widely used as a measure of gas prices. 1,000,000,000 wei = 1 Giga wei (Gwei)",
           "source": "https://academy.binance.com/en/glossary/gwei"
@@ -4944,7 +4944,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/hackathon",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/hackathon",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4958,7 +4958,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/hacker",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/hacker",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4972,7 +4972,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/haha-money-printer-go-brrrrr",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/haha-money-printer-go-brrrrr",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -4986,7 +4986,7 @@
       "definitionSource": "Consensys Software, Inc., A Blockchain Glossary for Beginners",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "Halving is a process that reduces the block reward of a PoW crypto like Bitcoin (BTC) to half. The next halving of Bitcoin is expected around 2024.",
           "source": "https://academy.binance.com/en/glossary/halving"
@@ -5005,7 +5005,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/hard-cap",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/hard-cap",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5019,7 +5019,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5033,7 +5033,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/hard-landing",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/hard-landing",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5047,7 +5047,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5061,7 +5061,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5075,7 +5075,7 @@
       "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "The output produced by a hash function after a piece of data is mapped. May also be referred to as hash value, hash code, or digest.",
           "source": "https://academy.binance.com/en/glossary/hash"
@@ -5098,7 +5098,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/hash-rate",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/hash-rate",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5112,7 +5112,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/hashed-timelock-contract",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/hashed-timelock-contract",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5126,7 +5126,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5140,7 +5140,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/herd-instinct",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/herd-instinct",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5154,7 +5154,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5168,7 +5168,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/high-frequency-trading-hft",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/high-frequency-trading-hft",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5182,7 +5182,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/hodl",
       "sampleSentence": "",
       "extended": "See also 'BUIDL'.",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/hodl",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5196,7 +5196,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/honeypot",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/honeypot",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5210,7 +5210,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5224,7 +5224,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5238,7 +5238,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5252,7 +5252,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5266,7 +5266,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5280,7 +5280,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/iceberg-order",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/iceberg-order",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5294,7 +5294,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5308,7 +5308,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5322,7 +5322,7 @@
       "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "The inability to change or be changed. One of the core features behind Bitcoin and blockchain technology.",
           "source": "https://academy.binance.com/en/glossary/immutability"
@@ -5341,7 +5341,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/index-funds",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/index-funds",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5355,7 +5355,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5369,7 +5369,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/initial-coin-offering",
       "sampleSentence": "",
       "extended": "Often referred to by its initialism, 'ICO'.",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/initial-coin-offering",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5383,7 +5383,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/initial-dex-offering-ido",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/initial-dex-offering-ido",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5397,7 +5397,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/initial-exchange-offering",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/initial-exchange-offering",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5411,7 +5411,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/inscription",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/inscription",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5425,7 +5425,7 @@
       "definitionSource": "Consensys Software, Inc., A Blockchain Glossary for Beginners",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5439,7 +5439,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/integrated-circuit",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/integrated-circuit",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5453,7 +5453,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/interest-rates",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/interest-rates",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5467,7 +5467,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5481,7 +5481,7 @@
       "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "A concept of allowing blockchains to be compatible with each other and build upon each other's features and use-cases.",
           "source": "https://academy.binance.com/en/glossary/interoperability"
@@ -5500,7 +5500,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "An open-source project building a protocol for distributed content storage and access.",
           "source": "https://academy.binance.com/en/glossary/interplanetary-file-system-ipfs"
@@ -5519,7 +5519,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/iou",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/iou",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5533,7 +5533,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5547,7 +5547,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5561,7 +5561,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "Refers to the moment a private company starts offering its shares to the public for the first time.",
           "source": "https://academy.binance.com/en/glossary/initial-public-offering"
@@ -5580,7 +5580,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/isolated-margin",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/isolated-margin",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5594,7 +5594,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/issuance",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/issuance",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5608,7 +5608,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5622,7 +5622,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5636,7 +5636,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/keccak",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/keccak",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5650,7 +5650,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5664,7 +5664,7 @@
       "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "A standard procedure in the finance industry which allows companies to identify their customers and comply with KYC AML laws",
           "source": "https://academy.binance.com/en/glossary/know-your-customer"
@@ -5683,7 +5683,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5697,7 +5697,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5711,7 +5711,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5725,7 +5725,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5739,7 +5739,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/laspeyres-index",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/laspeyres-index",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5753,7 +5753,7 @@
       "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "The time between submitting a transaction to a network and the first confirmation of acceptance by the network.",
           "source": "https://academy.binance.com/en/glossary/latency"
@@ -5772,7 +5772,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5786,7 +5786,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5800,7 +5800,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/law-of-demand",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/law-of-demand",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5814,7 +5814,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5828,7 +5828,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5842,7 +5842,7 @@
       "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "A secondary framework or protocol that is built on top of an existing blockchain system to provide increased scalability.",
           "source": "https://academy.binance.com/en/glossary/layer-2"
@@ -5861,7 +5861,7 @@
       "definitionSource": "Consensys Software, Inc., A Blockchain Glossary for Beginners",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "A list of entries containing transactions signed by clients. Conceptually, this can be traced back to the genesis block, but an actual validator's ledger may have only newer blocks to reduce storage, as older ones are not needed for validation of future blocks by design.",
           "source": "https://solana.com/docs/references/terminology#ledger"
@@ -5880,7 +5880,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5894,7 +5894,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5908,7 +5908,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/leveraged-tokens",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/leveraged-tokens",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -5922,7 +5922,7 @@
       "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "A collection of stable resources, which may include executable files, documentation, message templates, and written code.",
           "source": "https://academy.binance.com/en/glossary/library"
@@ -5941,7 +5941,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5955,7 +5955,7 @@
       "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "A type of client that can verify it's pointing to a valid cluster. It performs more ledger verification than a thin client and less than a validator.",
           "source": "https://solana.com/docs/references/terminology#light-client"
@@ -5974,7 +5974,7 @@
       "definitionSource": "Consensys Software, Inc., A Blockchain Glossary for Beginners",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "A second layer operating on top of a blockchain, enabling increased transaction speed among participating nodes.",
           "source": "https://academy.binance.com/en/glossary/lightning-network"
@@ -5993,7 +5993,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/limit-order",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/limit-order",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6007,7 +6007,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6021,7 +6021,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/linux",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/linux",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6035,7 +6035,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6049,7 +6049,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/liquid-staking",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/liquid-staking",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6063,7 +6063,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/liquid-staking-token-lst",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/liquid-staking-token-lst",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6077,7 +6077,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6091,7 +6091,7 @@
       "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "The ability to sell or buy any given asset without causing significant fluctuations in the market price for that asset.",
           "source": "https://academy.binance.com/en/glossary/liquidity"
@@ -6110,7 +6110,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/liquidity-crisis",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/liquidity-crisis",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6124,7 +6124,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6138,7 +6138,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/liquidity-provider",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/liquidity-provider",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6152,7 +6152,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/liquidity-ratios",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/liquidity-ratios",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6166,7 +6166,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6180,7 +6180,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/listing",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/listing",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6194,7 +6194,7 @@
       "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "A blockchain protocol which is fully developed and deployed where transactions are being broadcasted, verified, and recorded.",
           "source": "https://academy.binance.com/en/glossary/mainnet"
@@ -6213,7 +6213,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/mainnet-swap",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/mainnet-swap",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6227,7 +6227,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/maker",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/maker",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6241,7 +6241,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6255,7 +6255,7 @@
       "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "Any software program or code that is created to infiltrate and intentionally cause damage to computer systems and networks.",
           "source": "https://academy.binance.com/en/glossary/malware"
@@ -6274,7 +6274,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/margin-trading",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/margin-trading",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6288,7 +6288,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "The total trading value of a given coin - calculated by the product of the supply of the coin by the current price.",
           "source": "https://academy.binance.com/en/glossary/market-capitalization"
@@ -6307,7 +6307,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/market-momentum",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/market-momentum",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6321,7 +6321,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/market-order",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/market-order",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6335,7 +6335,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/masternode",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/masternode",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6349,7 +6349,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/matching-engine",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/matching-engine",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6363,7 +6363,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6377,7 +6377,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6391,7 +6391,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/maximum-supply",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/maximum-supply",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6405,7 +6405,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6419,7 +6419,7 @@
       "definitionSource": "Consensys Software Inc., A Blockchain Glossary for Beginners",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "A node’s mechanism for keeping track of unconfirmed transactions that the node has seen (but have not yet been added to a block).",
           "source": "https://academy.binance.com/en/glossary/mempool"
@@ -6438,7 +6438,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6452,7 +6452,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6466,7 +6466,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/merged-mining",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/merged-mining",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6480,7 +6480,7 @@
       "definitionSource": "Consensys Software Inc., A Blockchain Glossary for Beginners",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6494,7 +6494,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/merkle-tree",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/merkle-tree",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6508,7 +6508,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6522,7 +6522,7 @@
       "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "Data that includes information about other data, such as information about features of a specific transaction.",
           "source": "https://academy.binance.com/en/glossary/metadata"
@@ -6541,7 +6541,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6555,7 +6555,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6569,7 +6569,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6583,7 +6583,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6597,7 +6597,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6611,7 +6611,7 @@
       "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "The metaverse is a concept of a persistent, online, 3D virtual environment that many believe will be a key element of future digital experiences.",
           "source": "https://academy.binance.com/en/glossary/metaverse"
@@ -6630,7 +6630,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6644,7 +6644,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6658,7 +6658,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/microtransactions",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/microtransactions",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6672,7 +6672,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6686,7 +6686,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6700,7 +6700,7 @@
       "definitionSource": "Consensys Software Inc., A Blockchain Glossary for Beginners",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "The verification of transactions on a blockchain network, in which transactions are added as entries into the blockchain ledger.",
           "source": "https://academy.binance.com/en/glossary/mining"
@@ -6719,7 +6719,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/mining-farm",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/mining-farm",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6733,7 +6733,7 @@
       "definitionSource": "Consensys Software Inc., A Blockchain Glossary for Beginners",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "Minting adds fresh tokens into the crypto ecosystem, enabling them to be traded or used within its network. Minting is similar to mining, with some key differences.",
           "source": "https://academy.binance.com/en/glossary/mint"
@@ -6752,7 +6752,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6766,7 +6766,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6780,7 +6780,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6794,7 +6794,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/monetary-policy",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/monetary-policy",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6808,7 +6808,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/money-markets",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/money-markets",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6822,7 +6822,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/monitoring-tag",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/monitoring-tag",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6836,7 +6836,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/moon",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/moon",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6850,7 +6850,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6864,7 +6864,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/moving-average-envelopes",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/moving-average-envelopes",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6878,7 +6878,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/moving-average-ribbon",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/moving-average-ribbon",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6892,7 +6892,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/mt-gox",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/mt-gox",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6906,7 +6906,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6920,7 +6920,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "Wallet which requires another party to authorize a transaction before it is broadcasted to the network.",
           "source": "https://academy.binance.com/en/glossary/multisignature"
@@ -6939,7 +6939,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/nakamoto-consensus",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/nakamoto-consensus",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6953,7 +6953,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6967,7 +6967,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/net-asset-value-nav",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/net-asset-value-nav",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -6981,7 +6981,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6995,7 +6995,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7009,7 +7009,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7023,7 +7023,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7037,7 +7037,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7051,7 +7051,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7065,7 +7065,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/nft-floor-prices",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/nft-floor-prices",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7079,7 +7079,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/nft-mystery-boxes",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/nft-mystery-boxes",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7093,7 +7093,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/ngmi",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/ngmi",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7107,7 +7107,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7121,7 +7121,7 @@
       "definitionSource": "Consensys Software Inc., A Blockchain Glossary for Beginners",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "A participant on a blockchain network that communicates with other participants to ensure the security and integrity of the system.",
           "source": "https://academy.binance.com/en/glossary/node"
@@ -7144,7 +7144,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "A type of cryptographic token that represents a unique digital or real-world asset and isn't interchangeable.",
           "source": "https://academy.binance.com/en/glossary/non-fungible-token-nft"
@@ -7163,7 +7163,7 @@
       "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "A single-use arbitrary string or number generated for verification purposes to prevent replaying past transactions.",
           "source": "https://academy.binance.com/en/glossary/nonce"
@@ -7182,7 +7182,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/oco-order",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/oco-order",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7196,7 +7196,7 @@
       "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "Discover how off-chain transactions in crypto enhance scalability and speed. Explore their use in Layer 2 solutions, reducing transaction costs.",
           "source": "https://academy.binance.com/en/glossary/off-chain"
@@ -7215,7 +7215,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7229,7 +7229,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/offline-signing-orchestrator-oso",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/offline-signing-orchestrator-oso",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7243,7 +7243,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/offshore-account",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/offshore-account",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7257,7 +7257,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7271,7 +7271,7 @@
       "definitionSource": "Consensys Software Inc., A Blockchain Glossary for Beginners",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "On-chain refers to transactions and activities directly recorded on the blockchain, ensuring data transparency, security, and immutability.",
           "source": "https://academy.binance.com/en/glossary/on-chain"
@@ -7290,7 +7290,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7304,7 +7304,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7318,7 +7318,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/opbnb",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/opbnb",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7332,7 +7332,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/open-source-software-oss",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/open-source-software-oss",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7346,7 +7346,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7360,7 +7360,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7374,7 +7374,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/opportunity-cost",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/opportunity-cost",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7388,7 +7388,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7402,7 +7402,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7416,7 +7416,7 @@
       "definitionSource": "Consensys Software Inc., A Blockchain Glossary for Beginners",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "A data source or feed from a third party used for determining outcomes for smart contracts.",
           "source": "https://academy.binance.com/en/glossary/oracle"
@@ -7435,7 +7435,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/orc-20-tokens",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/orc-20-tokens",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7449,7 +7449,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/order-book",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/order-book",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7463,7 +7463,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/ordinals",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/ordinals",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7477,7 +7477,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/orphan-block",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/orphan-block",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7491,7 +7491,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7505,7 +7505,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7519,7 +7519,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/pancakeswap",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/pancakeswap",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7533,7 +7533,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/paper-wallet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/paper-wallet",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7547,7 +7547,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/parallelization",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/parallelization",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7561,7 +7561,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7575,7 +7575,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7589,7 +7589,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/passive-management",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/passive-management",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7603,7 +7603,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7617,7 +7617,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7631,7 +7631,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7645,7 +7645,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7659,7 +7659,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/peer-to-peer",
       "sampleSentence": "",
       "extended": "See also, P2P.",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/peer-to-peer",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7673,7 +7673,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/pegged-currency",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/pegged-currency",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7687,7 +7687,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7701,7 +7701,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7715,7 +7715,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/permissionless-blockchain",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/permissionless-blockchain",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7729,7 +7729,7 @@
       "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "A malicious attack where a bad actor will attempt to obtain the credentials of a user in order to gain unauthorised access into their account.",
           "source": "https://academy.binance.com/en/glossary/phishing"
@@ -7748,7 +7748,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7762,7 +7762,7 @@
       "definitionSource": "Consensys Software Inc., A Blockchain Glossary for Beginners",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "An Ethereum off-chain scaling solution which may allow Etherum to greatly increase the transactions per second capablities.",
           "source": "https://academy.binance.com/en/glossary/plasma"
@@ -7781,7 +7781,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7795,7 +7795,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/polkadot-crowdloan",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/polkadot-crowdloan",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7809,7 +7809,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7823,7 +7823,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/ponzi-scheme",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/ponzi-scheme",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7837,7 +7837,7 @@
       "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "Not to be confused with 'wallet'.",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7851,7 +7851,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7865,7 +7865,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7879,7 +7879,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/premining",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/premining",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7893,7 +7893,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/price-action",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/price-action",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7907,7 +7907,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7921,7 +7921,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/prisoners-dilemma",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/prisoners-dilemma",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -7935,7 +7935,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7949,7 +7949,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7963,7 +7963,7 @@
       "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "In the context of cryptocurrency, a private key is a number that allows users to sign transactions and to generate receiving addresses.",
           "source": "https://academy.binance.com/en/glossary/private-key"
@@ -7986,7 +7986,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/private-sale",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/private-sale",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8000,7 +8000,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/progressive-web-application",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/progressive-web-application",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8014,7 +8014,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/proof-of-attendance-protocol-poap",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/proof-of-attendance-protocol-poap",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8028,7 +8028,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/proof-of-reserves-por",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/proof-of-reserves-por",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8042,7 +8042,7 @@
       "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "A consensus mechanism that reward block validators according to the amount of coins they have at stake.",
           "source": "https://academy.binance.com/en/glossary/proof-of-stake"
@@ -8061,7 +8061,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/proof-of-staked-authority-posa",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/proof-of-staked-authority-posa",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8075,7 +8075,7 @@
       "definitionSource": "Consensys Software Inc., A Blockchain Glossary for Beginners",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "Proof of Work is a crypto consensus mechanism where miners use special equipment to solve cryptographic puzzles to validate transactions and create new blocks.",
           "source": "https://academy.binance.com/en/glossary/proof-of-work"
@@ -8094,7 +8094,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/proposer-builder-separation-pbs",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/proposer-builder-separation-pbs",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8108,7 +8108,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/proto-danksharding",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/proto-danksharding",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8122,7 +8122,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8136,7 +8136,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/pseudorandom",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/pseudorandom",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8150,7 +8150,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8164,7 +8164,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8178,7 +8178,7 @@
       "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "A public key is one-half of a key pair used to encrypt messages or verify digital signatures. In the crypto space, it essentially works as your wallet address.",
           "source": "https://academy.binance.com/en/glossary/public-key"
@@ -8201,7 +8201,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8215,7 +8215,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/pump-and-dump",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/pump-and-dump",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8229,7 +8229,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8243,7 +8243,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/quantitative-easing-qe",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/quantitative-easing-qe",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8257,7 +8257,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/quantitative-tightening-qt",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/quantitative-tightening-qt",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8271,7 +8271,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/quantum-computing",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/quantum-computing",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8285,7 +8285,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8299,7 +8299,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/race-attack",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/race-attack",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8313,7 +8313,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/ransomware",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/ransomware",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8327,7 +8327,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8341,7 +8341,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/real-world-assets-rwas",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/real-world-assets-rwas",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8355,7 +8355,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/recession",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/recession",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8369,7 +8369,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/recursive-inscription",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/recursive-inscription",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8383,7 +8383,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/rekt",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/rekt",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8397,7 +8397,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/relative-strength-index",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/relative-strength-index",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8411,7 +8411,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8425,7 +8425,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "See also 'RPC'.",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8439,7 +8439,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/resistance",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/resistance",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8453,7 +8453,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/return-on-investment",
       "sampleSentence": "",
       "extended": "Generally referred to by its initialism, 'ROI'.",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/return-on-investment",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8467,7 +8467,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/revenge-trading",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/revenge-trading",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8481,7 +8481,7 @@
       "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8495,7 +8495,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/risk-premium",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/risk-premium",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8509,7 +8509,7 @@
       "definitionSource": "Consensys Software Inc., A Blockchain Glossary for Beginners",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "A business planning technique which lays out the short and long term goals of a company within a flexible estimated timeline.",
           "source": "https://academy.binance.com/en/glossary/roadmap"
@@ -8528,7 +8528,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8542,7 +8542,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8556,7 +8556,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8570,7 +8570,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/routing-attack",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/routing-attack",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8584,7 +8584,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8598,7 +8598,7 @@
       "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "A rug pull in the crypto industry is when a development team suddenly abandons a project and sells or removes all its liquidity.",
           "source": "https://academy.binance.com/en/glossary/rug-pull"
@@ -8617,7 +8617,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8631,7 +8631,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/sahm-rule",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/sahm-rule",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8645,7 +8645,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8659,7 +8659,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8673,7 +8673,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/sandwich-trading",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/sandwich-trading",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8687,7 +8687,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8701,7 +8701,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/satoshi",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/satoshi",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8715,7 +8715,7 @@
       "definitionSource": "Consensys Software Inc., A Blockchain Glossary for Beginners",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "Satoshi Nakamoto was the pseudonym of the creator or creators of the bitcoin protocol and whitepaper.",
           "source": "https://academy.binance.com/en/glossary/satoshi-nakamoto"
@@ -8734,7 +8734,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8748,7 +8748,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8762,7 +8762,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8776,7 +8776,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8790,7 +8790,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8804,7 +8804,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8818,7 +8818,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8832,7 +8832,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/secure-asset-fund-for-users",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/secure-asset-fund-for-users",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8846,7 +8846,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/securities-and-exchange-commission",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/securities-and-exchange-commission",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8860,7 +8860,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/security-audit",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/security-audit",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8874,7 +8874,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8888,7 +8888,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "Unravel Security Token Offering (STO), a method of raising capital by issuing security tokens. Explore some of the benefits they offer to investors.",
           "source": "https://academy.binance.com/en/glossary/security-token-offering-sto"
@@ -8907,7 +8907,7 @@
       "definitionSource": "Consensys Software Inc., A Blockchain Glossary for Beginners",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "A seed phrase or menmonic seed is a collection of words that can be used to access your cryptocurrency wallet.",
           "source": "https://academy.binance.com/en/glossary/seed-phrase"
@@ -8926,7 +8926,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/seed-tag",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/seed-tag",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8940,7 +8940,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/segregated-witness",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/segregated-witness",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8954,7 +8954,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8968,7 +8968,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8982,7 +8982,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/selfish-mining",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/selfish-mining",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -8996,7 +8996,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/sell-wall",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/sell-wall",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9010,7 +9010,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/sentiment",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/sentiment",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9024,7 +9024,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9038,7 +9038,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9052,7 +9052,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9066,7 +9066,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9080,7 +9080,7 @@
       "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "Sharding is a method of splitting blockchains ( or other types of databases) into smaller, partitioned blockchains that manage specific data segments.",
           "source": "https://academy.binance.com/en/glossary/sharding"
@@ -9099,7 +9099,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/sharpe-ratio",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/sharpe-ratio",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9113,7 +9113,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9127,7 +9127,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "Sidechains are independent blockchains linked to a parent blockchain, designed to enhance scalability and facilitate digital asset transfers between networks.",
           "source": "https://academy.binance.com/en/glossary/sidechains"
@@ -9146,7 +9146,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "A 64-byte ed25519 signature of R (32-bytes) and S (32-bytes). With the requirement that R is a packed Edwards point not of small order and S is a scalar in the range of 0 <= S < L. This requirement ensures no signature malleability. Each transaction must have at least one signature for fee account. Thus, the first signature in transaction can be treated as transaction id",
           "source": "https://solana.com/docs/references/terminology#signature"
@@ -9165,7 +9165,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/simple-moving-average-sma",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/simple-moving-average-sma",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9179,7 +9179,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/slashing",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/slashing",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9193,7 +9193,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9207,7 +9207,7 @@
       "definitionSource": "Consensys Software Inc., A Blockchain Glossary for Beginners",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "Slippage occurs when a trade settles at a different price than originally requested or expected, usually in low-liquidity markets and when using market orders.",
           "source": "https://academy.binance.com/en/glossary/slippage"
@@ -9226,7 +9226,7 @@
       "definitionSource": "Consensys Software Inc., A Blockchain Glossary for Beginners",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "The period of time for which each leader ingests transactions and produces a block. Collectively, slots create a logical clock. Slots are ordered sequentially and non-overlapping, comprising roughly equal real-world time as per PoH.",
           "source": "https://solana.com/docs/references/terminology#slot"
@@ -9245,7 +9245,7 @@
       "definitionSource": "Consensys Software Inc., A Blockchain Glossary for Beginners",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "Smart contracts are self-executing contracts that exist on certain blockchain networks. Their conditions and terms are written directly into lines of code.",
           "source": "https://academy.binance.com/en/glossary/smart-contract"
@@ -9268,7 +9268,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/smart-contract-wallet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/smart-contract-wallet",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9282,7 +9282,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/snapshot",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/snapshot",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9296,7 +9296,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/social-recovery-wallet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/social-recovery-wallet",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9310,7 +9310,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/social-trading",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/social-trading",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9324,7 +9324,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/socialfi",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/socialfi",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9338,7 +9338,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9352,7 +9352,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/soft-landing",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/soft-landing",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9366,7 +9366,7 @@
       "definitionSource": "Consensys Software Inc., A Blockchain Glossary for Beginners",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "Solidity is a programming language created in 2014 that was specifically designed to write and implement smart contracts on the Ethereum blockchain.",
           "source": "https://academy.binance.com/en/glossary/solidity"
@@ -9385,7 +9385,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/source-code",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/source-code",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9399,7 +9399,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/spl",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/spl",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9413,7 +9413,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/src-20-tokens",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/src-20-tokens",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9427,7 +9427,7 @@
       "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "A type of cryptocurrency that is designed to maintain a stable value, rather than experiencing significant price changes.",
           "source": "https://academy.binance.com/en/glossary/stablecoin"
@@ -9446,7 +9446,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/stagflation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/stagflation",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9460,7 +9460,7 @@
       "definitionSource": "Consensys Software Inc., A Blockchain Glossary for Beginners",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "Tokens forfeit to the cluster if malicious validator behavior can be proven.",
           "source": "https://solana.com/docs/references/terminology#stake"
@@ -9479,7 +9479,7 @@
       "definitionSource": "Consensys Software Inc., A Blockchain Glossary for Beginners",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9493,7 +9493,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/staking-pool",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/staking-pool",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9507,7 +9507,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9521,7 +9521,7 @@
       "definitionSource": "Consensys Software Inc., A Blockchain Glossary for Beginners",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "A two-way communication channel between two users or nodes on a network, or between a user and a service.",
           "source": "https://academy.binance.com/en/glossary/state-channel"
@@ -9540,7 +9540,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/steth",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/steth",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9554,7 +9554,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9568,7 +9568,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/stock-variable",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/stock-variable",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9582,7 +9582,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/store-of-value",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/store-of-value",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9596,7 +9596,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9610,7 +9610,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/supercomputer",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/supercomputer",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9624,7 +9624,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/supply-chain",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/supply-chain",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9638,7 +9638,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/support",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/support",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9652,7 +9652,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9666,7 +9666,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/sybil-attack",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/sybil-attack",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9680,7 +9680,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9694,7 +9694,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/taker",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/taker",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9708,7 +9708,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/tank",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/tank",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9722,7 +9722,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9736,7 +9736,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9750,7 +9750,7 @@
       "definitionSource": "Consensys Software Inc., A Blockchain Glossary for Beginners",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "Testnets are replicas of the mainnet, offering risk-free, secure environments for exploring and testing blockchain features.",
           "source": "https://academy.binance.com/en/glossary/testnet"
@@ -9769,7 +9769,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9783,7 +9783,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9797,7 +9797,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9811,7 +9811,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/ticker",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/ticker",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9825,7 +9825,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/ticker-symbol",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/ticker-symbol",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9839,7 +9839,7 @@
       "definitionSource": "Consensys Software Inc., A Blockchain Glossary for Beginners",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "Tokens (not to be confused with coins) are digital units issued on a blockchain. They can hold value or be redeemed for assets.",
           "source": "https://academy.binance.com/en/glossary/token"
@@ -9862,7 +9862,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/token-generation-event-tge",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/token-generation-event-tge",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9876,7 +9876,7 @@
       "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "Token lockup or vesting period refers to the time span in which tokens or coins are not allowed to be transferred or traded.",
           "source": "https://academy.binance.com/en/glossary/token-lockup"
@@ -9895,7 +9895,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/token-merge",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/token-merge",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9909,7 +9909,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/token-sale",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/token-sale",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9923,7 +9923,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "Learn about ERC-20, ERC-721, BEP-20, and TRC-20 token standards in blockchain networks. Understand their role in cryptocurrency transactions and decentralized applications.",
           "source": "https://academy.binance.com/en/glossary/token-standards"
@@ -9942,7 +9942,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/tokenization",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/tokenization",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9956,7 +9956,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/tokenomics",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/tokenomics",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9970,7 +9970,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/total-supply",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/total-supply",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9984,7 +9984,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/total-value-locked-tvl",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/total-value-locked-tvl",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -9998,7 +9998,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/tradfi",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/tradfi",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -10012,7 +10012,7 @@
       "definitionSource": "Consensys Software Inc., A Blockchain Glossary for Beginners",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "One or more instructions signed by a client using one or more keypairs and executed atomically with only two possible outcomes: success or failure.",
           "source": "https://solana.com/docs/references/terminology#transaction"
@@ -10031,7 +10031,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10045,7 +10045,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10059,7 +10059,7 @@
       "definitionSource": "Consensys Software Inc., A Blockchain Glossary for Beginners",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "A transaction ID (TXID) is a unique string of characters that labels each transaction on the blockchain.",
           "source": "https://academy.binance.com/en/glossary/transaction-id"
@@ -10082,7 +10082,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10096,7 +10096,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/transactions-per-second-tps",
       "sampleSentence": "",
       "extended": "Generally abbreviated to 'TPS'.",
-      "alternate": [
+      "additional": [
         {
           "definition": "Transactions per second.",
           "source": "https://solana.com/docs/references/terminology#tps"
@@ -10115,7 +10115,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10129,7 +10129,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/treasury-bills-t-bills",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/treasury-bills-t-bills",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -10143,7 +10143,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10157,7 +10157,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/trueusd-tusd",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/trueusd-tusd",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -10171,7 +10171,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10185,7 +10185,7 @@
       "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "No single entity has authority over the system and consensus is achieved between participants who do not have to trust each other.",
           "source": "https://academy.binance.com/en/glossary/trustless"
@@ -10204,7 +10204,7 @@
       "definitionSource": "Consensys Software Inc., A Blockchain Glossary for Beginners",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "A machine that, given enough time and memory along with the necessary instructions, can solve any computational problem.",
           "source": "https://academy.binance.com/en/glossary/turing-complete"
@@ -10223,7 +10223,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10237,7 +10237,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10251,7 +10251,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10265,7 +10265,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/understanding-cz-s-number-4",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/understanding-cz-s-number-4",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -10279,7 +10279,7 @@
       "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10293,7 +10293,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10307,7 +10307,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/unit-of-account",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/unit-of-account",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -10321,7 +10321,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "An output created in a transaction, which must be referenced in a future transaction to spend funds.",
           "source": "https://academy.binance.com/en/glossary/unspent-transaction-output-utxo"
@@ -10340,7 +10340,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10354,7 +10354,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10368,7 +10368,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10382,7 +10382,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10396,7 +10396,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/user-interface",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/user-interface",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -10410,7 +10410,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/utility-token",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/utility-token",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -10424,7 +10424,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10438,7 +10438,7 @@
       "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "A full participant in a Solana network cluster that produces new blocks. A validator validates the transactions added to the ledger",
           "source": "https://solana.com/docs/references/terminology#validator"
@@ -10457,7 +10457,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10471,7 +10471,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10485,7 +10485,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/verification-code",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/verification-code",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -10499,7 +10499,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10513,7 +10513,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10527,7 +10527,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/virtual-machine",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/virtual-machine",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -10541,7 +10541,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/vladimir-club",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/vladimir-club",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -10555,7 +10555,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/volatility",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/volatility",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -10569,7 +10569,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/volume",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/volume",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -10583,7 +10583,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/wagmi",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/wagmi",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -10597,7 +10597,7 @@
       "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "Used to send and receive cryptocurrencies. Different types include software wallets, hardware wallets, and paper wallets.",
           "source": "https://academy.binance.com/en/glossary/wallet"
@@ -10620,7 +10620,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10634,7 +10634,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10648,7 +10648,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/wash-trading",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/wash-trading",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -10662,7 +10662,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/weak-hands",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/weak-hands",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -10676,7 +10676,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/weak-subjectivity",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/weak-subjectivity",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -10690,7 +10690,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/web-1",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/web-1",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -10704,7 +10704,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10718,7 +10718,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10732,7 +10732,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10746,7 +10746,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10760,7 +10760,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10774,7 +10774,7 @@
       "definitionSource": "Consensys Software Inc., A Blockchain Glossary for Beginners",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "The smallest possible denomination of ether (ETH), the currency used on the Ethereum network. Often used when referring to gas prices.",
           "source": "https://academy.binance.com/en/glossary/wei"
@@ -10793,7 +10793,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/weighted-moving-average-wma",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/weighted-moving-average-wma",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -10807,7 +10807,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/whale",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/whale",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -10821,7 +10821,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/whiskers",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/whiskers",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -10835,7 +10835,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/whitelist",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/whitelist",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -10849,7 +10849,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10863,7 +10863,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/wick",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/wick",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -10877,7 +10877,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/win-rate",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/win-rate",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -10891,7 +10891,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/wrapped-ether",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/wrapped-ether",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -10905,7 +10905,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10919,7 +10919,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/wyckoff",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/wyckoff",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -10933,7 +10933,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10947,7 +10947,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10961,7 +10961,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10975,7 +10975,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10989,7 +10989,7 @@
       "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "Yield farming is a high-risk practice in DeFi where investors lock up assets to provide liquidity, lend or stake in return for rewards or interest.",
           "source": "https://academy.binance.com/en/glossary/yield-farming"
@@ -11008,7 +11008,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -11022,7 +11022,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "Verify transactions are valid without revealing any information about the transactions, providing privacy.",
           "source": "https://academy.binance.com/en/glossary/zero-knowledge-proofs"
@@ -11041,7 +11041,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "Zk-rollup is a layer-2 scaling solution designed to increase the transaction throughput of blockchain networks without compromising on security.",
           "source": "https://academy.binance.com/en/glossary/zk-rollup"
@@ -11060,7 +11060,7 @@
       "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [
+      "additional": [
         {
           "definition": "“Zero-Knowledge Succinct Non-Interactive Argument of Knowledge” - an approach to zero-knowledge proofs.",
           "source": "https://academy.binance.com/en/glossary/zk-snarks"
@@ -11079,7 +11079,7 @@
       "definitionSource": "https://academy.binance.com/en/glossary/zk-starks",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/en/glossary/zk-starks",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
@@ -11093,7 +11093,7 @@
       "definitionSource": "https://solana.com/docs/references/terminology#account-owner",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "Solana Glossary",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
@@ -11107,7 +11107,7 @@
       "definitionSource": "https://solana.com/docs/references/terminology#app",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "Solana Glossary",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
@@ -11121,7 +11121,7 @@
       "definitionSource": "https://solana.com/docs/references/terminology#authority",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "Solana Glossary",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
@@ -11135,7 +11135,7 @@
       "definitionSource": "https://solana.com/docs/references/terminology#bank-state",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "Solana Glossary",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
@@ -11149,7 +11149,7 @@
       "definitionSource": "https://solana.com/docs/references/terminology#blockhash",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "Solana Glossary",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
@@ -11163,7 +11163,7 @@
       "definitionSource": "https://solana.com/docs/references/terminology#bootstrap-validator",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "Solana Glossary",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
@@ -11177,7 +11177,7 @@
       "definitionSource": "https://solana.com/docs/references/terminology#bpf-loader",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "Solana Glossary",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
@@ -11191,7 +11191,7 @@
       "definitionSource": "https://solana.com/docs/references/terminology#commitment",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "Solana Glossary",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
@@ -11205,7 +11205,7 @@
       "definitionSource": "https://solana.com/docs/references/terminology#cluster",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "Solana Glossary",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
@@ -11219,7 +11219,7 @@
       "definitionSource": "https://solana.com/docs/references/terminology#compute-budget",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "Solana Glossary",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
@@ -11233,7 +11233,7 @@
       "definitionSource": "https://solana.com/docs/references/terminology#compute-units",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "Solana Glossary",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
@@ -11247,7 +11247,7 @@
       "definitionSource": "https://solana.com/docs/references/terminology#confirmed-block",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "Solana Glossary",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
@@ -11261,7 +11261,7 @@
       "definitionSource": "https://solana.com/docs/references/terminology#control-plane",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "Solana Glossary",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
@@ -11275,7 +11275,7 @@
       "definitionSource": "https://solana.com/docs/references/terminology#cooldown-period",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "Solana Glossary",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
@@ -11289,7 +11289,7 @@
       "definitionSource": "https://solana.com/docs/references/terminology#credit",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "Solana Glossary",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
@@ -11303,7 +11303,7 @@
       "definitionSource": "https://solana.com/docs/references/terminology#cross-program-invocation-cpi",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "Solana Glossary",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
@@ -11317,7 +11317,7 @@
       "definitionSource": "https://solana.com/docs/references/terminology#data-plane",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "Solana Glossary",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
@@ -11331,7 +11331,7 @@
       "definitionSource": "https://solana.com/docs/references/terminology#drone",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "Solana Glossary",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
@@ -11345,7 +11345,7 @@
       "definitionSource": "https://solana.com/docs/references/terminology#entry",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "Solana Glossary",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
@@ -11359,7 +11359,7 @@
       "definitionSource": "https://solana.com/docs/references/terminology#entry-id",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "Solana Glossary",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
@@ -11373,7 +11373,7 @@
       "definitionSource": "https://solana.com/docs/references/terminology#fee-account",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "Solana Glossary",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
@@ -11387,7 +11387,7 @@
       "definitionSource": "https://solana.com/docs/references/terminology#genesis-config",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "Solana Glossary",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
@@ -11401,7 +11401,7 @@
       "definitionSource": "https://solana.com/docs/references/terminology#inflation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "Solana Glossary",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
@@ -11415,7 +11415,7 @@
       "definitionSource": "https://solana.com/docs/references/terminology#inner-instruction",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "Solana Glossary",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
@@ -11429,7 +11429,7 @@
       "definitionSource": "https://solana.com/docs/references/terminology#instruction",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "Solana Glossary",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
@@ -11443,7 +11443,7 @@
       "definitionSource": "https://solana.com/docs/references/terminology#instruction-handler",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "Solana Glossary",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
@@ -11457,7 +11457,7 @@
       "definitionSource": "https://solana.com/docs/references/terminology#keypair",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "Solana Glossary",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
@@ -11471,7 +11471,7 @@
       "definitionSource": "https://solana.com/docs/references/terminology#lamport",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "Solana Glossary",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
@@ -11485,7 +11485,7 @@
       "definitionSource": "https://solana.com/docs/references/terminology#leader",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "Solana Glossary",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
@@ -11499,7 +11499,7 @@
       "definitionSource": "https://solana.com/docs/references/terminology#leader-schedule",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "Solana Glossary",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
@@ -11513,7 +11513,7 @@
       "definitionSource": "https://solana.com/docs/references/terminology#ledger-vote",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "Solana Glossary",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
@@ -11527,7 +11527,7 @@
       "definitionSource": "https://solana.com/docs/references/terminology#loader",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "Solana Glossary",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
@@ -11541,7 +11541,7 @@
       "definitionSource": "https://solana.com/docs/references/terminology#lockout",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "Solana Glossary",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
@@ -11555,7 +11555,7 @@
       "definitionSource": "https://solana.com/docs/references/terminology#message",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "Solana Glossary",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
@@ -11569,7 +11569,7 @@
       "definitionSource": "https://solana.com/docs/references/terminology#nakamoto-coefficient",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "Solana Glossary",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
@@ -11583,7 +11583,7 @@
       "definitionSource": "https://solana.com/docs/references/terminology#native-token",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "Solana Glossary",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
@@ -11597,7 +11597,7 @@
       "definitionSource": "https://solana.com/docs/references/terminology#node-count",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "Solana Glossary",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
@@ -11611,7 +11611,7 @@
       "definitionSource": "https://solana.com/docs/references/terminology#onchain-program",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "Solana Glossary",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
@@ -11625,7 +11625,7 @@
       "definitionSource": "https://solana.com/docs/references/terminology#poh",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "Solana Glossary",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
@@ -11639,7 +11639,7 @@
       "definitionSource": "https://solana.com/docs/references/terminology#point",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "Solana Glossary",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
@@ -11653,7 +11653,7 @@
       "definitionSource": "https://solana.com/docs/references/terminology#program",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "Solana Glossary",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
@@ -11667,7 +11667,7 @@
       "definitionSource": "https://solana.com/docs/references/terminology#program-derived-account-pda",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "Solana Glossary",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
@@ -11681,7 +11681,7 @@
       "definitionSource": "https://solana.com/docs/references/terminology#program-id",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "Solana Glossary",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
@@ -11695,7 +11695,7 @@
       "definitionSource": "https://solana.com/docs/references/terminology#proof-of-history-poh",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "Solana Glossary",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
@@ -11709,7 +11709,7 @@
       "definitionSource": "https://solana.com/docs/references/terminology#prioritization-fee",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "Solana Glossary",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
@@ -11723,7 +11723,7 @@
       "definitionSource": "https://solana.com/docs/references/terminology#rent",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "Solana Glossary",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
@@ -11737,7 +11737,7 @@
       "definitionSource": "https://solana.com/docs/references/terminology#rent-exempt",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "Solana Glossary",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
@@ -11751,7 +11751,7 @@
       "definitionSource": "https://solana.com/docs/references/terminology#root",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "Solana Glossary",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
@@ -11765,7 +11765,7 @@
       "definitionSource": "https://solana.com/docs/references/terminology#runtime",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "Solana Glossary",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
@@ -11779,7 +11779,7 @@
       "definitionSource": "https://solana.com/docs/references/terminology#sealevel",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "Solana Glossary",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
@@ -11793,7 +11793,7 @@
       "definitionSource": "https://solana.com/docs/references/terminology#shred",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "Solana Glossary",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
@@ -11807,7 +11807,7 @@
       "definitionSource": "https://solana.com/docs/references/terminology#skip-rate",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "Solana Glossary",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
@@ -11821,7 +11821,7 @@
       "definitionSource": "https://solana.com/docs/references/terminology#skipped-slot",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "Solana Glossary",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
@@ -11835,7 +11835,7 @@
       "definitionSource": "https://solana.com/docs/references/terminology#sol",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "Solana Glossary",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
@@ -11849,7 +11849,7 @@
       "definitionSource": "https://solana.com/docs/references/terminology#solana-program-library-spl",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "Solana Glossary",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
@@ -11863,7 +11863,7 @@
       "definitionSource": "https://solana.com/docs/references/terminology#stake-weighted-quality-of-service-swqos",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "Solana Glossary",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
@@ -11877,7 +11877,7 @@
       "definitionSource": "https://solana.com/docs/references/terminology#supermajority",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "Solana Glossary",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
@@ -11891,7 +11891,7 @@
       "definitionSource": "https://solana.com/docs/references/terminology#sysvar",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "Solana Glossary",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
@@ -11905,7 +11905,7 @@
       "definitionSource": "https://solana.com/docs/references/terminology#thin-client",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "Solana Glossary",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
@@ -11919,7 +11919,7 @@
       "definitionSource": "https://solana.com/docs/references/terminology#tick",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "Solana Glossary",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
@@ -11933,7 +11933,7 @@
       "definitionSource": "https://solana.com/docs/references/terminology#tick-height",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "Solana Glossary",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
@@ -11947,7 +11947,7 @@
       "definitionSource": "https://solana.com/docs/references/terminology#token-extensions-program",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "Solana Glossary",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
@@ -11961,7 +11961,7 @@
       "definitionSource": "https://solana.com/docs/references/terminology#token-mint",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "Solana Glossary",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
@@ -11975,7 +11975,7 @@
       "definitionSource": "https://solana.com/docs/references/terminology#token-program",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "Solana Glossary",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
@@ -11989,7 +11989,7 @@
       "definitionSource": "https://solana.com/docs/references/terminology#tpu",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "Solana Glossary",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
@@ -12003,7 +12003,7 @@
       "definitionSource": "https://solana.com/docs/references/terminology#transaction-confirmations",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "Solana Glossary",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
@@ -12017,7 +12017,7 @@
       "definitionSource": "https://solana.com/docs/references/terminology#transactions-entry",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "Solana Glossary",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
@@ -12031,7 +12031,7 @@
       "definitionSource": "https://solana.com/docs/references/terminology#tvu",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "Solana Glossary",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
@@ -12045,7 +12045,7 @@
       "definitionSource": "https://solana.com/docs/references/terminology#vdf",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "Solana Glossary",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
@@ -12059,7 +12059,7 @@
       "definitionSource": "https://solana.com/docs/references/terminology#verifiable-delay-function-vdf",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "Solana Glossary",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
@@ -12073,7 +12073,7 @@
       "definitionSource": "https://solana.com/docs/references/terminology#vote",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "Solana Glossary",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
@@ -12087,7 +12087,7 @@
       "definitionSource": "https://solana.com/docs/references/terminology#vote-credit",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "Solana Glossary",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
@@ -12101,7 +12101,7 @@
       "definitionSource": "https://solana.com/docs/references/terminology#warmup-period",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "Solana Glossary",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""

--- a/locales/en-US/en-US.json
+++ b/locales/en-US/en-US.json
@@ -10120,7 +10120,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "treasury-bills-t-bills": {
+    "treasury-bills": {
       "term": "Treasury Bills",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/es-419/es-419.json
+++ b/locales/es-419/es-419.json
@@ -9576,8 +9576,8 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "treasury-bills-t-bills": {
-      "term": "Letras del Tesoro (<em>T-Bills</em>)",
+    "treasury-bills": {
+      "term": "Letras del Tesoro",
       "partOfSpeech": "",
       "termCategory": "",
       "phonetic": "",

--- a/locales/es-419/es-419.json
+++ b/locales/es-419/es-419.json
@@ -9,7 +9,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -23,7 +23,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -37,7 +37,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -51,7 +51,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -65,7 +65,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -79,7 +79,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -93,7 +93,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -107,7 +107,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/absolute-advantage",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/absolute-advantage",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -121,7 +121,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -135,7 +135,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -149,7 +149,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/active-management",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/active-management",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -163,7 +163,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/actively-validated-services-avs",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/actively-validated-services-avs",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -177,7 +177,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/ad-hoc",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/ad-hoc",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -191,7 +191,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/address",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/address",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -205,7 +205,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -219,7 +219,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -233,7 +233,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -247,7 +247,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/airdrop",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/airdrop",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -261,7 +261,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -275,7 +275,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -289,7 +289,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/algorithm",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/algorithm",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -303,7 +303,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/all-or-none-order",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/all-or-none-order",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -317,7 +317,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/all-time-high",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/all-time-high",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -331,7 +331,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/allocation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/allocation",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -345,7 +345,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/alpha",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/alpha",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -359,7 +359,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/altcoin",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/altcoin",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -373,7 +373,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -387,7 +387,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/angel-investor",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/angel-investor",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -401,7 +401,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/anti-money-laundering",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/anti-money-laundering",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -415,7 +415,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -429,7 +429,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -443,7 +443,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -457,7 +457,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/application-programming-interface",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/application-programming-interface",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -471,7 +471,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/application-specific-integrated-circuit",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/application-specific-integrated-circuit",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -485,7 +485,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/arbitrage",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/arbitrage",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -499,7 +499,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -513,7 +513,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/arc-20",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/arc-20",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -527,7 +527,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/artificial-intelligence-ai",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/artificial-intelligence-ai",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -541,7 +541,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -555,7 +555,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/asic-resistant",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/asic-resistant",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -569,7 +569,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/asking-price",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/asking-price",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -583,7 +583,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/asset-management",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/asset-management",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -597,7 +597,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -611,7 +611,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/assets-under-management-aum",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/assets-under-management-aum",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -625,7 +625,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/asynchronous",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/asynchronous",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -639,7 +639,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/atomic-swap",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/atomic-swap",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -653,7 +653,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/attack-surface",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/attack-surface",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -667,7 +667,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -681,7 +681,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/auction",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/auction",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -695,7 +695,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -709,7 +709,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/automated-market-maker-amm",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/automated-market-maker-amm",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -723,7 +723,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -737,7 +737,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -751,7 +751,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -765,7 +765,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/b-tokens",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/b-tokens",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -779,7 +779,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/bags",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/bags",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -793,7 +793,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -807,7 +807,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/beacon-chain",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/beacon-chain",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -821,7 +821,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/bear-market",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/bear-market",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -835,7 +835,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/benchmark",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/benchmark",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -849,7 +849,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/bep-1155",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/bep-1155",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -863,7 +863,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/bep-20",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/bep-20",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -877,7 +877,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/bep-721",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/bep-721",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -891,7 +891,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/bep-95",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/bep-95",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -905,7 +905,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -919,7 +919,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/beta-coefficient",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/beta-coefficient",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -933,7 +933,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/beta-release",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/beta-release",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -947,7 +947,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/bid-ask-spread",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/bid-ask-spread",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -961,7 +961,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/bid-price",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/bid-price",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -975,7 +975,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -989,7 +989,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/binance-blockchain-charity-foundation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/binance-blockchain-charity-foundation",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1003,7 +1003,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/binance-ecosystem-fund",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/binance-ecosystem-fund",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1017,7 +1017,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/binancian",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/binancian",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1031,7 +1031,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/bitcoin",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/bitcoin",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1045,7 +1045,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/bitcoin-core",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/bitcoin-core",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1059,7 +1059,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/bitcoin-dominance",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/bitcoin-dominance",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1073,7 +1073,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/bitcoin-maximalists",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/bitcoin-maximalists",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1087,7 +1087,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/bitcoin-pizza",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/bitcoin-pizza",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1101,7 +1101,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/black-swan-event",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/black-swan-event",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1115,7 +1115,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/block",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/block",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1129,7 +1129,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/block-explorer",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/block-explorer",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1143,7 +1143,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/block-header",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/block-header",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1157,7 +1157,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/block-height",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/block-height",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1171,7 +1171,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/block-reward",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/block-reward",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1185,7 +1185,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1199,7 +1199,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1213,7 +1213,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/blockchain",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/blockchain",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1227,7 +1227,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1241,7 +1241,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1255,7 +1255,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/bloom-filter",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/bloom-filter",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1269,7 +1269,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/blue-chip-token",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/blue-chip-token",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1283,7 +1283,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/bnb",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/bnb",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1297,7 +1297,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1311,7 +1311,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/bnsol",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/bnsol",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1325,7 +1325,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/bollinger-bands",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/bollinger-bands",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1339,7 +1339,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/bond",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/bond",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1353,7 +1353,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/bounty",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/bounty",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1367,7 +1367,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1381,7 +1381,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1395,7 +1395,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/brc-20-tokens",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/brc-20-tokens",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1409,7 +1409,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/break-even-point",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/break-even-point",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1423,7 +1423,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/breakeven-multiple",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/breakeven-multiple",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1437,7 +1437,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/breakout",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/breakout",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1451,7 +1451,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1465,7 +1465,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/bscscan",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/bscscan",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1479,7 +1479,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1493,7 +1493,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/btc-wallet-address",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/btc-wallet-address",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1507,7 +1507,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/buidl",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/buidl",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1521,7 +1521,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/bull-market",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/bull-market",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1535,7 +1535,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/burner-wallet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/burner-wallet",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1549,7 +1549,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/buy-wall",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/buy-wall",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1563,7 +1563,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1577,7 +1577,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1591,7 +1591,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1605,7 +1605,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/candidate-block",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/candidate-block",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1619,7 +1619,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/candlestick",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/candlestick",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1633,7 +1633,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/capitulation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/capitulation",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1647,7 +1647,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1661,7 +1661,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/censorship-resistance",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/censorship-resistance",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1675,7 +1675,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/central-bank",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/central-bank",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1689,7 +1689,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/central-bank-digital-currency-cbdc",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/central-bank-digital-currency-cbdc",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1703,7 +1703,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/central-processing-unit",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/central-processing-unit",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1717,7 +1717,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/centralized",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/centralized",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1731,7 +1731,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/centralized-exchange",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/centralized-exchange",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1745,7 +1745,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1759,7 +1759,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1773,7 +1773,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/chatgpt",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/chatgpt",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1787,7 +1787,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1801,7 +1801,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/cipher",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/cipher",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1815,7 +1815,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/circulating-supply",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/circulating-supply",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1829,7 +1829,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1843,7 +1843,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/cloud",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/cloud",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1857,7 +1857,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1871,7 +1871,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/coin",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/coin",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1885,7 +1885,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1899,7 +1899,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1913,7 +1913,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/cold-storage",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/cold-storage",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1927,7 +1927,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1941,7 +1941,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/collateral",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/collateral",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1955,7 +1955,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/colocation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/colocation",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1969,7 +1969,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/commodity-futures-trading-commission",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/commodity-futures-trading-commission",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1983,7 +1983,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1997,7 +1997,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2011,7 +2011,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/compound-interest",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/compound-interest",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2025,7 +2025,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2039,7 +2039,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/confirmation-time",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/confirmation-time",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2053,7 +2053,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/confluence",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/confluence",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2067,7 +2067,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2081,7 +2081,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/consensus-algorithm",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/consensus-algorithm",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2095,7 +2095,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2109,7 +2109,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2123,7 +2123,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2137,7 +2137,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2151,7 +2151,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2165,7 +2165,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/consumer-price-index-(cpi)",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/consumer-price-index-(cpi)",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2179,7 +2179,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/contango-and-backwardation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/contango-and-backwardation",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2193,7 +2193,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2207,7 +2207,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2221,7 +2221,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2235,7 +2235,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/copy-trading",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/copy-trading",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2249,7 +2249,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/counterparty-risk",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/counterparty-risk",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2263,7 +2263,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/credentials",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/credentials",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2277,7 +2277,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/cross-chain-bridges",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/cross-chain-bridges",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2291,7 +2291,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2305,7 +2305,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2319,7 +2319,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2333,7 +2333,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2347,7 +2347,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/crypto-etfs",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/crypto-etfs",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2361,7 +2361,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/crypto-fear-and-greed-index",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/crypto-fear-and-greed-index",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2375,7 +2375,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2389,7 +2389,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/crypto-protocol",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/crypto-protocol",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2403,7 +2403,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2417,7 +2417,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/crypto-winter",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/crypto-winter",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2431,7 +2431,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2445,7 +2445,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/cryptocurrency",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/cryptocurrency",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2459,7 +2459,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2473,7 +2473,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/cryptography",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/cryptography",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2487,7 +2487,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2501,7 +2501,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/custody",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/custody",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2515,7 +2515,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2529,7 +2529,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/daemon",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/daemon",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2543,7 +2543,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2557,7 +2557,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/danksharding",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/danksharding",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2571,7 +2571,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2585,7 +2585,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2599,7 +2599,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2613,7 +2613,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/dead-cat-bounce",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/dead-cat-bounce",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2627,7 +2627,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/death-cross",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/death-cross",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2641,7 +2641,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2655,7 +2655,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/decentralized-application",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/decentralized-application",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2669,7 +2669,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/decentralized-autonomous-cooperative",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/decentralized-autonomous-cooperative",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2683,7 +2683,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/decentralized-autonomous-organization",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/decentralized-autonomous-organization",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2697,7 +2697,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/decentralized-exchange",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/decentralized-exchange",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2711,7 +2711,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2725,7 +2725,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/decentralized-indexes",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/decentralized-indexes",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2739,7 +2739,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2753,7 +2753,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/decryption",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/decryption",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2767,7 +2767,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/deep-web",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/deep-web",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2781,7 +2781,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2795,7 +2795,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2809,7 +2809,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/delisting",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/delisting",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2823,7 +2823,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2837,7 +2837,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/depeg",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/depeg",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2851,7 +2851,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2865,7 +2865,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/depression",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/depression",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2879,7 +2879,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2893,7 +2893,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/design-flaw-attack",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/design-flaw-attack",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2907,7 +2907,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2921,7 +2921,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2935,7 +2935,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2949,7 +2949,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2963,7 +2963,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/diamond-hands",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/diamond-hands",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2977,7 +2977,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/difficulty",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/difficulty",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2991,7 +2991,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/difficulty-bomb",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/difficulty-bomb",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3005,7 +3005,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3019,7 +3019,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3033,7 +3033,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/digital-signature",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/digital-signature",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3047,7 +3047,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3061,7 +3061,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/direct-market-access-dma",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/direct-market-access-dma",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3075,7 +3075,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3089,7 +3089,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/divergence",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/divergence",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3103,7 +3103,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/diversification",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/diversification",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3117,7 +3117,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3131,7 +3131,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/do-your-own-research",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/do-your-own-research",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3145,7 +3145,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/dollar-cost-averaging",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/dollar-cost-averaging",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3159,7 +3159,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/dot-plot",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/dot-plot",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3173,7 +3173,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3187,7 +3187,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/double-spending",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/double-spending",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3201,7 +3201,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/eclipse-attack",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/eclipse-attack",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3215,7 +3215,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3229,7 +3229,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3243,7 +3243,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/efficient-market-hypothesis-emh",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/efficient-market-hypothesis-emh",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3257,7 +3257,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/eigenlayer",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/eigenlayer",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3271,7 +3271,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/eip",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/eip",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3285,7 +3285,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3299,7 +3299,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/eip-3074",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/eip-3074",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3313,7 +3313,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/eip-4844",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/eip-4844",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3327,7 +3327,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/eip-7251",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/eip-7251",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3341,7 +3341,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/eip-7702",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/eip-7702",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3355,7 +3355,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/elasticity",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/elasticity",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3369,7 +3369,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3383,7 +3383,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/encryption",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/encryption",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3397,7 +3397,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/endogenous-variable",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/endogenous-variable",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3411,7 +3411,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3425,7 +3425,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3439,7 +3439,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3453,7 +3453,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3467,7 +3467,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/erc-1155",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/erc-1155",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3481,7 +3481,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/erc-20",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/erc-20",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3495,7 +3495,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/erc-404",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/erc-404",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3509,7 +3509,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/erc-721",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/erc-721",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3523,7 +3523,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/etf",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/etf",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3537,7 +3537,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3551,7 +3551,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3565,7 +3565,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3579,7 +3579,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3593,7 +3593,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/ethereum-classic",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/ethereum-classic",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3607,7 +3607,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/ethereum-foundation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/ethereum-foundation",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3621,7 +3621,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3635,7 +3635,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3649,7 +3649,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3663,7 +3663,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3677,7 +3677,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/ethereum-virtual-machine-evm",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/ethereum-virtual-machine-evm",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3691,7 +3691,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3705,7 +3705,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3719,7 +3719,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3733,7 +3733,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/exchange",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/exchange",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3747,7 +3747,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3761,7 +3761,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3775,7 +3775,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/exogenous-variable",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/exogenous-variable",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3789,7 +3789,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/exponential-moving-average-ema",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/exponential-moving-average-ema",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3803,7 +3803,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/externally-owned-account-eoa",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/externally-owned-account-eoa",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3817,7 +3817,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/fakeout",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/fakeout",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3831,7 +3831,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/falling-knife",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/falling-knife",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3845,7 +3845,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/fan-tokens",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/fan-tokens",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3859,7 +3859,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3873,7 +3873,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3887,7 +3887,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3901,7 +3901,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/fear-of-missing-out",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/fear-of-missing-out",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3915,7 +3915,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/fear-uncertainty-and-doubt",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/fear-uncertainty-and-doubt",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3929,7 +3929,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/fiat",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/fiat",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3943,7 +3943,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3957,7 +3957,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/fibonacci-retracement",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/fibonacci-retracement",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3971,7 +3971,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/fill-or-kill-order",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/fill-or-kill-order",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3985,7 +3985,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/finality",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/finality",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3999,7 +3999,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4013,7 +4013,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4027,7 +4027,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4041,7 +4041,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4055,7 +4055,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4069,7 +4069,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4083,7 +4083,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/first-mover-advantage",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/first-mover-advantage",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4097,7 +4097,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/fiscal-policy",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/fiscal-policy",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4111,7 +4111,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/flappening",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/flappening",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4125,7 +4125,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/flashbots",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/flashbots",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4139,7 +4139,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/flippening",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/flippening",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4153,7 +4153,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/flow-variable",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/flow-variable",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4167,7 +4167,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/forced-liquidation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/forced-liquidation",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4181,7 +4181,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/forex-fx",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/forex-fx",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4195,7 +4195,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/fork",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/fork",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4209,7 +4209,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/formal-verification",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/formal-verification",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4223,7 +4223,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4237,7 +4237,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/fraud-proof",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/fraud-proof",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4251,7 +4251,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/fren",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/fren",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4265,7 +4265,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4279,7 +4279,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/full-node",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/full-node",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4293,7 +4293,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/fully-diluted-valuation-fdv",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/fully-diluted-valuation-fdv",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4307,7 +4307,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/fundamental-analysis",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/fundamental-analysis",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4321,7 +4321,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/funding-fees",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/funding-fees",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4335,7 +4335,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/fungibility",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/fungibility",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4349,7 +4349,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/futures-contract",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/futures-contract",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4363,7 +4363,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/gamefi",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/gamefi",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4377,7 +4377,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4391,7 +4391,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/gas",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/gas",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4405,7 +4405,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4419,7 +4419,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/gas-limit",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/gas-limit",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4433,7 +4433,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4447,7 +4447,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4461,7 +4461,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4475,7 +4475,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/gdp-deflator",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/gdp-deflator",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4489,7 +4489,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/general-public-license",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/general-public-license",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4503,7 +4503,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/genesis-block",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/genesis-block",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4517,7 +4517,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4531,7 +4531,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/github",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/github",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4545,7 +4545,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/gm-good-morning",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/gm-good-morning",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4559,7 +4559,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4573,7 +4573,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/golden-cross",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/golden-cross",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4587,7 +4587,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/golden-ratio",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/golden-ratio",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4601,7 +4601,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/goldilocks",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/goldilocks",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4615,7 +4615,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/gossip-protocol",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/gossip-protocol",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4629,7 +4629,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4643,7 +4643,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/gross-domestic-product-gdp",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/gross-domestic-product-gdp",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4657,7 +4657,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4671,7 +4671,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/gwei",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/gwei",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4685,7 +4685,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/hackathon",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/hackathon",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4699,7 +4699,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/hacker",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/hacker",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4713,7 +4713,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/haha-money-printer-go-brrrrr",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/haha-money-printer-go-brrrrr",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4727,7 +4727,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/halving",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/halving",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4741,7 +4741,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/hard-cap",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/hard-cap",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4755,7 +4755,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4769,7 +4769,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/hard-landing",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/hard-landing",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4783,7 +4783,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4797,7 +4797,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4811,7 +4811,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/hash",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/hash",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4825,7 +4825,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/hash-rate",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/hash-rate",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4839,7 +4839,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/hashed-timelock-contract",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/hashed-timelock-contract",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4853,7 +4853,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4867,7 +4867,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/herd-instinct",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/herd-instinct",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4881,7 +4881,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4895,7 +4895,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/high-frequency-trading-hft",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/high-frequency-trading-hft",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4909,7 +4909,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/hodl",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/hodl",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4923,7 +4923,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/honeypot",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/honeypot",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4937,7 +4937,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4951,7 +4951,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4965,7 +4965,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4979,7 +4979,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4993,7 +4993,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5007,7 +5007,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/iceberg-order",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/iceberg-order",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5021,7 +5021,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5035,7 +5035,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5049,7 +5049,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/immutability",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/immutability",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5063,7 +5063,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/index-funds",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/index-funds",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5077,7 +5077,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5091,7 +5091,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/initial-coin-offering",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/initial-coin-offering",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5105,7 +5105,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/initial-dex-offering-ido",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/initial-dex-offering-ido",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5119,7 +5119,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/initial-exchange-offering",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/initial-exchange-offering",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5133,7 +5133,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/initial-public-offering",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/initial-public-offering",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5147,7 +5147,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/inscription",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/inscription",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5161,7 +5161,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5175,7 +5175,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/integrated-circuit",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/integrated-circuit",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5189,7 +5189,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/interest-rates",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/interest-rates",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5203,7 +5203,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5217,7 +5217,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/interoperability",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/interoperability",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5231,7 +5231,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5245,7 +5245,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/interplanetary-file-system-ipfs",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/interplanetary-file-system-ipfs",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5259,7 +5259,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/iou",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/iou",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5273,7 +5273,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5287,7 +5287,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5301,7 +5301,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5315,7 +5315,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/isolated-margin",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/isolated-margin",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5329,7 +5329,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/issuance",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/issuance",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5343,7 +5343,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5357,7 +5357,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5371,7 +5371,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/keccak",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/keccak",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5385,7 +5385,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5399,7 +5399,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/know-your-customer",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/know-your-customer",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5413,7 +5413,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5427,7 +5427,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5441,7 +5441,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5455,7 +5455,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5469,7 +5469,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/laspeyres-index",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/laspeyres-index",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5483,7 +5483,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/latency",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/latency",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5497,7 +5497,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5511,7 +5511,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5525,7 +5525,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/law-of-demand",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/law-of-demand",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5539,7 +5539,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5553,7 +5553,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/layer-2",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/layer-2",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5567,7 +5567,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/ledger",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/ledger",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5581,7 +5581,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5595,7 +5595,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5609,7 +5609,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/leveraged-tokens",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/leveraged-tokens",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5623,7 +5623,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/library",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/library",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5637,7 +5637,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5651,7 +5651,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5665,7 +5665,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/lightning-network",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/lightning-network",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5679,7 +5679,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/limit-order",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/limit-order",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5693,7 +5693,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5707,7 +5707,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/linux",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/linux",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5721,7 +5721,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/liquid-staking",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/liquid-staking",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5735,7 +5735,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/liquid-staking-token-lst",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/liquid-staking-token-lst",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5749,7 +5749,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5763,7 +5763,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/liquidity",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/liquidity",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5777,7 +5777,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/liquidity-crisis",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/liquidity-crisis",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5791,7 +5791,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5805,7 +5805,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/liquidity-provider",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/liquidity-provider",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5819,7 +5819,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/liquidity-ratios",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/liquidity-ratios",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5833,7 +5833,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5847,7 +5847,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/listing",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/listing",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5861,7 +5861,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/mainnet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/mainnet",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5875,7 +5875,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/mainnet-swap",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/mainnet-swap",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5889,7 +5889,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/maker",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/maker",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5903,7 +5903,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5917,7 +5917,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/malware",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/malware",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5931,7 +5931,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/margin-trading",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/margin-trading",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5945,7 +5945,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5959,7 +5959,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/market-capitalization",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/market-capitalization",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5973,7 +5973,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/market-momentum",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/market-momentum",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5987,7 +5987,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/market-order",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/market-order",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6001,7 +6001,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/masternode",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/masternode",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6015,7 +6015,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/matching-engine",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/matching-engine",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6029,7 +6029,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6043,7 +6043,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/maximum-supply",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/maximum-supply",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6057,7 +6057,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6071,7 +6071,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/mempool",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/mempool",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6085,7 +6085,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6099,7 +6099,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6113,7 +6113,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/merged-mining",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/merged-mining",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6127,7 +6127,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6141,7 +6141,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/merkle-tree",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/merkle-tree",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6155,7 +6155,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6169,7 +6169,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/metadata",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/metadata",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6183,7 +6183,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6197,7 +6197,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6211,7 +6211,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6225,7 +6225,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6239,7 +6239,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6253,7 +6253,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/metaverse",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/metaverse",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6267,7 +6267,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6281,7 +6281,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6295,7 +6295,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/microtransactions",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/microtransactions",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6309,7 +6309,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6323,7 +6323,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6337,7 +6337,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/mining",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/mining",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6351,7 +6351,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/mining-farm",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/mining-farm",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6365,7 +6365,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/mint",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/mint",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6379,7 +6379,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6393,7 +6393,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6407,7 +6407,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6421,7 +6421,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/monetary-policy",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/monetary-policy",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6435,7 +6435,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/money-markets",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/money-markets",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6449,7 +6449,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/monitoring-tag",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/monitoring-tag",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6463,7 +6463,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/moon",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/moon",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6477,7 +6477,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6491,7 +6491,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/moving-average-envelopes",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/moving-average-envelopes",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6505,7 +6505,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/moving-average-ribbon",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/moving-average-ribbon",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6519,7 +6519,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/mt-gox",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/mt-gox",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6533,7 +6533,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6547,7 +6547,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6561,7 +6561,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/multisignature",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/multisignature",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6575,7 +6575,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/nakamoto-consensus",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/nakamoto-consensus",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6589,7 +6589,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6603,7 +6603,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/net-asset-value-nav",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/net-asset-value-nav",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6617,7 +6617,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6631,7 +6631,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6645,7 +6645,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6659,7 +6659,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6673,7 +6673,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6687,7 +6687,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6701,7 +6701,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/nft-floor-prices",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/nft-floor-prices",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6715,7 +6715,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/nft-mystery-boxes",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/nft-mystery-boxes",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6729,7 +6729,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/ngmi",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/ngmi",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6743,7 +6743,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6757,7 +6757,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/node",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/node",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6771,7 +6771,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6785,7 +6785,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/non-fungible-token-nft",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/non-fungible-token-nft",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6799,7 +6799,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/nonce",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/nonce",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6813,7 +6813,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/oco-order",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/oco-order",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6827,7 +6827,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/off-chain",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/off-chain",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6841,7 +6841,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6855,7 +6855,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/offline-signing-orchestrator-oso",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/offline-signing-orchestrator-oso",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6869,7 +6869,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/offshore-account",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/offshore-account",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6883,7 +6883,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6897,7 +6897,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/on-chain",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/on-chain",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6911,7 +6911,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6925,7 +6925,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6939,7 +6939,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/opbnb",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/opbnb",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6953,7 +6953,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/open-source-software-oss",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/open-source-software-oss",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6967,7 +6967,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6981,7 +6981,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6995,7 +6995,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/opportunity-cost",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/opportunity-cost",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7009,7 +7009,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7023,7 +7023,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7037,7 +7037,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/oracle",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/oracle",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7051,7 +7051,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/orc-20-tokens",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/orc-20-tokens",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7065,7 +7065,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/order-book",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/order-book",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7079,7 +7079,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/ordinals",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/ordinals",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7093,7 +7093,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/orphan-block",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/orphan-block",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7107,7 +7107,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7121,7 +7121,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7135,7 +7135,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/pancakeswap",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/pancakeswap",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7149,7 +7149,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/paper-wallet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/paper-wallet",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7163,7 +7163,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/parallelization",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/parallelization",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7177,7 +7177,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7191,7 +7191,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7205,7 +7205,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/passive-management",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/passive-management",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7219,7 +7219,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7233,7 +7233,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7247,7 +7247,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7261,7 +7261,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7275,7 +7275,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/peer-to-peer",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/peer-to-peer",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7289,7 +7289,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/pegged-currency",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/pegged-currency",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7303,7 +7303,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7317,7 +7317,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/permissionless-blockchain",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/permissionless-blockchain",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7331,7 +7331,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/phishing",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/phishing",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7345,7 +7345,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7359,7 +7359,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/plasma",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/plasma",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7373,7 +7373,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7387,7 +7387,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/polkadot-crowdloan",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/polkadot-crowdloan",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7401,7 +7401,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7415,7 +7415,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/ponzi-scheme",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/ponzi-scheme",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7429,7 +7429,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7443,7 +7443,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7457,7 +7457,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/premining",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/premining",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7471,7 +7471,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/price-action",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/price-action",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7485,7 +7485,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/prisoners-dilemma",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/prisoners-dilemma",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7499,7 +7499,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7513,7 +7513,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7527,7 +7527,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/private-key",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/private-key",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7541,7 +7541,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/private-sale",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/private-sale",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7555,7 +7555,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/progressive-web-application",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/progressive-web-application",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7569,7 +7569,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/proof-of-attendance-protocol-poap",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/proof-of-attendance-protocol-poap",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7583,7 +7583,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/proof-of-reserves-por",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/proof-of-reserves-por",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7597,7 +7597,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/proof-of-stake",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/proof-of-stake",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7611,7 +7611,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/proof-of-staked-authority-posa",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/proof-of-staked-authority-posa",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7625,7 +7625,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/proof-of-work",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/proof-of-work",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7639,7 +7639,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/proposer-builder-separation-pbs",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/proposer-builder-separation-pbs",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7653,7 +7653,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/proto-danksharding",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/proto-danksharding",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7667,7 +7667,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7681,7 +7681,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/pseudorandom",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/pseudorandom",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7695,7 +7695,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7709,7 +7709,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7723,7 +7723,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/public-key",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/public-key",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7737,7 +7737,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7751,7 +7751,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/pump-and-dump",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/pump-and-dump",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7765,7 +7765,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7779,7 +7779,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/quantitative-easing-qe",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/quantitative-easing-qe",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7793,7 +7793,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/quantitative-tightening-qt",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/quantitative-tightening-qt",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7807,7 +7807,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/quantum-computing",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/quantum-computing",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7821,7 +7821,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7835,7 +7835,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/race-attack",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/race-attack",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7849,7 +7849,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/ransomware",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/ransomware",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7863,7 +7863,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7877,7 +7877,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/real-world-assets-rwas",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/real-world-assets-rwas",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7891,7 +7891,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/recession",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/recession",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7905,7 +7905,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/recursive-inscription",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/recursive-inscription",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7919,7 +7919,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/rekt",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/rekt",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7933,7 +7933,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/relative-strength-index",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/relative-strength-index",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7947,7 +7947,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7961,7 +7961,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7975,7 +7975,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/resistance",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/resistance",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7989,7 +7989,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/return-on-investment",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/return-on-investment",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8003,7 +8003,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/revenge-trading",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/revenge-trading",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8017,7 +8017,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8031,7 +8031,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/risk-premium",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/risk-premium",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8045,7 +8045,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/roadmap",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/roadmap",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8059,7 +8059,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8073,7 +8073,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8087,7 +8087,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8101,7 +8101,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/routing-attack",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/routing-attack",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8115,7 +8115,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8129,7 +8129,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/rug-pull",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/rug-pull",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8143,7 +8143,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8157,7 +8157,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/sahm-rule",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/sahm-rule",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8171,7 +8171,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8185,7 +8185,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8199,7 +8199,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/sandwich-trading",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/sandwich-trading",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8213,7 +8213,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8227,7 +8227,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/satoshi",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/satoshi",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8241,7 +8241,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/satoshi-nakamoto",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/satoshi-nakamoto",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8255,7 +8255,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8269,7 +8269,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8283,7 +8283,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8297,7 +8297,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8311,7 +8311,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8325,7 +8325,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8339,7 +8339,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8353,7 +8353,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/secure-asset-fund-for-users",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/secure-asset-fund-for-users",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8367,7 +8367,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/securities-and-exchange-commission",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/securities-and-exchange-commission",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8381,7 +8381,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/security-audit",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/security-audit",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8395,7 +8395,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8409,7 +8409,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8423,7 +8423,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/security-token-offering-sto",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/security-token-offering-sto",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8437,7 +8437,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/seed-phrase",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/seed-phrase",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8451,7 +8451,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/seed-tag",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/seed-tag",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8465,7 +8465,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/segregated-witness",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/segregated-witness",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8479,7 +8479,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8493,7 +8493,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8507,7 +8507,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/selfish-mining",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/selfish-mining",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8521,7 +8521,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/sell-wall",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/sell-wall",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8535,7 +8535,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/sentiment",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/sentiment",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8549,7 +8549,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8563,7 +8563,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8577,7 +8577,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8591,7 +8591,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8605,7 +8605,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/sharding",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/sharding",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8619,7 +8619,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/sharpe-ratio",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/sharpe-ratio",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8633,7 +8633,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8647,7 +8647,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8661,7 +8661,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/sidechains",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/sidechains",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8675,7 +8675,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/simple-moving-average-sma",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/simple-moving-average-sma",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8689,7 +8689,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/slashing",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/slashing",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8703,7 +8703,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8717,7 +8717,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/slippage",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/slippage",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8731,7 +8731,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8745,7 +8745,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/smart-contract",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/smart-contract",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8759,7 +8759,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/smart-contract-wallet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/smart-contract-wallet",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8773,7 +8773,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/snapshot",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/snapshot",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8787,7 +8787,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/social-recovery-wallet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/social-recovery-wallet",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8801,7 +8801,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/social-trading",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/social-trading",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8815,7 +8815,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/socialfi",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/socialfi",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8829,7 +8829,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8843,7 +8843,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/soft-landing",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/soft-landing",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8857,7 +8857,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/solidity",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/solidity",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8871,7 +8871,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/source-code",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/source-code",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8885,7 +8885,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/spl",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/spl",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8899,7 +8899,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/src-20-tokens",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/src-20-tokens",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8913,7 +8913,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/stablecoin",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/stablecoin",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8927,7 +8927,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/stagflation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/stagflation",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8941,7 +8941,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8955,7 +8955,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8969,7 +8969,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/staking-pool",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/staking-pool",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8983,7 +8983,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8997,7 +8997,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/state-channel",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/state-channel",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9011,7 +9011,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9025,7 +9025,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/steth",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/steth",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9039,7 +9039,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9053,7 +9053,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/stock-variable",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/stock-variable",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9067,7 +9067,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/store-of-value",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/store-of-value",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9081,7 +9081,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9095,7 +9095,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/supercomputer",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/supercomputer",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9109,7 +9109,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/supply-chain",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/supply-chain",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9123,7 +9123,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/support",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/support",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9137,7 +9137,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9151,7 +9151,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/sybil-attack",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/sybil-attack",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9165,7 +9165,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9179,7 +9179,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/taker",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/taker",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9193,7 +9193,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/tank",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/tank",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9207,7 +9207,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9221,7 +9221,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9235,7 +9235,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/testnet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/testnet",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9249,7 +9249,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9263,7 +9263,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9277,7 +9277,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9291,7 +9291,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/ticker",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/ticker",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9305,7 +9305,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/ticker-symbol",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/ticker-symbol",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9319,7 +9319,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/token",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/token",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9333,7 +9333,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/token-generation-event-tge",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/token-generation-event-tge",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9347,7 +9347,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/token-lockup",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/token-lockup",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9361,7 +9361,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/token-merge",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/token-merge",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9375,7 +9375,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/token-sale",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/token-sale",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9389,7 +9389,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9403,7 +9403,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/token-standards",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/token-standards",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9417,7 +9417,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/tokenization",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/tokenization",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9431,7 +9431,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/tokenomics",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/tokenomics",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9445,7 +9445,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/total-supply",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/total-supply",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9459,7 +9459,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/total-value-locked-tvl",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/total-value-locked-tvl",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9473,7 +9473,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/tradfi",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/tradfi",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9487,7 +9487,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9501,7 +9501,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9515,7 +9515,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9529,7 +9529,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/transaction-id",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/transaction-id",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9543,7 +9543,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9557,7 +9557,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/transactions-per-second-tps",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/transactions-per-second-tps",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9571,7 +9571,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9585,7 +9585,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/treasury-bills-t-bills",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/treasury-bills-t-bills",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9599,7 +9599,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9613,7 +9613,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/trueusd-tusd",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/trueusd-tusd",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9627,7 +9627,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9641,7 +9641,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/trustless",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/trustless",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9655,7 +9655,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/turing-complete",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/turing-complete",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9669,7 +9669,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9683,7 +9683,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9697,7 +9697,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9711,7 +9711,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/understanding-cz-s-number-4",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/understanding-cz-s-number-4",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9725,7 +9725,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9739,7 +9739,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9753,7 +9753,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/unit-of-account",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/unit-of-account",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9767,7 +9767,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9781,7 +9781,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/unspent-transaction-output-utxo",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/unspent-transaction-output-utxo",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9795,7 +9795,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9809,7 +9809,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9823,7 +9823,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9837,7 +9837,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9851,7 +9851,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/user-interface",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/user-interface",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9865,7 +9865,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/utility-token",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/utility-token",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9879,7 +9879,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9893,7 +9893,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9907,7 +9907,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9921,7 +9921,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/verification-code",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/verification-code",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9935,7 +9935,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9949,7 +9949,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9963,7 +9963,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/virtual-machine",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/virtual-machine",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9977,7 +9977,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/vladimir-club",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/vladimir-club",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9991,7 +9991,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/volatility",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/volatility",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10005,7 +10005,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/volume",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/volume",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10019,7 +10019,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/wagmi",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/wagmi",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10033,7 +10033,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/wallet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/wallet",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10047,7 +10047,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10061,7 +10061,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10075,7 +10075,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/wash-trading",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/wash-trading",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10089,7 +10089,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/weak-hands",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/weak-hands",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10103,7 +10103,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/weak-subjectivity",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/weak-subjectivity",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10117,7 +10117,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/web-1",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/web-1",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10131,7 +10131,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10145,7 +10145,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10159,7 +10159,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10173,7 +10173,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10187,7 +10187,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10201,7 +10201,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/wei",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/wei",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10215,7 +10215,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/weighted-moving-average-wma",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/weighted-moving-average-wma",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10229,7 +10229,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/whale",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/whale",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10243,7 +10243,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/whiskers",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/whiskers",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10257,7 +10257,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/whitelist",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/whitelist",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10271,7 +10271,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10285,7 +10285,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/wick",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/wick",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10299,7 +10299,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/win-rate",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/win-rate",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10313,7 +10313,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/wrapped-ether",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/wrapped-ether",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10327,7 +10327,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10341,7 +10341,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/wyckoff",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/wyckoff",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10355,7 +10355,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10369,7 +10369,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10383,7 +10383,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10397,7 +10397,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10411,7 +10411,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/yield-farming",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/yield-farming",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10425,7 +10425,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10439,7 +10439,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10453,7 +10453,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/zero-knowledge-proofs",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/zero-knowledge-proofs",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10467,7 +10467,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10481,7 +10481,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/zk-rollup",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/zk-rollup",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10495,7 +10495,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/zk-snarks",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/zk-snarks",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10509,7 +10509,7 @@
       "definitionSource": "https://academy.binance.com/es/glossary/zk-starks",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/es/glossary/zk-starks",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""

--- a/locales/fa-AF/fa-AF.json
+++ b/locales/fa-AF/fa-AF.json
@@ -9,7 +9,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -23,7 +23,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -37,7 +37,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -51,7 +51,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -65,7 +65,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -79,7 +79,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -93,7 +93,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -107,7 +107,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -121,7 +121,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -135,7 +135,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -149,7 +149,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -163,7 +163,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -177,7 +177,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -191,7 +191,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -205,7 +205,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -219,7 +219,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -233,7 +233,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -247,7 +247,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -261,7 +261,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -275,7 +275,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -289,7 +289,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -303,7 +303,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -317,7 +317,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -331,7 +331,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -345,7 +345,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -359,7 +359,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -373,7 +373,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -387,7 +387,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -401,7 +401,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -415,7 +415,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -429,7 +429,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -443,7 +443,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -457,7 +457,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -471,7 +471,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -485,7 +485,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -499,7 +499,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -513,7 +513,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -527,7 +527,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -541,7 +541,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -555,7 +555,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -569,7 +569,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -583,7 +583,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -597,7 +597,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -611,7 +611,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -625,7 +625,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -639,7 +639,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -653,7 +653,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -667,7 +667,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -681,7 +681,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -695,7 +695,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -709,7 +709,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -723,7 +723,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -737,7 +737,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -751,7 +751,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -765,7 +765,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -779,7 +779,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -793,7 +793,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -807,7 +807,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -821,7 +821,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -835,7 +835,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -849,7 +849,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -863,7 +863,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -877,7 +877,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -891,7 +891,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -905,7 +905,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -919,7 +919,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -933,7 +933,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -947,7 +947,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -961,7 +961,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -975,7 +975,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -989,7 +989,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1003,7 +1003,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1017,7 +1017,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1031,7 +1031,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1045,7 +1045,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1059,7 +1059,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1073,7 +1073,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1087,7 +1087,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1101,7 +1101,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1115,7 +1115,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1129,7 +1129,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1143,7 +1143,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1157,7 +1157,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1171,7 +1171,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1185,7 +1185,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1199,7 +1199,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1213,7 +1213,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1227,7 +1227,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1241,7 +1241,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1255,7 +1255,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1269,7 +1269,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1283,7 +1283,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1297,7 +1297,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1311,7 +1311,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1325,7 +1325,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1339,7 +1339,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1353,7 +1353,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1367,7 +1367,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1381,7 +1381,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1395,7 +1395,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1409,7 +1409,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1423,7 +1423,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1437,7 +1437,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1451,7 +1451,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1465,7 +1465,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1479,7 +1479,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1493,7 +1493,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1507,7 +1507,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1521,7 +1521,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1535,7 +1535,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1549,7 +1549,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1563,7 +1563,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1577,7 +1577,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1591,7 +1591,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1605,7 +1605,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1619,7 +1619,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1633,7 +1633,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1647,7 +1647,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1661,7 +1661,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1675,7 +1675,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1689,7 +1689,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1703,7 +1703,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1717,7 +1717,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1731,7 +1731,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1745,7 +1745,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1759,7 +1759,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1773,7 +1773,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1787,7 +1787,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1801,7 +1801,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1815,7 +1815,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1829,7 +1829,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1843,7 +1843,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1857,7 +1857,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1871,7 +1871,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1885,7 +1885,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1899,7 +1899,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1913,7 +1913,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1927,7 +1927,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1941,7 +1941,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1955,7 +1955,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1969,7 +1969,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1983,7 +1983,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1997,7 +1997,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2011,7 +2011,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2025,7 +2025,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2039,7 +2039,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2053,7 +2053,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2067,7 +2067,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2081,7 +2081,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2095,7 +2095,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2109,7 +2109,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2123,7 +2123,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2137,7 +2137,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2151,7 +2151,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2165,7 +2165,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2179,7 +2179,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2193,7 +2193,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2207,7 +2207,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2221,7 +2221,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2235,7 +2235,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2249,7 +2249,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2263,7 +2263,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2277,7 +2277,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2291,7 +2291,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2305,7 +2305,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2319,7 +2319,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2333,7 +2333,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2347,7 +2347,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2361,7 +2361,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2375,7 +2375,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2389,7 +2389,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2403,7 +2403,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2417,7 +2417,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2431,7 +2431,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2445,7 +2445,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2459,7 +2459,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2473,7 +2473,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2487,7 +2487,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2501,7 +2501,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2515,7 +2515,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2529,7 +2529,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2543,7 +2543,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2557,7 +2557,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2571,7 +2571,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2585,7 +2585,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2599,7 +2599,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2613,7 +2613,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2627,7 +2627,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2641,7 +2641,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2655,7 +2655,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2669,7 +2669,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2683,7 +2683,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2697,7 +2697,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2711,7 +2711,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2725,7 +2725,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2739,7 +2739,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2753,7 +2753,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2767,7 +2767,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2781,7 +2781,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2795,7 +2795,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2809,7 +2809,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2823,7 +2823,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2837,7 +2837,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2851,7 +2851,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2865,7 +2865,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2879,7 +2879,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2893,7 +2893,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2907,7 +2907,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2921,7 +2921,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2935,7 +2935,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2949,7 +2949,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2963,7 +2963,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2977,7 +2977,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2991,7 +2991,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3005,7 +3005,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3019,7 +3019,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3033,7 +3033,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3047,7 +3047,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3061,7 +3061,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3075,7 +3075,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3089,7 +3089,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3103,7 +3103,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3117,7 +3117,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3131,7 +3131,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3145,7 +3145,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3159,7 +3159,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3173,7 +3173,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3187,7 +3187,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3201,7 +3201,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3215,7 +3215,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3229,7 +3229,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3243,7 +3243,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3257,7 +3257,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3271,7 +3271,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3285,7 +3285,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3299,7 +3299,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3313,7 +3313,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3327,7 +3327,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3341,7 +3341,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3355,7 +3355,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3369,7 +3369,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3383,7 +3383,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3397,7 +3397,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3411,7 +3411,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3425,7 +3425,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3439,7 +3439,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3453,7 +3453,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3467,7 +3467,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3481,7 +3481,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3495,7 +3495,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3509,7 +3509,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3523,7 +3523,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3537,7 +3537,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3551,7 +3551,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3565,7 +3565,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3579,7 +3579,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3593,7 +3593,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3607,7 +3607,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3621,7 +3621,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3635,7 +3635,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3649,7 +3649,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3663,7 +3663,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3677,7 +3677,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3691,7 +3691,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3705,7 +3705,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3719,7 +3719,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3733,7 +3733,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3747,7 +3747,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3761,7 +3761,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3775,7 +3775,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3789,7 +3789,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3803,7 +3803,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3817,7 +3817,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3831,7 +3831,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3845,7 +3845,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3859,7 +3859,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3873,7 +3873,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3887,7 +3887,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3901,7 +3901,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3915,7 +3915,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3929,7 +3929,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3943,7 +3943,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3957,7 +3957,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3971,7 +3971,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3985,7 +3985,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3999,7 +3999,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4013,7 +4013,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4027,7 +4027,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4041,7 +4041,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4055,7 +4055,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4069,7 +4069,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4083,7 +4083,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4097,7 +4097,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4111,7 +4111,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4125,7 +4125,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4139,7 +4139,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4153,7 +4153,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4167,7 +4167,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4181,7 +4181,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4195,7 +4195,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4209,7 +4209,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4223,7 +4223,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4237,7 +4237,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4251,7 +4251,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4265,7 +4265,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4279,7 +4279,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4293,7 +4293,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4307,7 +4307,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4321,7 +4321,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4335,7 +4335,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4349,7 +4349,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4363,7 +4363,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4377,7 +4377,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4391,7 +4391,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4405,7 +4405,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4419,7 +4419,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4433,7 +4433,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4447,7 +4447,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4461,7 +4461,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4475,7 +4475,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4489,7 +4489,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4503,7 +4503,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4517,7 +4517,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4531,7 +4531,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4545,7 +4545,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4559,7 +4559,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4573,7 +4573,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4587,7 +4587,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4601,7 +4601,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4615,7 +4615,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4629,7 +4629,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4643,7 +4643,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4657,7 +4657,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4671,7 +4671,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4685,7 +4685,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4699,7 +4699,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4713,7 +4713,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4727,7 +4727,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4741,7 +4741,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4755,7 +4755,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4769,7 +4769,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4783,7 +4783,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4797,7 +4797,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4811,7 +4811,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4825,7 +4825,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4839,7 +4839,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4853,7 +4853,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4867,7 +4867,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4881,7 +4881,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4895,7 +4895,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4909,7 +4909,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4923,7 +4923,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4937,7 +4937,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4951,7 +4951,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4965,7 +4965,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4979,7 +4979,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4993,7 +4993,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5007,7 +5007,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5021,7 +5021,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5035,7 +5035,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5049,7 +5049,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5063,7 +5063,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5077,7 +5077,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5091,7 +5091,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5105,7 +5105,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5119,7 +5119,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5133,7 +5133,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5147,7 +5147,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5161,7 +5161,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5175,7 +5175,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5189,7 +5189,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5203,7 +5203,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5217,7 +5217,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5231,7 +5231,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5245,7 +5245,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5259,7 +5259,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5273,7 +5273,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5287,7 +5287,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5301,7 +5301,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5315,7 +5315,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5329,7 +5329,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5343,7 +5343,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5357,7 +5357,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5371,7 +5371,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5385,7 +5385,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5399,7 +5399,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5413,7 +5413,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5427,7 +5427,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5441,7 +5441,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5455,7 +5455,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5469,7 +5469,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5483,7 +5483,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5497,7 +5497,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5511,7 +5511,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5525,7 +5525,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5539,7 +5539,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5553,7 +5553,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5567,7 +5567,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5581,7 +5581,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5595,7 +5595,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5609,7 +5609,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5623,7 +5623,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5637,7 +5637,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5651,7 +5651,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5665,7 +5665,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5679,7 +5679,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""

--- a/locales/fr-FR/fr-FR.json
+++ b/locales/fr-FR/fr-FR.json
@@ -9,7 +9,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -23,7 +23,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -37,7 +37,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -51,7 +51,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -65,7 +65,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -79,7 +79,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -93,7 +93,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -107,7 +107,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/absolute-advantage",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/absolute-advantage",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -121,7 +121,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -135,7 +135,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -149,7 +149,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/active-management",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/active-management",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -163,7 +163,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/actively-validated-services-avs",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/actively-validated-services-avs",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -177,7 +177,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/ad-hoc",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/ad-hoc",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -191,7 +191,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/address",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/address",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -205,7 +205,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -219,7 +219,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -233,7 +233,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -247,7 +247,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/airdrop",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/airdrop",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -261,7 +261,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -275,7 +275,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -289,7 +289,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/algorithm",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/algorithm",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -303,7 +303,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/all-or-none-order",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/all-or-none-order",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -317,7 +317,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/all-time-high",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/all-time-high",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -331,7 +331,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/allocation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/allocation",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -345,7 +345,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/alpha",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/alpha",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -359,7 +359,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/altcoin",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/altcoin",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -373,7 +373,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -387,7 +387,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/angel-investor",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/angel-investor",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -401,7 +401,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/anti-money-laundering",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/anti-money-laundering",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -415,7 +415,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -429,7 +429,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -443,7 +443,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -457,7 +457,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/application-programming-interface",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/application-programming-interface",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -471,7 +471,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/application-specific-integrated-circuit",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/application-specific-integrated-circuit",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -485,7 +485,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/arbitrage",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/arbitrage",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -499,7 +499,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -513,7 +513,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/arc-20",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/arc-20",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -527,7 +527,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/artificial-intelligence-ai",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/artificial-intelligence-ai",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -541,7 +541,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -555,7 +555,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/asic-resistant",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/asic-resistant",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -569,7 +569,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/asking-price",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/asking-price",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -583,7 +583,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/asset-management",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/asset-management",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -597,7 +597,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -611,7 +611,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/assets-under-management-aum",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/assets-under-management-aum",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -625,7 +625,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/asynchronous",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/asynchronous",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -639,7 +639,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/atomic-swap",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/atomic-swap",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -653,7 +653,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/attack-surface",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/attack-surface",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -667,7 +667,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -681,7 +681,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/auction",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/auction",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -695,7 +695,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -709,7 +709,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/automated-market-maker-amm",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/automated-market-maker-amm",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -723,7 +723,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -737,7 +737,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -751,7 +751,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -765,7 +765,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/b-tokens",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/b-tokens",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -779,7 +779,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/bags",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/bags",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -793,7 +793,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -807,7 +807,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/beacon-chain",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/beacon-chain",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -821,7 +821,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/bear-market",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/bear-market",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -835,7 +835,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/benchmark",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/benchmark",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -849,7 +849,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/bep-1155",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/bep-1155",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -863,7 +863,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/bep-20",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/bep-20",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -877,7 +877,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/bep-721",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/bep-721",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -891,7 +891,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/bep-95",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/bep-95",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -905,7 +905,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -919,7 +919,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/beta-coefficient",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/beta-coefficient",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -933,7 +933,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/beta-release",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/beta-release",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -947,7 +947,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/bid-ask-spread",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/bid-ask-spread",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -961,7 +961,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/bid-price",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/bid-price",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -975,7 +975,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -989,7 +989,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/binance-blockchain-charity-foundation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/binance-blockchain-charity-foundation",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1003,7 +1003,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/binance-ecosystem-fund",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/binance-ecosystem-fund",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1017,7 +1017,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/binancian",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/binancian",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1031,7 +1031,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/bitcoin",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/bitcoin",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1045,7 +1045,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/bitcoin-core",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/bitcoin-core",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1059,7 +1059,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/bitcoin-dominance",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/bitcoin-dominance",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1073,7 +1073,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/bitcoin-maximalists",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/bitcoin-maximalists",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1087,7 +1087,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/bitcoin-pizza",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/bitcoin-pizza",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1101,7 +1101,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/black-swan-event",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/black-swan-event",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1115,7 +1115,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/block",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/block",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1129,7 +1129,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/block-explorer",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/block-explorer",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1143,7 +1143,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/block-header",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/block-header",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1157,7 +1157,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/block-height",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/block-height",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1171,7 +1171,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/block-reward",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/block-reward",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1185,7 +1185,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1199,7 +1199,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1213,7 +1213,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/blockchain",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/blockchain",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1227,7 +1227,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1241,7 +1241,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1255,7 +1255,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/bloom-filter",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/bloom-filter",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1269,7 +1269,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/blue-chip-token",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/blue-chip-token",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1283,7 +1283,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/bnb",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/bnb",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1297,7 +1297,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1311,7 +1311,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/bnsol",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/bnsol",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1325,7 +1325,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/bollinger-bands",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/bollinger-bands",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1339,7 +1339,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/bond",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/bond",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1353,7 +1353,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/bounty",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/bounty",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1367,7 +1367,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1381,7 +1381,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1395,7 +1395,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/brc-20-tokens",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/brc-20-tokens",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1409,7 +1409,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/break-even-point",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/break-even-point",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1423,7 +1423,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/breakeven-multiple",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/breakeven-multiple",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1437,7 +1437,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/breakout",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/breakout",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1451,7 +1451,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1465,7 +1465,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/bscscan",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/bscscan",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1479,7 +1479,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1493,7 +1493,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/btc-wallet-address",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/btc-wallet-address",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1507,7 +1507,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/buidl",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/buidl",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1521,7 +1521,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/bull-market",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/bull-market",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1535,7 +1535,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/burner-wallet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/burner-wallet",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1549,7 +1549,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/buy-wall",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/buy-wall",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1563,7 +1563,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1577,7 +1577,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1591,7 +1591,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1605,7 +1605,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/candidate-block",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/candidate-block",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1619,7 +1619,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/candlestick",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/candlestick",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1633,7 +1633,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/capitulation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/capitulation",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1647,7 +1647,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1661,7 +1661,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/censorship-resistance",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/censorship-resistance",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1675,7 +1675,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/central-bank",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/central-bank",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1689,7 +1689,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/central-bank-digital-currency-cbdc",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/central-bank-digital-currency-cbdc",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1703,7 +1703,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/central-processing-unit",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/central-processing-unit",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1717,7 +1717,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/centralized",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/centralized",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1731,7 +1731,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/centralized-exchange",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/centralized-exchange",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1745,7 +1745,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1759,7 +1759,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1773,7 +1773,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/chatgpt",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/chatgpt",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1787,7 +1787,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1801,7 +1801,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/cipher",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/cipher",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1815,7 +1815,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/circulating-supply",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/circulating-supply",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1829,7 +1829,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1843,7 +1843,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/cloud",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/cloud",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1857,7 +1857,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1871,7 +1871,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/coin",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/coin",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1885,7 +1885,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1899,7 +1899,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1913,7 +1913,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/cold-storage",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/cold-storage",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1927,7 +1927,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1941,7 +1941,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/collateral",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/collateral",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1955,7 +1955,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/colocation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/colocation",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1969,7 +1969,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/commodity-futures-trading-commission",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/commodity-futures-trading-commission",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1983,7 +1983,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1997,7 +1997,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2011,7 +2011,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/compound-interest",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/compound-interest",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2025,7 +2025,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2039,7 +2039,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/confirmation-time",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/confirmation-time",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2053,7 +2053,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/confluence",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/confluence",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2067,7 +2067,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2081,7 +2081,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/consensus-algorithm",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/consensus-algorithm",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2095,7 +2095,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2109,7 +2109,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2123,7 +2123,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2137,7 +2137,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2151,7 +2151,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2165,7 +2165,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/consumer-price-index-(cpi)",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/consumer-price-index-(cpi)",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2179,7 +2179,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/contango-and-backwardation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/contango-and-backwardation",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2193,7 +2193,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2207,7 +2207,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2221,7 +2221,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2235,7 +2235,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/copy-trading",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/copy-trading",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2249,7 +2249,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/counterparty-risk",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/counterparty-risk",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2263,7 +2263,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/credentials",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/credentials",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2277,7 +2277,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/cross-chain-bridges",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/cross-chain-bridges",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2291,7 +2291,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2305,7 +2305,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2319,7 +2319,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2333,7 +2333,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2347,7 +2347,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/crypto-etfs",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/crypto-etfs",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2361,7 +2361,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/crypto-fear-and-greed-index",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/crypto-fear-and-greed-index",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2375,7 +2375,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2389,7 +2389,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/crypto-protocol",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/crypto-protocol",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2403,7 +2403,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2417,7 +2417,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/crypto-winter",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/crypto-winter",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2431,7 +2431,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2445,7 +2445,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/cryptocurrency",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/cryptocurrency",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2459,7 +2459,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2473,7 +2473,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/cryptography",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/cryptography",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2487,7 +2487,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2501,7 +2501,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/custody",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/custody",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2515,7 +2515,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2529,7 +2529,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/daemon",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/daemon",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2543,7 +2543,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2557,7 +2557,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/danksharding",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/danksharding",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2571,7 +2571,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2585,7 +2585,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2599,7 +2599,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2613,7 +2613,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/dead-cat-bounce",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/dead-cat-bounce",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2627,7 +2627,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/death-cross",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/death-cross",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2641,7 +2641,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2655,7 +2655,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/decentralized-application",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/decentralized-application",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2669,7 +2669,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/decentralized-autonomous-cooperative",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/decentralized-autonomous-cooperative",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2683,7 +2683,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/decentralized-autonomous-organization",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/decentralized-autonomous-organization",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2697,7 +2697,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/decentralized-exchange",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/decentralized-exchange",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2711,7 +2711,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2725,7 +2725,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/decentralized-indexes",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/decentralized-indexes",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2739,7 +2739,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2753,7 +2753,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/decryption",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/decryption",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2767,7 +2767,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/deep-web",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/deep-web",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2781,7 +2781,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2795,7 +2795,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2809,7 +2809,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/delisting",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/delisting",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2823,7 +2823,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2837,7 +2837,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/depeg",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/depeg",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2851,7 +2851,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2865,7 +2865,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/depression",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/depression",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2879,7 +2879,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2893,7 +2893,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/design-flaw-attack",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/design-flaw-attack",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2907,7 +2907,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2921,7 +2921,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2935,7 +2935,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2949,7 +2949,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2963,7 +2963,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/diamond-hands",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/diamond-hands",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2977,7 +2977,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/difficulty",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/difficulty",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2991,7 +2991,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/difficulty-bomb",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/difficulty-bomb",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3005,7 +3005,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3019,7 +3019,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3033,7 +3033,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/digital-signature",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/digital-signature",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3047,7 +3047,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3061,7 +3061,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/direct-market-access-dma",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/direct-market-access-dma",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3075,7 +3075,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3089,7 +3089,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/divergence",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/divergence",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3103,7 +3103,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/diversification",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/diversification",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3117,7 +3117,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3131,7 +3131,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/do-your-own-research",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/do-your-own-research",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3145,7 +3145,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/dollar-cost-averaging",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/dollar-cost-averaging",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3159,7 +3159,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/dot-plot",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/dot-plot",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3173,7 +3173,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3187,7 +3187,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/double-spending",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/double-spending",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3201,7 +3201,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/eclipse-attack",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/eclipse-attack",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3215,7 +3215,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3229,7 +3229,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3243,7 +3243,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/efficient-market-hypothesis-emh",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/efficient-market-hypothesis-emh",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3257,7 +3257,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/eigenlayer",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/eigenlayer",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3271,7 +3271,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/eip",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/eip",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3285,7 +3285,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3299,7 +3299,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/eip-3074",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/eip-3074",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3313,7 +3313,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/eip-4844",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/eip-4844",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3327,7 +3327,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/eip-7251",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/eip-7251",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3341,7 +3341,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/eip-7702",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/eip-7702",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3355,7 +3355,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/elasticity",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/elasticity",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3369,7 +3369,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3383,7 +3383,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/encryption",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/encryption",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3397,7 +3397,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/endogenous-variable",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/endogenous-variable",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3411,7 +3411,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3425,7 +3425,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3439,7 +3439,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3453,7 +3453,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3467,7 +3467,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/erc-1155",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/erc-1155",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3481,7 +3481,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/erc-20",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/erc-20",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3495,7 +3495,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/erc-404",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/erc-404",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3509,7 +3509,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/erc-721",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/erc-721",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3523,7 +3523,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/etf",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/etf",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3537,7 +3537,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3551,7 +3551,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3565,7 +3565,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3579,7 +3579,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3593,7 +3593,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/ethereum-classic",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/ethereum-classic",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3607,7 +3607,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/ethereum-foundation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/ethereum-foundation",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3621,7 +3621,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3635,7 +3635,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3649,7 +3649,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3663,7 +3663,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3677,7 +3677,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/ethereum-virtual-machine-evm",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/ethereum-virtual-machine-evm",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3691,7 +3691,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3705,7 +3705,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3719,7 +3719,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3733,7 +3733,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/exchange",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/exchange",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3747,7 +3747,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3761,7 +3761,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3775,7 +3775,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/exogenous-variable",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/exogenous-variable",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3789,7 +3789,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/exponential-moving-average-ema",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/exponential-moving-average-ema",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3803,7 +3803,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/externally-owned-account-eoa",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/externally-owned-account-eoa",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3817,7 +3817,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/fakeout",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/fakeout",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3831,7 +3831,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/falling-knife",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/falling-knife",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3845,7 +3845,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/fan-tokens",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/fan-tokens",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3859,7 +3859,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3873,7 +3873,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3887,7 +3887,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3901,7 +3901,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/fear-of-missing-out",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/fear-of-missing-out",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3915,7 +3915,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/fear-uncertainty-and-doubt",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/fear-uncertainty-and-doubt",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3929,7 +3929,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/fiat",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/fiat",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3943,7 +3943,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3957,7 +3957,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/fibonacci-retracement",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/fibonacci-retracement",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3971,7 +3971,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/fill-or-kill-order",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/fill-or-kill-order",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3985,7 +3985,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/finality",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/finality",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3999,7 +3999,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4013,7 +4013,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4027,7 +4027,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4041,7 +4041,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4055,7 +4055,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4069,7 +4069,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4083,7 +4083,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/first-mover-advantage",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/first-mover-advantage",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4097,7 +4097,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/fiscal-policy",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/fiscal-policy",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4111,7 +4111,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/flappening",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/flappening",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4125,7 +4125,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/flashbots",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/flashbots",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4139,7 +4139,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/flippening",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/flippening",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4153,7 +4153,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/flow-variable",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/flow-variable",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4167,7 +4167,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/forced-liquidation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/forced-liquidation",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4181,7 +4181,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/forex-fx",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/forex-fx",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4195,7 +4195,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/fork",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/fork",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4209,7 +4209,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/formal-verification",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/formal-verification",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4223,7 +4223,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4237,7 +4237,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/fraud-proof",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/fraud-proof",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4251,7 +4251,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/fren",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/fren",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4265,7 +4265,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4279,7 +4279,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/full-node",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/full-node",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4293,7 +4293,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/fully-diluted-valuation-fdv",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/fully-diluted-valuation-fdv",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4307,7 +4307,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/fundamental-analysis",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/fundamental-analysis",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4321,7 +4321,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/funding-fees",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/funding-fees",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4335,7 +4335,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/fungibility",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/fungibility",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4349,7 +4349,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/futures-contract",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/futures-contract",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4363,7 +4363,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/gamefi",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/gamefi",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4377,7 +4377,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4391,7 +4391,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/gas",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/gas",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4405,7 +4405,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4419,7 +4419,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/gas-limit",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/gas-limit",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4433,7 +4433,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4447,7 +4447,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4461,7 +4461,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4475,7 +4475,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/gdp-deflator",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/gdp-deflator",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4489,7 +4489,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/general-public-license",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/general-public-license",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4503,7 +4503,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/genesis-block",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/genesis-block",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4517,7 +4517,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4531,7 +4531,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/github",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/github",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4545,7 +4545,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/gm-good-morning",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/gm-good-morning",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4559,7 +4559,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4573,7 +4573,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/golden-cross",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/golden-cross",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4587,7 +4587,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/golden-ratio",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/golden-ratio",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4601,7 +4601,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/goldilocks",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/goldilocks",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4615,7 +4615,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/gossip-protocol",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/gossip-protocol",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4629,7 +4629,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4643,7 +4643,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/gross-domestic-product-gdp",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/gross-domestic-product-gdp",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4657,7 +4657,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4671,7 +4671,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/gwei",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/gwei",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4685,7 +4685,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/hackathon",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/hackathon",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4699,7 +4699,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/hacker",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/hacker",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4713,7 +4713,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/haha-money-printer-go-brrrrr",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/haha-money-printer-go-brrrrr",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4727,7 +4727,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/halving",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/halving",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4741,7 +4741,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/hard-cap",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/hard-cap",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4755,7 +4755,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4769,7 +4769,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/hard-landing",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/hard-landing",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4783,7 +4783,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4797,7 +4797,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4811,7 +4811,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/hash",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/hash",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4825,7 +4825,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/hash-rate",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/hash-rate",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4839,7 +4839,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/hashed-timelock-contract",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/hashed-timelock-contract",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4853,7 +4853,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4867,7 +4867,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/herd-instinct",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/herd-instinct",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4881,7 +4881,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4895,7 +4895,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/high-frequency-trading-hft",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/high-frequency-trading-hft",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4909,7 +4909,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/hodl",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/hodl",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4923,7 +4923,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/honeypot",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/honeypot",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4937,7 +4937,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4951,7 +4951,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4965,7 +4965,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4979,7 +4979,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4993,7 +4993,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5007,7 +5007,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/iceberg-order",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/iceberg-order",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5021,7 +5021,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5035,7 +5035,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5049,7 +5049,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/immutability",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/immutability",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5063,7 +5063,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/index-funds",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/index-funds",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5077,7 +5077,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5091,7 +5091,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/initial-coin-offering",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/initial-coin-offering",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5105,7 +5105,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/initial-dex-offering-ido",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/initial-dex-offering-ido",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5119,7 +5119,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/initial-exchange-offering",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/initial-exchange-offering",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5133,7 +5133,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/initial-public-offering",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/initial-public-offering",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5147,7 +5147,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/inscription",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/inscription",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5161,7 +5161,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5175,7 +5175,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/integrated-circuit",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/integrated-circuit",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5189,7 +5189,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/interest-rates",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/interest-rates",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5203,7 +5203,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5217,7 +5217,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/interoperability",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/interoperability",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5231,7 +5231,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5245,7 +5245,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/interplanetary-file-system-ipfs",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/interplanetary-file-system-ipfs",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5259,7 +5259,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/iou",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/iou",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5273,7 +5273,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5287,7 +5287,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5301,7 +5301,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5315,7 +5315,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/isolated-margin",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/isolated-margin",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5329,7 +5329,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/issuance",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/issuance",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5343,7 +5343,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5357,7 +5357,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5371,7 +5371,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/keccak",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/keccak",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5385,7 +5385,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5399,7 +5399,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/know-your-customer",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/know-your-customer",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5413,7 +5413,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5427,7 +5427,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5441,7 +5441,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5455,7 +5455,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5469,7 +5469,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/laspeyres-index",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/laspeyres-index",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5483,7 +5483,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/latency",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/latency",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5497,7 +5497,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5511,7 +5511,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5525,7 +5525,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/law-of-demand",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/law-of-demand",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5539,7 +5539,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5553,7 +5553,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/layer-2",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/layer-2",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5567,7 +5567,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/ledger",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/ledger",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5581,7 +5581,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5595,7 +5595,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5609,7 +5609,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/leveraged-tokens",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/leveraged-tokens",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5623,7 +5623,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/library",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/library",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5637,7 +5637,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5651,7 +5651,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5665,7 +5665,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/lightning-network",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/lightning-network",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5679,7 +5679,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/limit-order",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/limit-order",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5693,7 +5693,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5707,7 +5707,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/linux",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/linux",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5721,7 +5721,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/liquid-staking",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/liquid-staking",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5735,7 +5735,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/liquid-staking-token-lst",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/liquid-staking-token-lst",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5749,7 +5749,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5763,7 +5763,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/liquidity",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/liquidity",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5777,7 +5777,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/liquidity-crisis",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/liquidity-crisis",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5791,7 +5791,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5805,7 +5805,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/liquidity-provider",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/liquidity-provider",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5819,7 +5819,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/liquidity-ratios",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/liquidity-ratios",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5833,7 +5833,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5847,7 +5847,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/listing",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/listing",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5861,7 +5861,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/mainnet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/mainnet",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5875,7 +5875,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/mainnet-swap",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/mainnet-swap",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5889,7 +5889,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/maker",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/maker",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5903,7 +5903,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5917,7 +5917,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/malware",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/malware",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5931,7 +5931,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/margin-trading",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/margin-trading",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5945,7 +5945,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5959,7 +5959,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/market-capitalization",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/market-capitalization",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5973,7 +5973,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/market-momentum",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/market-momentum",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5987,7 +5987,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/market-order",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/market-order",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6001,7 +6001,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/masternode",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/masternode",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6015,7 +6015,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/matching-engine",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/matching-engine",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6029,7 +6029,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6043,7 +6043,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/maximum-supply",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/maximum-supply",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6057,7 +6057,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6071,7 +6071,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/mempool",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/mempool",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6085,7 +6085,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6099,7 +6099,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6113,7 +6113,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/merged-mining",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/merged-mining",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6127,7 +6127,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6141,7 +6141,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/merkle-tree",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/merkle-tree",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6155,7 +6155,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6169,7 +6169,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/metadata",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/metadata",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6183,7 +6183,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6197,7 +6197,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6211,7 +6211,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6225,7 +6225,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6239,7 +6239,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6253,7 +6253,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/metaverse",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/metaverse",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6267,7 +6267,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6281,7 +6281,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6295,7 +6295,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/microtransactions",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/microtransactions",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6309,7 +6309,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6323,7 +6323,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6337,7 +6337,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/mining",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/mining",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6351,7 +6351,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/mining-farm",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/mining-farm",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6365,7 +6365,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/mint",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/mint",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6379,7 +6379,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6393,7 +6393,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6407,7 +6407,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6421,7 +6421,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/monetary-policy",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/monetary-policy",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6435,7 +6435,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/money-markets",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/money-markets",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6449,7 +6449,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/monitoring-tag",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/monitoring-tag",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6463,7 +6463,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/moon",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/moon",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6477,7 +6477,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6491,7 +6491,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/moving-average-envelopes",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/moving-average-envelopes",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6505,7 +6505,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/moving-average-ribbon",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/moving-average-ribbon",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6519,7 +6519,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/mt-gox",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/mt-gox",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6533,7 +6533,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6547,7 +6547,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6561,7 +6561,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/multisignature",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/multisignature",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6575,7 +6575,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/nakamoto-consensus",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/nakamoto-consensus",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6589,7 +6589,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6603,7 +6603,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/net-asset-value-nav",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/net-asset-value-nav",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6617,7 +6617,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6631,7 +6631,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6645,7 +6645,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6659,7 +6659,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6673,7 +6673,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6687,7 +6687,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6701,7 +6701,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/nft-floor-prices",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/nft-floor-prices",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6715,7 +6715,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/nft-mystery-boxes",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/nft-mystery-boxes",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6729,7 +6729,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/ngmi",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/ngmi",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6743,7 +6743,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6757,7 +6757,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/node",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/node",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6771,7 +6771,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6785,7 +6785,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/non-fungible-token-nft",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/non-fungible-token-nft",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6799,7 +6799,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/nonce",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/nonce",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6813,7 +6813,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/oco-order",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/oco-order",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6827,7 +6827,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/off-chain",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/off-chain",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6841,7 +6841,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6855,7 +6855,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/offline-signing-orchestrator-oso",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/offline-signing-orchestrator-oso",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6869,7 +6869,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/offshore-account",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/offshore-account",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6883,7 +6883,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6897,7 +6897,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/on-chain",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/on-chain",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6911,7 +6911,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6925,7 +6925,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6939,7 +6939,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/opbnb",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/opbnb",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6953,7 +6953,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/open-source-software-oss",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/open-source-software-oss",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6967,7 +6967,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6981,7 +6981,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6995,7 +6995,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/opportunity-cost",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/opportunity-cost",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7009,7 +7009,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7023,7 +7023,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7037,7 +7037,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/oracle",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/oracle",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7051,7 +7051,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/orc-20-tokens",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/orc-20-tokens",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7065,7 +7065,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/order-book",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/order-book",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7079,7 +7079,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/ordinals",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/ordinals",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7093,7 +7093,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/orphan-block",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/orphan-block",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7107,7 +7107,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7121,7 +7121,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7135,7 +7135,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/pancakeswap",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/pancakeswap",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7149,7 +7149,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/paper-wallet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/paper-wallet",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7163,7 +7163,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/parallelization",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/parallelization",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7177,7 +7177,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7191,7 +7191,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7205,7 +7205,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/passive-management",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/passive-management",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7219,7 +7219,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7233,7 +7233,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7247,7 +7247,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7261,7 +7261,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7275,7 +7275,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/peer-to-peer",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/peer-to-peer",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7289,7 +7289,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/pegged-currency",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/pegged-currency",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7303,7 +7303,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7317,7 +7317,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/permissionless-blockchain",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/permissionless-blockchain",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7331,7 +7331,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/phishing",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/phishing",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7345,7 +7345,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7359,7 +7359,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/plasma",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/plasma",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7373,7 +7373,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7387,7 +7387,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/polkadot-crowdloan",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/polkadot-crowdloan",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7401,7 +7401,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7415,7 +7415,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/ponzi-scheme",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/ponzi-scheme",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7429,7 +7429,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7443,7 +7443,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7457,7 +7457,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/premining",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/premining",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7471,7 +7471,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/price-action",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/price-action",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7485,7 +7485,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/prisoners-dilemma",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/prisoners-dilemma",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7499,7 +7499,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7513,7 +7513,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7527,7 +7527,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/private-key",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/private-key",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7541,7 +7541,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/private-sale",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/private-sale",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7555,7 +7555,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/progressive-web-application",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/progressive-web-application",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7569,7 +7569,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/proof-of-attendance-protocol-poap",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/proof-of-attendance-protocol-poap",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7583,7 +7583,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/proof-of-reserves-por",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/proof-of-reserves-por",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7597,7 +7597,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/proof-of-stake",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/proof-of-stake",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7611,7 +7611,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/proof-of-staked-authority-posa",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/proof-of-staked-authority-posa",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7625,7 +7625,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/proof-of-work",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/proof-of-work",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7639,7 +7639,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/proposer-builder-separation-pbs",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/proposer-builder-separation-pbs",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7653,7 +7653,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/proto-danksharding",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/proto-danksharding",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7667,7 +7667,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7681,7 +7681,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/pseudorandom",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/pseudorandom",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7695,7 +7695,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7709,7 +7709,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7723,7 +7723,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/public-key",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/public-key",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7737,7 +7737,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7751,7 +7751,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/pump-and-dump",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/pump-and-dump",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7765,7 +7765,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7779,7 +7779,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/quantitative-easing-qe",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/quantitative-easing-qe",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7793,7 +7793,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/quantitative-tightening-qt",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/quantitative-tightening-qt",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7807,7 +7807,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/quantum-computing",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/quantum-computing",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7821,7 +7821,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7835,7 +7835,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/race-attack",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/race-attack",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7849,7 +7849,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/ransomware",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/ransomware",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7863,7 +7863,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7877,7 +7877,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/real-world-assets-rwas",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/real-world-assets-rwas",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7891,7 +7891,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/recession",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/recession",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7905,7 +7905,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/recursive-inscription",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/recursive-inscription",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7919,7 +7919,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/rekt",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/rekt",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7933,7 +7933,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/relative-strength-index",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/relative-strength-index",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7947,7 +7947,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7961,7 +7961,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7975,7 +7975,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/resistance",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/resistance",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7989,7 +7989,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/return-on-investment",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/return-on-investment",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8003,7 +8003,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/revenge-trading",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/revenge-trading",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8017,7 +8017,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8031,7 +8031,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/risk-premium",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/risk-premium",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8045,7 +8045,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/roadmap",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/roadmap",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8059,7 +8059,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8073,7 +8073,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8087,7 +8087,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8101,7 +8101,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/routing-attack",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/routing-attack",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8115,7 +8115,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8129,7 +8129,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/rug-pull",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/rug-pull",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8143,7 +8143,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8157,7 +8157,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/sahm-rule",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/sahm-rule",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8171,7 +8171,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8185,7 +8185,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8199,7 +8199,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/sandwich-trading",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/sandwich-trading",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8213,7 +8213,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8227,7 +8227,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/satoshi",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/satoshi",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8241,7 +8241,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/satoshi-nakamoto",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/satoshi-nakamoto",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8255,7 +8255,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8269,7 +8269,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8283,7 +8283,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8297,7 +8297,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8311,7 +8311,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8325,7 +8325,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8339,7 +8339,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8353,7 +8353,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/secure-asset-fund-for-users",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/secure-asset-fund-for-users",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8367,7 +8367,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/securities-and-exchange-commission",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/securities-and-exchange-commission",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8381,7 +8381,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/security-audit",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/security-audit",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8395,7 +8395,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8409,7 +8409,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8423,7 +8423,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/security-token-offering-sto",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/security-token-offering-sto",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8437,7 +8437,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/seed-phrase",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/seed-phrase",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8451,7 +8451,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/seed-tag",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/seed-tag",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8465,7 +8465,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/segregated-witness",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/segregated-witness",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8479,7 +8479,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8493,7 +8493,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8507,7 +8507,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/selfish-mining",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/selfish-mining",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8521,7 +8521,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/sell-wall",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/sell-wall",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8535,7 +8535,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/sentiment",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/sentiment",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8549,7 +8549,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8563,7 +8563,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8577,7 +8577,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8591,7 +8591,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8605,7 +8605,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/sharding",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/sharding",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8619,7 +8619,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/sharpe-ratio",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/sharpe-ratio",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8633,7 +8633,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8647,7 +8647,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8661,7 +8661,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/sidechains",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/sidechains",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8675,7 +8675,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/simple-moving-average-sma",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/simple-moving-average-sma",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8689,7 +8689,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/slashing",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/slashing",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8703,7 +8703,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8717,7 +8717,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/slippage",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/slippage",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8731,7 +8731,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8745,7 +8745,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/smart-contract",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/smart-contract",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8759,7 +8759,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/smart-contract-wallet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/smart-contract-wallet",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8773,7 +8773,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/snapshot",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/snapshot",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8787,7 +8787,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/social-recovery-wallet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/social-recovery-wallet",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8801,7 +8801,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/social-trading",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/social-trading",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8815,7 +8815,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/socialfi",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/socialfi",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8829,7 +8829,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8843,7 +8843,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/soft-landing",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/soft-landing",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8857,7 +8857,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/solidity",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/solidity",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8871,7 +8871,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/source-code",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/source-code",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8885,7 +8885,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/spl",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/spl",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8899,7 +8899,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/src-20-tokens",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/src-20-tokens",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8913,7 +8913,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/stablecoin",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/stablecoin",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8927,7 +8927,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/stagflation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/stagflation",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8941,7 +8941,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8955,7 +8955,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8969,7 +8969,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/staking-pool",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/staking-pool",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8983,7 +8983,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8997,7 +8997,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/state-channel",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/state-channel",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9011,7 +9011,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9025,7 +9025,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/steth",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/steth",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9039,7 +9039,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9053,7 +9053,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/stock-variable",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/stock-variable",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9067,7 +9067,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/store-of-value",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/store-of-value",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9081,7 +9081,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9095,7 +9095,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/supercomputer",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/supercomputer",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9109,7 +9109,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/supply-chain",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/supply-chain",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9123,7 +9123,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/support",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/support",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9137,7 +9137,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9151,7 +9151,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/sybil-attack",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/sybil-attack",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9165,7 +9165,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9179,7 +9179,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/taker",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/taker",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9193,7 +9193,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/tank",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/tank",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9207,7 +9207,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9221,7 +9221,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9235,7 +9235,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/testnet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/testnet",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9249,7 +9249,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9263,7 +9263,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9277,7 +9277,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9291,7 +9291,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/ticker",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/ticker",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9305,7 +9305,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/ticker-symbol",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/ticker-symbol",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9319,7 +9319,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/token",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/token",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9333,7 +9333,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/token-generation-event-tge",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/token-generation-event-tge",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9347,7 +9347,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/token-lockup",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/token-lockup",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9361,7 +9361,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/token-merge",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/token-merge",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9375,7 +9375,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/token-sale",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/token-sale",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9389,7 +9389,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9403,7 +9403,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/token-standards",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/token-standards",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9417,7 +9417,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/tokenization",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/tokenization",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9431,7 +9431,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/tokenomics",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/tokenomics",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9445,7 +9445,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/total-supply",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/total-supply",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9459,7 +9459,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/total-value-locked-tvl",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/total-value-locked-tvl",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9473,7 +9473,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/tradfi",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/tradfi",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9487,7 +9487,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9501,7 +9501,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9515,7 +9515,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9529,7 +9529,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/transaction-id",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/transaction-id",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9543,7 +9543,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9557,7 +9557,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/transactions-per-second-tps",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/transactions-per-second-tps",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9571,7 +9571,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9585,7 +9585,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/treasury-bills-t-bills",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/treasury-bills-t-bills",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9599,7 +9599,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9613,7 +9613,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/trueusd-tusd",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/trueusd-tusd",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9627,7 +9627,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9641,7 +9641,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/trustless",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/trustless",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9655,7 +9655,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/turing-complete",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/turing-complete",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9669,7 +9669,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9683,7 +9683,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9697,7 +9697,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9711,7 +9711,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/understanding-cz-s-number-4",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/understanding-cz-s-number-4",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9725,7 +9725,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9739,7 +9739,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9753,7 +9753,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/unit-of-account",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/unit-of-account",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9767,7 +9767,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9781,7 +9781,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/unspent-transaction-output-utxo",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/unspent-transaction-output-utxo",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9795,7 +9795,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9809,7 +9809,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9823,7 +9823,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9837,7 +9837,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9851,7 +9851,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/user-interface",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/user-interface",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9865,7 +9865,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/utility-token",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/utility-token",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9879,7 +9879,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9893,7 +9893,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9907,7 +9907,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9921,7 +9921,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/verification-code",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/verification-code",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9935,7 +9935,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9949,7 +9949,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9963,7 +9963,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/virtual-machine",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/virtual-machine",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9977,7 +9977,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/vladimir-club",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/vladimir-club",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9991,7 +9991,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/volatility",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/volatility",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10005,7 +10005,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/volume",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/volume",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10019,7 +10019,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/wagmi",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/wagmi",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10033,7 +10033,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/wallet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/wallet",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10047,7 +10047,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10061,7 +10061,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10075,7 +10075,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/wash-trading",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/wash-trading",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10089,7 +10089,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/weak-hands",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/weak-hands",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10103,7 +10103,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/weak-subjectivity",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/weak-subjectivity",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10117,7 +10117,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/web-1",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/web-1",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10131,7 +10131,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10145,7 +10145,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10159,7 +10159,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10173,7 +10173,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10187,7 +10187,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10201,7 +10201,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/wei",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/wei",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10215,7 +10215,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/weighted-moving-average-wma",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/weighted-moving-average-wma",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10229,7 +10229,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/whale",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/whale",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10243,7 +10243,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/whiskers",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/whiskers",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10257,7 +10257,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/whitelist",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/whitelist",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10271,7 +10271,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10285,7 +10285,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/wick",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/wick",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10299,7 +10299,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/win-rate",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/win-rate",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10313,7 +10313,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/wrapped-ether",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/wrapped-ether",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10327,7 +10327,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10341,7 +10341,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/wyckoff",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/wyckoff",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10355,7 +10355,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10369,7 +10369,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10383,7 +10383,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10397,7 +10397,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10411,7 +10411,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/yield-farming",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/yield-farming",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10425,7 +10425,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10439,7 +10439,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10453,7 +10453,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/zero-knowledge-proofs",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/zero-knowledge-proofs",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10467,7 +10467,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10481,7 +10481,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/zk-rollup",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/zk-rollup",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10495,7 +10495,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/zk-snarks",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/zk-snarks",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10509,7 +10509,7 @@
       "definitionSource": "https://academy.binance.com/fr/glossary/zk-starks",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/fr/glossary/zk-starks",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""

--- a/locales/fr-FR/fr-FR.json
+++ b/locales/fr-FR/fr-FR.json
@@ -9576,7 +9576,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "treasury-bills-t-bills": {
+    "treasury-bills": {
       "term": "Bons du Trésor (T-bills)",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/ha-NG/ha-NG.json
+++ b/locales/ha-NG/ha-NG.json
@@ -9,7 +9,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -23,7 +23,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -37,7 +37,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -51,7 +51,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -65,7 +65,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -79,7 +79,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -93,7 +93,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -107,7 +107,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -121,7 +121,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -135,7 +135,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -149,7 +149,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -163,7 +163,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -177,7 +177,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -191,7 +191,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -205,7 +205,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -219,7 +219,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -233,7 +233,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -247,7 +247,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -261,7 +261,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -275,7 +275,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -289,7 +289,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -303,7 +303,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -317,7 +317,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -331,7 +331,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -345,7 +345,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -359,7 +359,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -373,7 +373,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -387,7 +387,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -401,7 +401,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -415,7 +415,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -429,7 +429,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -443,7 +443,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -457,7 +457,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -471,7 +471,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -485,7 +485,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -499,7 +499,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -513,7 +513,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -527,7 +527,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -541,7 +541,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -555,7 +555,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -569,7 +569,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -583,7 +583,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -597,7 +597,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -611,7 +611,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -625,7 +625,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -639,7 +639,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -653,7 +653,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -667,7 +667,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -681,7 +681,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -695,7 +695,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -709,7 +709,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -723,7 +723,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -737,7 +737,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -751,7 +751,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -765,7 +765,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -779,7 +779,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -793,7 +793,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -807,7 +807,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -821,7 +821,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -835,7 +835,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -849,7 +849,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -863,7 +863,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -877,7 +877,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -891,7 +891,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -905,7 +905,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -919,7 +919,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -933,7 +933,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -947,7 +947,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -961,7 +961,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -975,7 +975,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -989,7 +989,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1003,7 +1003,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1017,7 +1017,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1031,7 +1031,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1045,7 +1045,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1059,7 +1059,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1073,7 +1073,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1087,7 +1087,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1101,7 +1101,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1115,7 +1115,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1129,7 +1129,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1143,7 +1143,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1157,7 +1157,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1171,7 +1171,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1185,7 +1185,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1199,7 +1199,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1213,7 +1213,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1227,7 +1227,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1241,7 +1241,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1255,7 +1255,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1269,7 +1269,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1283,7 +1283,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1297,7 +1297,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1311,7 +1311,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1325,7 +1325,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1339,7 +1339,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1353,7 +1353,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1367,7 +1367,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1381,7 +1381,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1395,7 +1395,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1409,7 +1409,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1423,7 +1423,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1437,7 +1437,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1451,7 +1451,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1465,7 +1465,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1479,7 +1479,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1493,7 +1493,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1507,7 +1507,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1521,7 +1521,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1535,7 +1535,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1549,7 +1549,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1563,7 +1563,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1577,7 +1577,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1591,7 +1591,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1605,7 +1605,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1619,7 +1619,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1633,7 +1633,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1647,7 +1647,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1661,7 +1661,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1675,7 +1675,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1689,7 +1689,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1703,7 +1703,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1717,7 +1717,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1731,7 +1731,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1745,7 +1745,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1759,7 +1759,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1773,7 +1773,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1787,7 +1787,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1801,7 +1801,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1815,7 +1815,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1829,7 +1829,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1843,7 +1843,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1857,7 +1857,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1871,7 +1871,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1885,7 +1885,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1899,7 +1899,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1913,7 +1913,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1927,7 +1927,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1941,7 +1941,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1955,7 +1955,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1969,7 +1969,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1983,7 +1983,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1997,7 +1997,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2011,7 +2011,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2025,7 +2025,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2039,7 +2039,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2053,7 +2053,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2067,7 +2067,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2081,7 +2081,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2095,7 +2095,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2109,7 +2109,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2123,7 +2123,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2137,7 +2137,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2151,7 +2151,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2165,7 +2165,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2179,7 +2179,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2193,7 +2193,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2207,7 +2207,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2221,7 +2221,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2235,7 +2235,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2249,7 +2249,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2263,7 +2263,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2277,7 +2277,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2291,7 +2291,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2305,7 +2305,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2319,7 +2319,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2333,7 +2333,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2347,7 +2347,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2361,7 +2361,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2375,7 +2375,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2389,7 +2389,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2403,7 +2403,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2417,7 +2417,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2431,7 +2431,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2445,7 +2445,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2459,7 +2459,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2473,7 +2473,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2487,7 +2487,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2501,7 +2501,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2515,7 +2515,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2529,7 +2529,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2543,7 +2543,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2557,7 +2557,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2571,7 +2571,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2585,7 +2585,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2599,7 +2599,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2613,7 +2613,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2627,7 +2627,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2641,7 +2641,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2655,7 +2655,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2669,7 +2669,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2683,7 +2683,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2697,7 +2697,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2711,7 +2711,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2725,7 +2725,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2739,7 +2739,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2753,7 +2753,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2767,7 +2767,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2781,7 +2781,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2795,7 +2795,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2809,7 +2809,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2823,7 +2823,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2837,7 +2837,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2851,7 +2851,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2865,7 +2865,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2879,7 +2879,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2893,7 +2893,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2907,7 +2907,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2921,7 +2921,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2935,7 +2935,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2949,7 +2949,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2963,7 +2963,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2977,7 +2977,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2991,7 +2991,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3005,7 +3005,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3019,7 +3019,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3033,7 +3033,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3047,7 +3047,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3061,7 +3061,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3075,7 +3075,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3089,7 +3089,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3103,7 +3103,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3117,7 +3117,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3131,7 +3131,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3145,7 +3145,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3159,7 +3159,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3173,7 +3173,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3187,7 +3187,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3201,7 +3201,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3215,7 +3215,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3229,7 +3229,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3243,7 +3243,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3257,7 +3257,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3271,7 +3271,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3285,7 +3285,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3299,7 +3299,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3313,7 +3313,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3327,7 +3327,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3341,7 +3341,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3355,7 +3355,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3369,7 +3369,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3383,7 +3383,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3397,7 +3397,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3411,7 +3411,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3425,7 +3425,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3439,7 +3439,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3453,7 +3453,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3467,7 +3467,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3481,7 +3481,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3495,7 +3495,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3509,7 +3509,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3523,7 +3523,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3537,7 +3537,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3551,7 +3551,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3565,7 +3565,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3579,7 +3579,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3593,7 +3593,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3607,7 +3607,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3621,7 +3621,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3635,7 +3635,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3649,7 +3649,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3663,7 +3663,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3677,7 +3677,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3691,7 +3691,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3705,7 +3705,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3719,7 +3719,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3733,7 +3733,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3747,7 +3747,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3761,7 +3761,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3775,7 +3775,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3789,7 +3789,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3803,7 +3803,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3817,7 +3817,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3831,7 +3831,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3845,7 +3845,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3859,7 +3859,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3873,7 +3873,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3887,7 +3887,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3901,7 +3901,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3915,7 +3915,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3929,7 +3929,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3943,7 +3943,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3957,7 +3957,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3971,7 +3971,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3985,7 +3985,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3999,7 +3999,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4013,7 +4013,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4027,7 +4027,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4041,7 +4041,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4055,7 +4055,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4069,7 +4069,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4083,7 +4083,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4097,7 +4097,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4111,7 +4111,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4125,7 +4125,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4139,7 +4139,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4153,7 +4153,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4167,7 +4167,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4181,7 +4181,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4195,7 +4195,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4209,7 +4209,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4223,7 +4223,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4237,7 +4237,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4251,7 +4251,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4265,7 +4265,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4279,7 +4279,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4293,7 +4293,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4307,7 +4307,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4321,7 +4321,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4335,7 +4335,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4349,7 +4349,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4363,7 +4363,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4377,7 +4377,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4391,7 +4391,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4405,7 +4405,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4419,7 +4419,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4433,7 +4433,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4447,7 +4447,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4461,7 +4461,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4475,7 +4475,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4489,7 +4489,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4503,7 +4503,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4517,7 +4517,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4531,7 +4531,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4545,7 +4545,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4559,7 +4559,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4573,7 +4573,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4587,7 +4587,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4601,7 +4601,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4615,7 +4615,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4629,7 +4629,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4643,7 +4643,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4657,7 +4657,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4671,7 +4671,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4685,7 +4685,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4699,7 +4699,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4713,7 +4713,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4727,7 +4727,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4741,7 +4741,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4755,7 +4755,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4769,7 +4769,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4783,7 +4783,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4797,7 +4797,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4811,7 +4811,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4825,7 +4825,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4839,7 +4839,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4853,7 +4853,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4867,7 +4867,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4881,7 +4881,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4895,7 +4895,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4909,7 +4909,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4923,7 +4923,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4937,7 +4937,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4951,7 +4951,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4965,7 +4965,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4979,7 +4979,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4993,7 +4993,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5007,7 +5007,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5021,7 +5021,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5035,7 +5035,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5049,7 +5049,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5063,7 +5063,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5077,7 +5077,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5091,7 +5091,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5105,7 +5105,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5119,7 +5119,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5133,7 +5133,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5147,7 +5147,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5161,7 +5161,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5175,7 +5175,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5189,7 +5189,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5203,7 +5203,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5217,7 +5217,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5231,7 +5231,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5245,7 +5245,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5259,7 +5259,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5273,7 +5273,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5287,7 +5287,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5301,7 +5301,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5315,7 +5315,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5329,7 +5329,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5343,7 +5343,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5357,7 +5357,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5371,7 +5371,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5385,7 +5385,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5399,7 +5399,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5413,7 +5413,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5427,7 +5427,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5441,7 +5441,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5455,7 +5455,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5469,7 +5469,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5483,7 +5483,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5497,7 +5497,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5511,7 +5511,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5525,7 +5525,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5539,7 +5539,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5553,7 +5553,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5567,7 +5567,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5581,7 +5581,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5595,7 +5595,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5609,7 +5609,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5623,7 +5623,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5637,7 +5637,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5651,7 +5651,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5665,7 +5665,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5679,7 +5679,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""

--- a/locales/hi-IN/hi-IN.json
+++ b/locales/hi-IN/hi-IN.json
@@ -9,7 +9,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -23,7 +23,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -37,7 +37,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -51,7 +51,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -65,7 +65,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -79,7 +79,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -93,7 +93,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -107,7 +107,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -121,7 +121,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -135,7 +135,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -149,7 +149,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -163,7 +163,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -177,7 +177,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -191,7 +191,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -205,7 +205,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -219,7 +219,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -233,7 +233,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -247,7 +247,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -261,7 +261,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -275,7 +275,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -289,7 +289,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -303,7 +303,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -317,7 +317,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -331,7 +331,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -345,7 +345,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -359,7 +359,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -373,7 +373,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -387,7 +387,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -401,7 +401,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -415,7 +415,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -429,7 +429,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -443,7 +443,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -457,7 +457,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -471,7 +471,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -485,7 +485,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -499,7 +499,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -513,7 +513,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -527,7 +527,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -541,7 +541,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -555,7 +555,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -569,7 +569,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -583,7 +583,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -597,7 +597,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -611,7 +611,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -625,7 +625,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -639,7 +639,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -653,7 +653,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -667,7 +667,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -681,7 +681,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -695,7 +695,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -709,7 +709,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -723,7 +723,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -737,7 +737,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -751,7 +751,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -765,7 +765,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -779,7 +779,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -793,7 +793,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -807,7 +807,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -821,7 +821,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -835,7 +835,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -849,7 +849,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -863,7 +863,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -877,7 +877,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -891,7 +891,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -905,7 +905,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -919,7 +919,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -933,7 +933,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -947,7 +947,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -961,7 +961,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -975,7 +975,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -989,7 +989,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1003,7 +1003,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1017,7 +1017,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1031,7 +1031,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1045,7 +1045,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1059,7 +1059,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1073,7 +1073,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1087,7 +1087,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1101,7 +1101,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1115,7 +1115,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1129,7 +1129,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1143,7 +1143,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1157,7 +1157,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1171,7 +1171,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1185,7 +1185,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1199,7 +1199,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1213,7 +1213,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1227,7 +1227,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1241,7 +1241,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1255,7 +1255,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1269,7 +1269,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1283,7 +1283,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1297,7 +1297,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1311,7 +1311,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1325,7 +1325,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1339,7 +1339,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1353,7 +1353,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1367,7 +1367,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1381,7 +1381,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1395,7 +1395,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1409,7 +1409,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1423,7 +1423,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1437,7 +1437,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1451,7 +1451,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1465,7 +1465,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1479,7 +1479,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1493,7 +1493,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1507,7 +1507,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1521,7 +1521,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1535,7 +1535,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1549,7 +1549,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1563,7 +1563,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1577,7 +1577,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1591,7 +1591,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1605,7 +1605,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1619,7 +1619,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1633,7 +1633,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1647,7 +1647,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1661,7 +1661,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1675,7 +1675,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1689,7 +1689,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1703,7 +1703,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1717,7 +1717,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1731,7 +1731,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1745,7 +1745,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1759,7 +1759,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1773,7 +1773,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1787,7 +1787,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1801,7 +1801,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1815,7 +1815,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1829,7 +1829,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1843,7 +1843,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1857,7 +1857,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1871,7 +1871,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1885,7 +1885,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1899,7 +1899,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1913,7 +1913,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1927,7 +1927,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1941,7 +1941,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1955,7 +1955,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1969,7 +1969,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1983,7 +1983,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1997,7 +1997,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2011,7 +2011,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2025,7 +2025,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2039,7 +2039,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2053,7 +2053,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2067,7 +2067,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2081,7 +2081,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2095,7 +2095,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2109,7 +2109,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2123,7 +2123,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2137,7 +2137,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2151,7 +2151,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2165,7 +2165,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2179,7 +2179,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2193,7 +2193,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2207,7 +2207,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2221,7 +2221,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2235,7 +2235,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2249,7 +2249,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2263,7 +2263,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2277,7 +2277,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2291,7 +2291,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2305,7 +2305,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2319,7 +2319,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2333,7 +2333,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2347,7 +2347,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2361,7 +2361,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2375,7 +2375,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2389,7 +2389,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2403,7 +2403,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2417,7 +2417,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2431,7 +2431,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2445,7 +2445,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2459,7 +2459,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2473,7 +2473,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2487,7 +2487,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2501,7 +2501,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2515,7 +2515,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2529,7 +2529,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2543,7 +2543,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2557,7 +2557,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2571,7 +2571,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2585,7 +2585,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2599,7 +2599,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2613,7 +2613,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2627,7 +2627,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2641,7 +2641,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2655,7 +2655,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2669,7 +2669,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2683,7 +2683,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2697,7 +2697,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2711,7 +2711,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2725,7 +2725,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2739,7 +2739,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2753,7 +2753,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2767,7 +2767,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2781,7 +2781,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2795,7 +2795,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2809,7 +2809,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2823,7 +2823,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2837,7 +2837,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2851,7 +2851,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2865,7 +2865,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2879,7 +2879,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2893,7 +2893,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2907,7 +2907,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2921,7 +2921,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2935,7 +2935,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2949,7 +2949,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2963,7 +2963,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2977,7 +2977,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2991,7 +2991,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3005,7 +3005,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3019,7 +3019,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3033,7 +3033,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3047,7 +3047,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3061,7 +3061,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3075,7 +3075,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3089,7 +3089,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3103,7 +3103,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3117,7 +3117,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3131,7 +3131,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3145,7 +3145,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3159,7 +3159,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3173,7 +3173,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3187,7 +3187,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3201,7 +3201,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3215,7 +3215,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3229,7 +3229,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3243,7 +3243,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3257,7 +3257,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3271,7 +3271,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3285,7 +3285,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3299,7 +3299,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3313,7 +3313,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3327,7 +3327,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3341,7 +3341,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3355,7 +3355,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3369,7 +3369,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3383,7 +3383,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3397,7 +3397,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3411,7 +3411,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3425,7 +3425,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3439,7 +3439,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3453,7 +3453,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3467,7 +3467,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3481,7 +3481,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3495,7 +3495,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3509,7 +3509,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3523,7 +3523,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3537,7 +3537,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3551,7 +3551,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3565,7 +3565,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3579,7 +3579,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3593,7 +3593,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3607,7 +3607,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3621,7 +3621,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3635,7 +3635,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3649,7 +3649,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3663,7 +3663,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3677,7 +3677,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3691,7 +3691,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3705,7 +3705,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3719,7 +3719,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3733,7 +3733,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3747,7 +3747,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3761,7 +3761,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3775,7 +3775,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3789,7 +3789,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3803,7 +3803,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3817,7 +3817,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3831,7 +3831,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3845,7 +3845,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3859,7 +3859,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3873,7 +3873,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3887,7 +3887,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3901,7 +3901,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3915,7 +3915,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3929,7 +3929,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3943,7 +3943,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3957,7 +3957,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3971,7 +3971,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3985,7 +3985,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3999,7 +3999,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4013,7 +4013,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4027,7 +4027,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4041,7 +4041,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4055,7 +4055,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4069,7 +4069,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4083,7 +4083,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4097,7 +4097,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4111,7 +4111,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4125,7 +4125,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4139,7 +4139,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4153,7 +4153,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4167,7 +4167,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4181,7 +4181,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4195,7 +4195,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4209,7 +4209,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4223,7 +4223,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4237,7 +4237,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4251,7 +4251,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4265,7 +4265,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4279,7 +4279,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4293,7 +4293,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4307,7 +4307,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4321,7 +4321,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4335,7 +4335,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4349,7 +4349,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4363,7 +4363,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4377,7 +4377,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4391,7 +4391,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4405,7 +4405,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4419,7 +4419,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4433,7 +4433,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4447,7 +4447,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4461,7 +4461,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4475,7 +4475,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4489,7 +4489,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4503,7 +4503,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4517,7 +4517,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4531,7 +4531,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4545,7 +4545,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4559,7 +4559,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4573,7 +4573,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4587,7 +4587,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4601,7 +4601,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4615,7 +4615,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4629,7 +4629,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4643,7 +4643,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4657,7 +4657,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4671,7 +4671,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4685,7 +4685,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4699,7 +4699,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4713,7 +4713,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4727,7 +4727,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4741,7 +4741,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4755,7 +4755,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4769,7 +4769,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4783,7 +4783,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4797,7 +4797,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4811,7 +4811,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4825,7 +4825,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4839,7 +4839,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4853,7 +4853,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4867,7 +4867,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4881,7 +4881,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4895,7 +4895,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4909,7 +4909,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4923,7 +4923,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4937,7 +4937,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4951,7 +4951,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4965,7 +4965,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4979,7 +4979,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4993,7 +4993,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5007,7 +5007,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5021,7 +5021,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5035,7 +5035,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5049,7 +5049,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5063,7 +5063,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5077,7 +5077,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5091,7 +5091,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5105,7 +5105,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5119,7 +5119,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5133,7 +5133,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5147,7 +5147,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5161,7 +5161,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5175,7 +5175,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5189,7 +5189,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5203,7 +5203,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5217,7 +5217,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5231,7 +5231,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5245,7 +5245,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5259,7 +5259,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5273,7 +5273,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5287,7 +5287,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5301,7 +5301,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5315,7 +5315,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5329,7 +5329,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5343,7 +5343,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5357,7 +5357,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5371,7 +5371,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5385,7 +5385,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5399,7 +5399,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5413,7 +5413,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5427,7 +5427,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5441,7 +5441,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5455,7 +5455,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5469,7 +5469,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5483,7 +5483,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5497,7 +5497,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5511,7 +5511,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5525,7 +5525,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5539,7 +5539,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5553,7 +5553,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5567,7 +5567,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5581,7 +5581,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5595,7 +5595,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5609,7 +5609,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5623,7 +5623,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5637,7 +5637,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5651,7 +5651,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5665,7 +5665,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5679,7 +5679,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""

--- a/locales/hu-HU/hu-HU.json
+++ b/locales/hu-HU/hu-HU.json
@@ -9576,7 +9576,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "treasury-bills-t-bills": {
+    "treasury-bills": {
       "term": "Kincstárjegyek (T-Bills)",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/hu-HU/hu-HU.json
+++ b/locales/hu-HU/hu-HU.json
@@ -9,7 +9,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -23,7 +23,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -37,7 +37,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -51,7 +51,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -65,7 +65,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -79,7 +79,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -93,7 +93,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -107,7 +107,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/absolute-advantage",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/absolute-advantage",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -121,7 +121,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -135,7 +135,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -149,7 +149,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/active-management",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/active-management",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -163,7 +163,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/actively-validated-services-avs",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/actively-validated-services-avs",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -177,7 +177,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/ad-hoc",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/ad-hoc",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -191,7 +191,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/address",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/address",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -205,7 +205,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -219,7 +219,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -233,7 +233,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -247,7 +247,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/airdrop",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/airdrop",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -261,7 +261,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -275,7 +275,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -289,7 +289,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/algorithm",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/algorithm",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -303,7 +303,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/all-or-none-order",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/all-or-none-order",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -317,7 +317,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/all-time-high",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/all-time-high",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -331,7 +331,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/allocation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/allocation",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -345,7 +345,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/alpha",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/alpha",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -359,7 +359,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/altcoin",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/altcoin",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -373,7 +373,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -387,7 +387,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/angel-investor",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/angel-investor",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -401,7 +401,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/anti-money-laundering",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/anti-money-laundering",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -415,7 +415,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -429,7 +429,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -443,7 +443,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -457,7 +457,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/application-programming-interface",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/application-programming-interface",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -471,7 +471,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/application-specific-integrated-circuit",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/application-specific-integrated-circuit",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -485,7 +485,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/arbitrage",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/arbitrage",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -499,7 +499,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -513,7 +513,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/arc-20",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/arc-20",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -527,7 +527,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/artificial-intelligence-ai",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/artificial-intelligence-ai",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -541,7 +541,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -555,7 +555,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/asic-resistant",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/asic-resistant",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -569,7 +569,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/asking-price",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/asking-price",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -583,7 +583,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/asset-management",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/asset-management",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -597,7 +597,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -611,7 +611,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/assets-under-management-aum",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/assets-under-management-aum",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -625,7 +625,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/asynchronous",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/asynchronous",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -639,7 +639,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/atomic-swap",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/atomic-swap",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -653,7 +653,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/attack-surface",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/attack-surface",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -667,7 +667,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -681,7 +681,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/auction",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/auction",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -695,7 +695,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -709,7 +709,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/automated-market-maker-amm",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/automated-market-maker-amm",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -723,7 +723,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -737,7 +737,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -751,7 +751,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -765,7 +765,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/b-tokens",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/b-tokens",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -779,7 +779,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/bags",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/bags",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -793,7 +793,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -807,7 +807,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/beacon-chain",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/beacon-chain",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -821,7 +821,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/bear-market",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/bear-market",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -835,7 +835,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/benchmark",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/benchmark",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -849,7 +849,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/bep-1155",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/bep-1155",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -863,7 +863,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/bep-20",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/bep-20",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -877,7 +877,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/bep-721",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/bep-721",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -891,7 +891,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/bep-95",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/bep-95",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -905,7 +905,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -919,7 +919,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/beta-coefficient",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/beta-coefficient",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -933,7 +933,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/beta-release",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/beta-release",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -947,7 +947,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/bid-ask-spread",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/bid-ask-spread",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -961,7 +961,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/bid-price",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/bid-price",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -975,7 +975,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -989,7 +989,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/binance-blockchain-charity-foundation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/binance-blockchain-charity-foundation",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -1003,7 +1003,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/binance-ecosystem-fund",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/binance-ecosystem-fund",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -1017,7 +1017,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/binancian",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/binancian",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -1031,7 +1031,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/bitcoin",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/bitcoin",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -1045,7 +1045,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/bitcoin-core",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/bitcoin-core",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -1059,7 +1059,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/bitcoin-dominance",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/bitcoin-dominance",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -1073,7 +1073,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/bitcoin-maximalists",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/bitcoin-maximalists",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -1087,7 +1087,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/bitcoin-pizza",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/bitcoin-pizza",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -1101,7 +1101,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/black-swan-event",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/black-swan-event",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -1115,7 +1115,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/block",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/block",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -1129,7 +1129,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/block-explorer",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/block-explorer",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -1143,7 +1143,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/block-header",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/block-header",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -1157,7 +1157,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/block-height",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/block-height",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -1171,7 +1171,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/block-reward",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/block-reward",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -1185,7 +1185,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1199,7 +1199,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1213,7 +1213,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/blockchain",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/blockchain",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -1227,7 +1227,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1241,7 +1241,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1255,7 +1255,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/bloom-filter",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/bloom-filter",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -1269,7 +1269,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/blue-chip-token",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/blue-chip-token",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -1283,7 +1283,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/bnb",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/bnb",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -1297,7 +1297,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1311,7 +1311,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/bnsol",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/bnsol",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -1325,7 +1325,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/bollinger-bands",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/bollinger-bands",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -1339,7 +1339,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/bond",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/bond",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -1353,7 +1353,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/bounty",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/bounty",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -1367,7 +1367,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1381,7 +1381,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1395,7 +1395,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/brc-20-tokens",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/brc-20-tokens",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -1409,7 +1409,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/break-even-point",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/break-even-point",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -1423,7 +1423,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/breakeven-multiple",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/breakeven-multiple",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -1437,7 +1437,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/breakout",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/breakout",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -1451,7 +1451,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1465,7 +1465,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/bscscan",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/bscscan",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -1479,7 +1479,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1493,7 +1493,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/btc-wallet-address",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/btc-wallet-address",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -1507,7 +1507,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/buidl",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/buidl",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -1521,7 +1521,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/bull-market",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/bull-market",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -1535,7 +1535,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/burner-wallet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/burner-wallet",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -1549,7 +1549,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/buy-wall",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/buy-wall",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -1563,7 +1563,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1577,7 +1577,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1591,7 +1591,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1605,7 +1605,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/candidate-block",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/candidate-block",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -1619,7 +1619,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/candlestick",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/candlestick",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -1633,7 +1633,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/capitulation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/capitulation",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -1647,7 +1647,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1661,7 +1661,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/censorship-resistance",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/censorship-resistance",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -1675,7 +1675,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/central-bank",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/central-bank",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -1689,7 +1689,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/central-bank-digital-currency-cbdc",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/central-bank-digital-currency-cbdc",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -1703,7 +1703,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/central-processing-unit",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/central-processing-unit",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -1717,7 +1717,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/centralized",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/centralized",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -1731,7 +1731,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/centralized-exchange",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/centralized-exchange",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -1745,7 +1745,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1759,7 +1759,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1773,7 +1773,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/chatgpt",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/chatgpt",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -1787,7 +1787,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1801,7 +1801,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/cipher",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/cipher",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -1815,7 +1815,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/circulating-supply",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/circulating-supply",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -1829,7 +1829,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1843,7 +1843,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/cloud",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/cloud",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -1857,7 +1857,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1871,7 +1871,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/coin",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/coin",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -1885,7 +1885,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1899,7 +1899,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1913,7 +1913,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/cold-storage",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/cold-storage",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -1927,7 +1927,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1941,7 +1941,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/collateral",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/collateral",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -1955,7 +1955,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/colocation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/colocation",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -1969,7 +1969,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/commodity-futures-trading-commission",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/commodity-futures-trading-commission",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -1983,7 +1983,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1997,7 +1997,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2011,7 +2011,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/compound-interest",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/compound-interest",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -2025,7 +2025,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2039,7 +2039,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/confirmation-time",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/confirmation-time",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -2053,7 +2053,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/confluence",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/confluence",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -2067,7 +2067,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2081,7 +2081,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/consensus-algorithm",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/consensus-algorithm",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -2095,7 +2095,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2109,7 +2109,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2123,7 +2123,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2137,7 +2137,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2151,7 +2151,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2165,7 +2165,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/consumer-price-index-(cpi)",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/consumer-price-index-(cpi)",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -2179,7 +2179,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/contango-and-backwardation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/contango-and-backwardation",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -2193,7 +2193,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2207,7 +2207,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2221,7 +2221,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2235,7 +2235,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/copy-trading",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/copy-trading",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -2249,7 +2249,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/counterparty-risk",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/counterparty-risk",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -2263,7 +2263,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/credentials",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/credentials",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -2277,7 +2277,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/cross-chain-bridges",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/cross-chain-bridges",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -2291,7 +2291,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2305,7 +2305,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2319,7 +2319,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2333,7 +2333,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2347,7 +2347,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/crypto-etfs",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/crypto-etfs",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -2361,7 +2361,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/crypto-fear-and-greed-index",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/crypto-fear-and-greed-index",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -2375,7 +2375,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2389,7 +2389,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/crypto-protocol",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/crypto-protocol",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -2403,7 +2403,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2417,7 +2417,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/crypto-winter",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/crypto-winter",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -2431,7 +2431,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2445,7 +2445,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/cryptocurrency",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/cryptocurrency",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -2459,7 +2459,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2473,7 +2473,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/cryptography",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/cryptography",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -2487,7 +2487,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2501,7 +2501,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/custody",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/custody",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -2515,7 +2515,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2529,7 +2529,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/daemon",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/daemon",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -2543,7 +2543,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2557,7 +2557,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/danksharding",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/danksharding",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -2571,7 +2571,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2585,7 +2585,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2599,7 +2599,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2613,7 +2613,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/dead-cat-bounce",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/dead-cat-bounce",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -2627,7 +2627,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/death-cross",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/death-cross",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -2641,7 +2641,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2655,7 +2655,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/decentralized-application",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/decentralized-application",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -2669,7 +2669,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/decentralized-autonomous-cooperative",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/decentralized-autonomous-cooperative",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -2683,7 +2683,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/decentralized-autonomous-organization",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/decentralized-autonomous-organization",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -2697,7 +2697,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/decentralized-exchange",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/decentralized-exchange",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -2711,7 +2711,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2725,7 +2725,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/decentralized-indexes",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/decentralized-indexes",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -2739,7 +2739,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2753,7 +2753,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/decryption",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/decryption",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -2767,7 +2767,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/deep-web",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/deep-web",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -2781,7 +2781,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2795,7 +2795,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2809,7 +2809,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/delisting",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/delisting",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -2823,7 +2823,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2837,7 +2837,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/depeg",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/depeg",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -2851,7 +2851,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2865,7 +2865,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/depression",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/depression",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -2879,7 +2879,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2893,7 +2893,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/design-flaw-attack",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/design-flaw-attack",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -2907,7 +2907,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2921,7 +2921,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2935,7 +2935,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2949,7 +2949,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2963,7 +2963,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/diamond-hands",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/diamond-hands",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -2977,7 +2977,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/difficulty",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/difficulty",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -2991,7 +2991,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/difficulty-bomb",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/difficulty-bomb",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -3005,7 +3005,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3019,7 +3019,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3033,7 +3033,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/digital-signature",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/digital-signature",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -3047,7 +3047,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3061,7 +3061,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/direct-market-access-dma",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/direct-market-access-dma",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -3075,7 +3075,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3089,7 +3089,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/divergence",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/divergence",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -3103,7 +3103,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/diversification",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/diversification",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -3117,7 +3117,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3131,7 +3131,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/do-your-own-research",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/do-your-own-research",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -3145,7 +3145,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/dollar-cost-averaging",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/dollar-cost-averaging",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -3159,7 +3159,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/dot-plot",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/dot-plot",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -3173,7 +3173,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3187,7 +3187,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/double-spending",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/double-spending",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -3201,7 +3201,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/eclipse-attack",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/eclipse-attack",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -3215,7 +3215,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3229,7 +3229,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3243,7 +3243,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/efficient-market-hypothesis-emh",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/efficient-market-hypothesis-emh",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -3257,7 +3257,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/eigenlayer",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/eigenlayer",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -3271,7 +3271,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/eip",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/eip",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -3285,7 +3285,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3299,7 +3299,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/eip-3074",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/eip-3074",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -3313,7 +3313,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/eip-4844",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/eip-4844",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -3327,7 +3327,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/eip-7251",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/eip-7251",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -3341,7 +3341,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/eip-7702",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/eip-7702",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -3355,7 +3355,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/elasticity",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/elasticity",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -3369,7 +3369,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3383,7 +3383,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/encryption",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/encryption",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -3397,7 +3397,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/endogenous-variable",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/endogenous-variable",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -3411,7 +3411,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3425,7 +3425,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3439,7 +3439,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3453,7 +3453,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3467,7 +3467,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/erc-1155",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/erc-1155",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -3481,7 +3481,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/erc-20",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/erc-20",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -3495,7 +3495,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/erc-404",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/erc-404",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -3509,7 +3509,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/erc-721",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/erc-721",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -3523,7 +3523,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/etf",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/etf",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -3537,7 +3537,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3551,7 +3551,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3565,7 +3565,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3579,7 +3579,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3593,7 +3593,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/ethereum-classic",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/ethereum-classic",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -3607,7 +3607,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/ethereum-foundation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/ethereum-foundation",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -3621,7 +3621,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3635,7 +3635,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3649,7 +3649,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3663,7 +3663,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3677,7 +3677,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/ethereum-virtual-machine-evm",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/ethereum-virtual-machine-evm",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -3691,7 +3691,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3705,7 +3705,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3719,7 +3719,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3733,7 +3733,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/exchange",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/exchange",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -3747,7 +3747,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3761,7 +3761,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3775,7 +3775,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/exogenous-variable",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/exogenous-variable",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -3789,7 +3789,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/exponential-moving-average-ema",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/exponential-moving-average-ema",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -3803,7 +3803,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/externally-owned-account-eoa",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/externally-owned-account-eoa",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -3817,7 +3817,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/fakeout",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/fakeout",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -3831,7 +3831,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/falling-knife",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/falling-knife",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -3845,7 +3845,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/fan-tokens",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/fan-tokens",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -3859,7 +3859,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3873,7 +3873,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3887,7 +3887,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3901,7 +3901,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/fear-of-missing-out",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/fear-of-missing-out",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -3915,7 +3915,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/fear-uncertainty-and-doubt",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/fear-uncertainty-and-doubt",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -3929,7 +3929,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/fiat",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/fiat",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -3943,7 +3943,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3957,7 +3957,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/fibonacci-retracement",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/fibonacci-retracement",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -3971,7 +3971,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/fill-or-kill-order",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/fill-or-kill-order",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -3985,7 +3985,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/finality",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/finality",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -3999,7 +3999,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4013,7 +4013,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4027,7 +4027,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4041,7 +4041,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4055,7 +4055,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4069,7 +4069,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4083,7 +4083,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/first-mover-advantage",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/first-mover-advantage",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -4097,7 +4097,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/fiscal-policy",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/fiscal-policy",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -4111,7 +4111,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/flappening",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/flappening",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -4125,7 +4125,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/flashbots",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/flashbots",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -4139,7 +4139,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/flippening",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/flippening",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -4153,7 +4153,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/flow-variable",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/flow-variable",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -4167,7 +4167,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/forced-liquidation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/forced-liquidation",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -4181,7 +4181,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/forex-fx",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/forex-fx",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -4195,7 +4195,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/fork",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/fork",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -4209,7 +4209,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/formal-verification",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/formal-verification",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -4223,7 +4223,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4237,7 +4237,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/fraud-proof",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/fraud-proof",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -4251,7 +4251,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/fren",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/fren",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -4265,7 +4265,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4279,7 +4279,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/full-node",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/full-node",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -4293,7 +4293,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/fully-diluted-valuation-fdv",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/fully-diluted-valuation-fdv",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -4307,7 +4307,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/fundamental-analysis",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/fundamental-analysis",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -4321,7 +4321,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/funding-fees",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/funding-fees",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -4335,7 +4335,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/fungibility",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/fungibility",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -4349,7 +4349,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/futures-contract",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/futures-contract",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -4363,7 +4363,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/gamefi",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/gamefi",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -4377,7 +4377,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4391,7 +4391,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/gas",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/gas",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -4405,7 +4405,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4419,7 +4419,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/gas-limit",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/gas-limit",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -4433,7 +4433,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4447,7 +4447,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4461,7 +4461,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4475,7 +4475,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/gdp-deflator",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/gdp-deflator",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -4489,7 +4489,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/general-public-license",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/general-public-license",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -4503,7 +4503,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/genesis-block",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/genesis-block",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -4517,7 +4517,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4531,7 +4531,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/github",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/github",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -4545,7 +4545,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/gm-good-morning",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/gm-good-morning",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -4559,7 +4559,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4573,7 +4573,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/golden-cross",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/golden-cross",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -4587,7 +4587,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/golden-ratio",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/golden-ratio",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -4601,7 +4601,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/goldilocks",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/goldilocks",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -4615,7 +4615,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/gossip-protocol",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/gossip-protocol",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -4629,7 +4629,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4643,7 +4643,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/gross-domestic-product-gdp",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/gross-domestic-product-gdp",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -4657,7 +4657,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4671,7 +4671,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/gwei",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/gwei",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -4685,7 +4685,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/hackathon",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/hackathon",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -4699,7 +4699,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/hacker",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/hacker",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -4713,7 +4713,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/haha-money-printer-go-brrrrr",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/haha-money-printer-go-brrrrr",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -4727,7 +4727,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/halving",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/halving",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -4741,7 +4741,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/hard-cap",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/hard-cap",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -4755,7 +4755,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4769,7 +4769,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/hard-landing",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/hard-landing",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -4783,7 +4783,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4797,7 +4797,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4811,7 +4811,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/hash",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/hash",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -4825,7 +4825,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/hash-rate",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/hash-rate",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -4839,7 +4839,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/hashed-timelock-contract",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/hashed-timelock-contract",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -4853,7 +4853,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4867,7 +4867,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/herd-instinct",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/herd-instinct",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -4881,7 +4881,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4895,7 +4895,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/high-frequency-trading-hft",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/high-frequency-trading-hft",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -4909,7 +4909,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/hodl",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/hodl",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -4923,7 +4923,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/honeypot",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/honeypot",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -4937,7 +4937,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4951,7 +4951,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4965,7 +4965,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4979,7 +4979,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4993,7 +4993,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5007,7 +5007,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/iceberg-order",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/iceberg-order",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -5021,7 +5021,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5035,7 +5035,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5049,7 +5049,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/immutability",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/immutability",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -5063,7 +5063,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/index-funds",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/index-funds",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -5077,7 +5077,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5091,7 +5091,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/initial-coin-offering",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/initial-coin-offering",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -5105,7 +5105,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/initial-dex-offering-ido",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/initial-dex-offering-ido",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -5119,7 +5119,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/initial-exchange-offering",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/initial-exchange-offering",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -5133,7 +5133,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/initial-public-offering",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/initial-public-offering",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -5147,7 +5147,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/inscription",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/inscription",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -5161,7 +5161,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5175,7 +5175,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/integrated-circuit",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/integrated-circuit",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -5189,7 +5189,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/interest-rates",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/interest-rates",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -5203,7 +5203,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5217,7 +5217,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/interoperability",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/interoperability",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -5231,7 +5231,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5245,7 +5245,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/interplanetary-file-system-ipfs",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/interplanetary-file-system-ipfs",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -5259,7 +5259,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/iou",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/iou",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -5273,7 +5273,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5287,7 +5287,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5301,7 +5301,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5315,7 +5315,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/isolated-margin",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/isolated-margin",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -5329,7 +5329,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/issuance",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/issuance",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -5343,7 +5343,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5357,7 +5357,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5371,7 +5371,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/keccak",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/keccak",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -5385,7 +5385,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5399,7 +5399,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/know-your-customer",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/know-your-customer",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -5413,7 +5413,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5427,7 +5427,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5441,7 +5441,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5455,7 +5455,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5469,7 +5469,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/laspeyres-index",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/laspeyres-index",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -5483,7 +5483,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/latency",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/latency",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -5497,7 +5497,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5511,7 +5511,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5525,7 +5525,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/law-of-demand",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/law-of-demand",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -5539,7 +5539,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5553,7 +5553,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/layer-2",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/layer-2",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -5567,7 +5567,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/ledger",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/ledger",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -5581,7 +5581,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5595,7 +5595,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5609,7 +5609,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/leveraged-tokens",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/leveraged-tokens",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -5623,7 +5623,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/library",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/library",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -5637,7 +5637,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5651,7 +5651,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5665,7 +5665,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/lightning-network",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/lightning-network",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -5679,7 +5679,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/limit-order",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/limit-order",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -5693,7 +5693,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5707,7 +5707,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/linux",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/linux",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -5721,7 +5721,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/liquid-staking",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/liquid-staking",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -5735,7 +5735,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/liquid-staking-token-lst",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/liquid-staking-token-lst",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -5749,7 +5749,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5763,7 +5763,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/liquidity",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/liquidity",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -5777,7 +5777,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/liquidity-crisis",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/liquidity-crisis",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -5791,7 +5791,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5805,7 +5805,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/liquidity-provider",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/liquidity-provider",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -5819,7 +5819,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/liquidity-ratios",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/liquidity-ratios",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -5833,7 +5833,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5847,7 +5847,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/listing",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/listing",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -5861,7 +5861,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/mainnet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/mainnet",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -5875,7 +5875,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/mainnet-swap",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/mainnet-swap",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -5889,7 +5889,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/maker",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/maker",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -5903,7 +5903,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5917,7 +5917,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/malware",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/malware",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -5931,7 +5931,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/margin-trading",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/margin-trading",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -5945,7 +5945,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5959,7 +5959,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/market-capitalization",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/market-capitalization",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -5973,7 +5973,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/market-momentum",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/market-momentum",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -5987,7 +5987,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/market-order",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/market-order",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -6001,7 +6001,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/masternode",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/masternode",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -6015,7 +6015,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/matching-engine",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/matching-engine",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -6029,7 +6029,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6043,7 +6043,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/maximum-supply",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/maximum-supply",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -6057,7 +6057,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6071,7 +6071,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/mempool",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/mempool",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -6085,7 +6085,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6099,7 +6099,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6113,7 +6113,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/merged-mining",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/merged-mining",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -6127,7 +6127,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6141,7 +6141,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/merkle-tree",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/merkle-tree",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -6155,7 +6155,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6169,7 +6169,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/metadata",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/metadata",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -6183,7 +6183,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6197,7 +6197,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6211,7 +6211,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6225,7 +6225,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6239,7 +6239,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6253,7 +6253,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/metaverse",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/metaverse",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -6267,7 +6267,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6281,7 +6281,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6295,7 +6295,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/microtransactions",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/microtransactions",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -6309,7 +6309,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6323,7 +6323,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6337,7 +6337,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/mining",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/mining",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -6351,7 +6351,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/mining-farm",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/mining-farm",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -6365,7 +6365,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/mint",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/mint",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -6379,7 +6379,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6393,7 +6393,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6407,7 +6407,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6421,7 +6421,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/monetary-policy",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/monetary-policy",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -6435,7 +6435,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/money-markets",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/money-markets",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -6449,7 +6449,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/monitoring-tag",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/monitoring-tag",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -6463,7 +6463,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/moon",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/moon",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -6477,7 +6477,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6491,7 +6491,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/moving-average-envelopes",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/moving-average-envelopes",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -6505,7 +6505,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/moving-average-ribbon",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/moving-average-ribbon",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -6519,7 +6519,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/mt-gox",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/mt-gox",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -6533,7 +6533,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6547,7 +6547,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6561,7 +6561,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/multisignature",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/multisignature",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -6575,7 +6575,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/nakamoto-consensus",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/nakamoto-consensus",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -6589,7 +6589,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6603,7 +6603,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/net-asset-value-nav",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/net-asset-value-nav",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -6617,7 +6617,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6631,7 +6631,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6645,7 +6645,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6659,7 +6659,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6673,7 +6673,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6687,7 +6687,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6701,7 +6701,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/nft-floor-prices",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/nft-floor-prices",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -6715,7 +6715,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/nft-mystery-boxes",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/nft-mystery-boxes",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -6729,7 +6729,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/ngmi",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/ngmi",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -6743,7 +6743,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6757,7 +6757,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/node",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/node",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -6771,7 +6771,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6785,7 +6785,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/non-fungible-token-nft",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/non-fungible-token-nft",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -6799,7 +6799,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/nonce",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/nonce",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -6813,7 +6813,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/oco-order",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/oco-order",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -6827,7 +6827,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/off-chain",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/off-chain",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -6841,7 +6841,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6855,7 +6855,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/offline-signing-orchestrator-oso",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/offline-signing-orchestrator-oso",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -6869,7 +6869,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/offshore-account",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/offshore-account",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -6883,7 +6883,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6897,7 +6897,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/on-chain",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/on-chain",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -6911,7 +6911,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6925,7 +6925,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6939,7 +6939,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/opbnb",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/opbnb",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -6953,7 +6953,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/open-source-software-oss",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/open-source-software-oss",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -6967,7 +6967,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6981,7 +6981,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6995,7 +6995,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/opportunity-cost",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/opportunity-cost",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -7009,7 +7009,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7023,7 +7023,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7037,7 +7037,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/oracle",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/oracle",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -7051,7 +7051,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/orc-20-tokens",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/orc-20-tokens",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -7065,7 +7065,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/order-book",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/order-book",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -7079,7 +7079,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/ordinals",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/ordinals",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -7093,7 +7093,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/orphan-block",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/orphan-block",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -7107,7 +7107,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7121,7 +7121,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7135,7 +7135,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/pancakeswap",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/pancakeswap",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -7149,7 +7149,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/paper-wallet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/paper-wallet",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -7163,7 +7163,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/parallelization",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/parallelization",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -7177,7 +7177,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7191,7 +7191,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7205,7 +7205,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/passive-management",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/passive-management",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -7219,7 +7219,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7233,7 +7233,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7247,7 +7247,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7261,7 +7261,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7275,7 +7275,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/peer-to-peer",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/peer-to-peer",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -7289,7 +7289,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/pegged-currency",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/pegged-currency",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -7303,7 +7303,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7317,7 +7317,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/permissionless-blockchain",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/permissionless-blockchain",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -7331,7 +7331,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/phishing",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/phishing",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -7345,7 +7345,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7359,7 +7359,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/plasma",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/plasma",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -7373,7 +7373,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7387,7 +7387,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/polkadot-crowdloan",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/polkadot-crowdloan",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -7401,7 +7401,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7415,7 +7415,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/ponzi-scheme",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/ponzi-scheme",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -7429,7 +7429,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7443,7 +7443,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7457,7 +7457,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/premining",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/premining",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -7471,7 +7471,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/price-action",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/price-action",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -7485,7 +7485,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/prisoners-dilemma",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/prisoners-dilemma",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -7499,7 +7499,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7513,7 +7513,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7527,7 +7527,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/private-key",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/private-key",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -7541,7 +7541,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/private-sale",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/private-sale",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -7555,7 +7555,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/progressive-web-application",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/progressive-web-application",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -7569,7 +7569,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/proof-of-attendance-protocol-poap",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/proof-of-attendance-protocol-poap",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -7583,7 +7583,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/proof-of-reserves-por",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/proof-of-reserves-por",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -7597,7 +7597,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/proof-of-stake",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/proof-of-stake",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -7611,7 +7611,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/proof-of-staked-authority-posa",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/proof-of-staked-authority-posa",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -7625,7 +7625,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/proof-of-work",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/proof-of-work",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -7639,7 +7639,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/proposer-builder-separation-pbs",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/proposer-builder-separation-pbs",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -7653,7 +7653,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/proto-danksharding",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/proto-danksharding",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -7667,7 +7667,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7681,7 +7681,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/pseudorandom",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/pseudorandom",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -7695,7 +7695,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7709,7 +7709,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7723,7 +7723,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/public-key",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/public-key",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -7737,7 +7737,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7751,7 +7751,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/pump-and-dump",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/pump-and-dump",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -7765,7 +7765,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7779,7 +7779,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/quantitative-easing-qe",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/quantitative-easing-qe",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -7793,7 +7793,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/quantitative-tightening-qt",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/quantitative-tightening-qt",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -7807,7 +7807,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/quantum-computing",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/quantum-computing",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -7821,7 +7821,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7835,7 +7835,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/race-attack",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/race-attack",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -7849,7 +7849,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/ransomware",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/ransomware",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -7863,7 +7863,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7877,7 +7877,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/real-world-assets-rwas",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/real-world-assets-rwas",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -7891,7 +7891,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/recession",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/recession",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -7905,7 +7905,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/recursive-inscription",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/recursive-inscription",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -7919,7 +7919,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/rekt",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/rekt",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -7933,7 +7933,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/relative-strength-index",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/relative-strength-index",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -7947,7 +7947,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7961,7 +7961,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7975,7 +7975,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/resistance",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/resistance",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -7989,7 +7989,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/return-on-investment",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/return-on-investment",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -8003,7 +8003,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/revenge-trading",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/revenge-trading",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -8017,7 +8017,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8031,7 +8031,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/risk-premium",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/risk-premium",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -8045,7 +8045,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/roadmap",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/roadmap",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -8059,7 +8059,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8073,7 +8073,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8087,7 +8087,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8101,7 +8101,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/routing-attack",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/routing-attack",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -8115,7 +8115,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8129,7 +8129,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/rug-pull",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/rug-pull",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -8143,7 +8143,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8157,7 +8157,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/sahm-rule",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/sahm-rule",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -8171,7 +8171,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8185,7 +8185,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8199,7 +8199,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/sandwich-trading",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/sandwich-trading",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -8213,7 +8213,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8227,7 +8227,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/satoshi",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/satoshi",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -8241,7 +8241,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/satoshi-nakamoto",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/satoshi-nakamoto",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -8255,7 +8255,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8269,7 +8269,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8283,7 +8283,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8297,7 +8297,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8311,7 +8311,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8325,7 +8325,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8339,7 +8339,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8353,7 +8353,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/secure-asset-fund-for-users",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/secure-asset-fund-for-users",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -8367,7 +8367,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/securities-and-exchange-commission",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/securities-and-exchange-commission",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -8381,7 +8381,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/security-audit",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/security-audit",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -8395,7 +8395,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8409,7 +8409,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8423,7 +8423,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/security-token-offering-sto",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/security-token-offering-sto",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -8437,7 +8437,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/seed-phrase",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/seed-phrase",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -8451,7 +8451,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/seed-tag",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/seed-tag",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -8465,7 +8465,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/segregated-witness",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/segregated-witness",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -8479,7 +8479,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8493,7 +8493,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8507,7 +8507,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/selfish-mining",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/selfish-mining",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -8521,7 +8521,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/sell-wall",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/sell-wall",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -8535,7 +8535,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/sentiment",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/sentiment",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -8549,7 +8549,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8563,7 +8563,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8577,7 +8577,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8591,7 +8591,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8605,7 +8605,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/sharding",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/sharding",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -8619,7 +8619,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/sharpe-ratio",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/sharpe-ratio",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -8633,7 +8633,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8647,7 +8647,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8661,7 +8661,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/sidechains",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/sidechains",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -8675,7 +8675,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/simple-moving-average-sma",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/simple-moving-average-sma",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -8689,7 +8689,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/slashing",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/slashing",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -8703,7 +8703,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8717,7 +8717,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/slippage",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/slippage",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -8731,7 +8731,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8745,7 +8745,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/smart-contract",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/smart-contract",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -8759,7 +8759,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/smart-contract-wallet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/smart-contract-wallet",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -8773,7 +8773,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/snapshot",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/snapshot",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -8787,7 +8787,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/social-recovery-wallet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/social-recovery-wallet",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -8801,7 +8801,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/social-trading",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/social-trading",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -8815,7 +8815,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/socialfi",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/socialfi",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -8829,7 +8829,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8843,7 +8843,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/soft-landing",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/soft-landing",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -8857,7 +8857,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/solidity",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/solidity",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -8871,7 +8871,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/source-code",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/source-code",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -8885,7 +8885,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/spl",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/spl",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -8899,7 +8899,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/src-20-tokens",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/src-20-tokens",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -8913,7 +8913,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/stablecoin",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/stablecoin",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -8927,7 +8927,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/stagflation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/stagflation",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -8941,7 +8941,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8955,7 +8955,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8969,7 +8969,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/staking-pool",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/staking-pool",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -8983,7 +8983,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8997,7 +8997,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/state-channel",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/state-channel",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -9011,7 +9011,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9025,7 +9025,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/steth",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/steth",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -9039,7 +9039,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9053,7 +9053,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/stock-variable",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/stock-variable",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -9067,7 +9067,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/store-of-value",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/store-of-value",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -9081,7 +9081,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9095,7 +9095,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/supercomputer",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/supercomputer",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -9109,7 +9109,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/supply-chain",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/supply-chain",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -9123,7 +9123,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/support",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/support",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -9137,7 +9137,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9151,7 +9151,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/sybil-attack",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/sybil-attack",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -9165,7 +9165,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9179,7 +9179,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/taker",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/taker",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -9193,7 +9193,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/tank",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/tank",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -9207,7 +9207,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9221,7 +9221,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9235,7 +9235,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/testnet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/testnet",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -9249,7 +9249,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9263,7 +9263,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9277,7 +9277,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9291,7 +9291,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/ticker",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/ticker",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -9305,7 +9305,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/ticker-symbol",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/ticker-symbol",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -9319,7 +9319,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/token",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/token",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -9333,7 +9333,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/token-generation-event-tge",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/token-generation-event-tge",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -9347,7 +9347,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/token-lockup",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/token-lockup",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -9361,7 +9361,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/token-merge",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/token-merge",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -9375,7 +9375,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/token-sale",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/token-sale",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -9389,7 +9389,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9403,7 +9403,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/token-standards",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/token-standards",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -9417,7 +9417,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/tokenization",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/tokenization",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -9431,7 +9431,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/tokenomics",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/tokenomics",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -9445,7 +9445,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/total-supply",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/total-supply",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -9459,7 +9459,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/total-value-locked-tvl",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/total-value-locked-tvl",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -9473,7 +9473,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/tradfi",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/tradfi",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -9487,7 +9487,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9501,7 +9501,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9515,7 +9515,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9529,7 +9529,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/transaction-id",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/transaction-id",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -9543,7 +9543,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9557,7 +9557,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/transactions-per-second-tps",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/transactions-per-second-tps",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -9571,7 +9571,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9585,7 +9585,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/treasury-bills-t-bills",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/treasury-bills-t-bills",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -9599,7 +9599,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9613,7 +9613,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/trueusd-tusd",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/trueusd-tusd",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -9627,7 +9627,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9641,7 +9641,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/trustless",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/trustless",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -9655,7 +9655,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/turing-complete",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/turing-complete",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -9669,7 +9669,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9683,7 +9683,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9697,7 +9697,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9711,7 +9711,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/understanding-cz-s-number-4",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/understanding-cz-s-number-4",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -9725,7 +9725,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9739,7 +9739,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9753,7 +9753,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/unit-of-account",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/unit-of-account",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -9767,7 +9767,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9781,7 +9781,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/unspent-transaction-output-utxo",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/unspent-transaction-output-utxo",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -9795,7 +9795,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9809,7 +9809,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9823,7 +9823,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9837,7 +9837,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9851,7 +9851,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/user-interface",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/user-interface",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -9865,7 +9865,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/utility-token",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/utility-token",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -9879,7 +9879,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9893,7 +9893,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9907,7 +9907,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9921,7 +9921,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/verification-code",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/verification-code",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -9935,7 +9935,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9949,7 +9949,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9963,7 +9963,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/virtual-machine",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/virtual-machine",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -9977,7 +9977,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/vladimir-club",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/vladimir-club",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -9991,7 +9991,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/volatility",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/volatility",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -10005,7 +10005,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/volume",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/volume",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -10019,7 +10019,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/wagmi",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/wagmi",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -10033,7 +10033,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/wallet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/wallet",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -10047,7 +10047,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10061,7 +10061,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10075,7 +10075,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/wash-trading",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/wash-trading",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -10089,7 +10089,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/weak-hands",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/weak-hands",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -10103,7 +10103,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/weak-subjectivity",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/weak-subjectivity",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -10117,7 +10117,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/web-1",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/web-1",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -10131,7 +10131,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10145,7 +10145,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10159,7 +10159,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10173,7 +10173,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10187,7 +10187,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10201,7 +10201,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/wei",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/wei",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -10215,7 +10215,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/weighted-moving-average-wma",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/weighted-moving-average-wma",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -10229,7 +10229,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/whale",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/whale",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -10243,7 +10243,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/whiskers",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/whiskers",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -10257,7 +10257,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/whitelist",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/whitelist",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -10271,7 +10271,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10285,7 +10285,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/wick",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/wick",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -10299,7 +10299,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/win-rate",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/win-rate",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -10313,7 +10313,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/wrapped-ether",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/wrapped-ether",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -10327,7 +10327,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10341,7 +10341,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/wyckoff",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/wyckoff",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -10355,7 +10355,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10369,7 +10369,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10383,7 +10383,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10397,7 +10397,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10411,7 +10411,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/yield-farming",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/yield-farming",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -10425,7 +10425,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10439,7 +10439,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10453,7 +10453,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/zero-knowledge-proofs",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/zero-knowledge-proofs",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -10467,7 +10467,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10481,7 +10481,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/zk-rollup",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/zk-rollup",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -10495,7 +10495,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/zk-snarks",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/zk-snarks",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""
@@ -10509,7 +10509,7 @@
       "definitionSource": "https://academy.binance.com/hu/glossary/zk-starks",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/hu/glossary/zk-starks",
       "dateFirstRecorded": "2025-02-03",
       "commentary": ""

--- a/locales/id-ID/id-ID.json
+++ b/locales/id-ID/id-ID.json
@@ -9,7 +9,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -23,7 +23,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -37,7 +37,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -51,7 +51,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -65,7 +65,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -79,7 +79,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -93,7 +93,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -107,7 +107,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/absolute-advantage",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/absolute-advantage",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -121,7 +121,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -135,7 +135,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -149,7 +149,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/active-management",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/active-management",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -163,7 +163,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/actively-validated-services-avs",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/actively-validated-services-avs",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -177,7 +177,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/ad-hoc",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/ad-hoc",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -191,7 +191,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/address",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/address",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -205,7 +205,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -219,7 +219,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -233,7 +233,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -247,7 +247,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/airdrop",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/airdrop",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -261,7 +261,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -275,7 +275,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -289,7 +289,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/algorithm",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/algorithm",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -303,7 +303,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/all-or-none-order",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/all-or-none-order",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -317,7 +317,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/all-time-high",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/all-time-high",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -331,7 +331,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/allocation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/allocation",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -345,7 +345,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/alpha",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/alpha",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -359,7 +359,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/altcoin",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/altcoin",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -373,7 +373,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -387,7 +387,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/angel-investor",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/angel-investor",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -401,7 +401,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/anti-money-laundering",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/anti-money-laundering",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -415,7 +415,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -429,7 +429,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -443,7 +443,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -457,7 +457,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/application-programming-interface",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/application-programming-interface",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -471,7 +471,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/application-specific-integrated-circuit",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/application-specific-integrated-circuit",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -485,7 +485,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/arbitrage",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/arbitrage",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -499,7 +499,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -513,7 +513,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/arc-20",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/arc-20",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -527,7 +527,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/artificial-intelligence-ai",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/artificial-intelligence-ai",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -541,7 +541,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -555,7 +555,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/asic-resistant",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/asic-resistant",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -569,7 +569,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/asking-price",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/asking-price",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -583,7 +583,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/asset-management",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/asset-management",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -597,7 +597,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -611,7 +611,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/assets-under-management-aum",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/assets-under-management-aum",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -625,7 +625,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/asynchronous",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/asynchronous",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -639,7 +639,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/atomic-swap",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/atomic-swap",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -653,7 +653,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/attack-surface",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/attack-surface",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -667,7 +667,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -681,7 +681,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/auction",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/auction",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -695,7 +695,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -709,7 +709,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/automated-market-maker-amm",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/automated-market-maker-amm",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -723,7 +723,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -737,7 +737,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -751,7 +751,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -765,7 +765,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/b-tokens",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/b-tokens",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -779,7 +779,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/bags",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/bags",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -793,7 +793,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -807,7 +807,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/beacon-chain",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/beacon-chain",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -821,7 +821,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/bear-market",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/bear-market",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -835,7 +835,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/benchmark",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/benchmark",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -849,7 +849,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/bep-1155",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/bep-1155",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -863,7 +863,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/bep-20",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/bep-20",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -877,7 +877,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/bep-721",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/bep-721",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -891,7 +891,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/bep-95",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/bep-95",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -905,7 +905,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -919,7 +919,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/beta-coefficient",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/beta-coefficient",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -933,7 +933,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/beta-release",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/beta-release",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -947,7 +947,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/bid-ask-spread",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/bid-ask-spread",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -961,7 +961,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/bid-price",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/bid-price",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -975,7 +975,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -989,7 +989,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/binance-blockchain-charity-foundation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/binance-blockchain-charity-foundation",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1003,7 +1003,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/binance-ecosystem-fund",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/binance-ecosystem-fund",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1017,7 +1017,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/binancian",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/binancian",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1031,7 +1031,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/bitcoin",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/bitcoin",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1045,7 +1045,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/bitcoin-core",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/bitcoin-core",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1059,7 +1059,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/bitcoin-dominance",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/bitcoin-dominance",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1073,7 +1073,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/bitcoin-maximalists",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/bitcoin-maximalists",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1087,7 +1087,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/bitcoin-pizza",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/bitcoin-pizza",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1101,7 +1101,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/black-swan-event",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/black-swan-event",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1115,7 +1115,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/block",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/block",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1129,7 +1129,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/block-explorer",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/block-explorer",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1143,7 +1143,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/block-header",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/block-header",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1157,7 +1157,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/block-height",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/block-height",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1171,7 +1171,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/block-reward",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/block-reward",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1185,7 +1185,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1199,7 +1199,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1213,7 +1213,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/blockchain",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/blockchain",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1227,7 +1227,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1241,7 +1241,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1255,7 +1255,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/bloom-filter",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/bloom-filter",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1269,7 +1269,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/blue-chip-token",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/blue-chip-token",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1283,7 +1283,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/bnb",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/bnb",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1297,7 +1297,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1311,7 +1311,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/bnsol",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/bnsol",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1325,7 +1325,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/bollinger-bands",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/bollinger-bands",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1339,7 +1339,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/bond",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/bond",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1353,7 +1353,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/bounty",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/bounty",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1367,7 +1367,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1381,7 +1381,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1395,7 +1395,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/brc-20-tokens",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/brc-20-tokens",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1409,7 +1409,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/break-even-point",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/break-even-point",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1423,7 +1423,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/breakeven-multiple",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/breakeven-multiple",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1437,7 +1437,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/breakout",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/breakout",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1451,7 +1451,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1465,7 +1465,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/bscscan",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/bscscan",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1479,7 +1479,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1493,7 +1493,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/btc-wallet-address",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/btc-wallet-address",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1507,7 +1507,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/buidl",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/buidl",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1521,7 +1521,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/bull-market",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/bull-market",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1535,7 +1535,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/burner-wallet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/burner-wallet",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1549,7 +1549,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/buy-wall",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/buy-wall",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1563,7 +1563,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1577,7 +1577,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1591,7 +1591,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1605,7 +1605,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/candidate-block",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/candidate-block",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1619,7 +1619,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/candlestick",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/candlestick",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1633,7 +1633,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/capitulation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/capitulation",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1647,7 +1647,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1661,7 +1661,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/censorship-resistance",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/censorship-resistance",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1675,7 +1675,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/central-bank",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/central-bank",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1689,7 +1689,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/central-bank-digital-currency-cbdc",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/central-bank-digital-currency-cbdc",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1703,7 +1703,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/central-processing-unit",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/central-processing-unit",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1717,7 +1717,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/centralized",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/centralized",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1731,7 +1731,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/centralized-exchange",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/centralized-exchange",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1745,7 +1745,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1759,7 +1759,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1773,7 +1773,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/chatgpt",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/chatgpt",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1787,7 +1787,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1801,7 +1801,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/cipher",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/cipher",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1815,7 +1815,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/circulating-supply",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/circulating-supply",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1829,7 +1829,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1843,7 +1843,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/cloud",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/cloud",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1857,7 +1857,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1871,7 +1871,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/coin",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/coin",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1885,7 +1885,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1899,7 +1899,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1913,7 +1913,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/cold-storage",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/cold-storage",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1927,7 +1927,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1941,7 +1941,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/collateral",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/collateral",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1955,7 +1955,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/colocation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/colocation",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1969,7 +1969,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/commodity-futures-trading-commission",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/commodity-futures-trading-commission",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1983,7 +1983,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1997,7 +1997,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2011,7 +2011,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/compound-interest",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/compound-interest",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2025,7 +2025,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2039,7 +2039,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/confirmation-time",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/confirmation-time",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2053,7 +2053,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/confluence",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/confluence",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2067,7 +2067,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2081,7 +2081,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/consensus-algorithm",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/consensus-algorithm",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2095,7 +2095,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2109,7 +2109,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2123,7 +2123,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2137,7 +2137,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2151,7 +2151,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2165,7 +2165,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/consumer-price-index-(cpi)",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/consumer-price-index-(cpi)",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2179,7 +2179,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/contango-and-backwardation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/contango-and-backwardation",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2193,7 +2193,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2207,7 +2207,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2221,7 +2221,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2235,7 +2235,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/copy-trading",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/copy-trading",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2249,7 +2249,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/counterparty-risk",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/counterparty-risk",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2263,7 +2263,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/credentials",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/credentials",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2277,7 +2277,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/cross-chain-bridges",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/cross-chain-bridges",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2291,7 +2291,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2305,7 +2305,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2319,7 +2319,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2333,7 +2333,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2347,7 +2347,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/crypto-etfs",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/crypto-etfs",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2361,7 +2361,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/crypto-fear-and-greed-index",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/crypto-fear-and-greed-index",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2375,7 +2375,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2389,7 +2389,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/crypto-protocol",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/crypto-protocol",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2403,7 +2403,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2417,7 +2417,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/crypto-winter",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/crypto-winter",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2431,7 +2431,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2445,7 +2445,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/cryptocurrency",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/cryptocurrency",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2459,7 +2459,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2473,7 +2473,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/cryptography",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/cryptography",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2487,7 +2487,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2501,7 +2501,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/custody",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/custody",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2515,7 +2515,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2529,7 +2529,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/daemon",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/daemon",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2543,7 +2543,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2557,7 +2557,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/danksharding",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/danksharding",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2571,7 +2571,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2585,7 +2585,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2599,7 +2599,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2613,7 +2613,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/dead-cat-bounce",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/dead-cat-bounce",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2627,7 +2627,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/death-cross",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/death-cross",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2641,7 +2641,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2655,7 +2655,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/decentralized-application",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/decentralized-application",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2669,7 +2669,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/decentralized-autonomous-cooperative",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/decentralized-autonomous-cooperative",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2683,7 +2683,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/decentralized-autonomous-organization",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/decentralized-autonomous-organization",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2697,7 +2697,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/decentralized-exchange",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/decentralized-exchange",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2711,7 +2711,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2725,7 +2725,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/decentralized-indexes",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/decentralized-indexes",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2739,7 +2739,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2753,7 +2753,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/decryption",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/decryption",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2767,7 +2767,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/deep-web",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/deep-web",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2781,7 +2781,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2795,7 +2795,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2809,7 +2809,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/delisting",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/delisting",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2823,7 +2823,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2837,7 +2837,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/depeg",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/depeg",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2851,7 +2851,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2865,7 +2865,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/depression",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/depression",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2879,7 +2879,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2893,7 +2893,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/design-flaw-attack",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/design-flaw-attack",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2907,7 +2907,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2921,7 +2921,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2935,7 +2935,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2949,7 +2949,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2963,7 +2963,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/diamond-hands",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/diamond-hands",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2977,7 +2977,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/difficulty",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/difficulty",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2991,7 +2991,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/difficulty-bomb",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/difficulty-bomb",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3005,7 +3005,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3019,7 +3019,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3033,7 +3033,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/digital-signature",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/digital-signature",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3047,7 +3047,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3061,7 +3061,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/direct-market-access-dma",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/direct-market-access-dma",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3075,7 +3075,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3089,7 +3089,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/divergence",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/divergence",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3103,7 +3103,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/diversification",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/diversification",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3117,7 +3117,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3131,7 +3131,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/do-your-own-research",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/do-your-own-research",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3145,7 +3145,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/dollar-cost-averaging",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/dollar-cost-averaging",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3159,7 +3159,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/dot-plot",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/dot-plot",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3173,7 +3173,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3187,7 +3187,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/double-spending",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/double-spending",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3201,7 +3201,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/eclipse-attack",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/eclipse-attack",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3215,7 +3215,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3229,7 +3229,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3243,7 +3243,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/efficient-market-hypothesis-emh",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/efficient-market-hypothesis-emh",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3257,7 +3257,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/eigenlayer",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/eigenlayer",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3271,7 +3271,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/eip",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/eip",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3285,7 +3285,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3299,7 +3299,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/eip-3074",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/eip-3074",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3313,7 +3313,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/eip-4844",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/eip-4844",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3327,7 +3327,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/eip-7251",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/eip-7251",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3341,7 +3341,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/eip-7702",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/eip-7702",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3355,7 +3355,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/elasticity",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/elasticity",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3369,7 +3369,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3383,7 +3383,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/encryption",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/encryption",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3397,7 +3397,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/endogenous-variable",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/endogenous-variable",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3411,7 +3411,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3425,7 +3425,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3439,7 +3439,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3453,7 +3453,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3467,7 +3467,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/erc-1155",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/erc-1155",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3481,7 +3481,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/erc-20",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/erc-20",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3495,7 +3495,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/erc-404",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/erc-404",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3509,7 +3509,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/erc-721",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/erc-721",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3523,7 +3523,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/etf",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/etf",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3537,7 +3537,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3551,7 +3551,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3565,7 +3565,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3579,7 +3579,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3593,7 +3593,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/ethereum-classic",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/ethereum-classic",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3607,7 +3607,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/ethereum-foundation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/ethereum-foundation",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3621,7 +3621,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3635,7 +3635,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3649,7 +3649,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3663,7 +3663,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3677,7 +3677,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/ethereum-virtual-machine-evm",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/ethereum-virtual-machine-evm",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3691,7 +3691,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3705,7 +3705,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3719,7 +3719,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3733,7 +3733,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/exchange",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/exchange",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3747,7 +3747,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3761,7 +3761,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3775,7 +3775,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/exogenous-variable",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/exogenous-variable",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3789,7 +3789,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/exponential-moving-average-ema",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/exponential-moving-average-ema",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3803,7 +3803,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/externally-owned-account-eoa",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/externally-owned-account-eoa",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3817,7 +3817,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/fakeout",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/fakeout",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3831,7 +3831,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/falling-knife",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/falling-knife",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3845,7 +3845,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/fan-tokens",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/fan-tokens",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3859,7 +3859,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3873,7 +3873,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3887,7 +3887,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3901,7 +3901,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/fear-of-missing-out",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/fear-of-missing-out",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3915,7 +3915,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/fear-uncertainty-and-doubt",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/fear-uncertainty-and-doubt",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3929,7 +3929,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/fiat",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/fiat",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3943,7 +3943,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3957,7 +3957,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/fibonacci-retracement",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/fibonacci-retracement",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3971,7 +3971,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/fill-or-kill-order",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/fill-or-kill-order",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3985,7 +3985,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/finality",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/finality",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3999,7 +3999,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4013,7 +4013,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4027,7 +4027,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4041,7 +4041,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4055,7 +4055,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4069,7 +4069,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4083,7 +4083,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/first-mover-advantage",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/first-mover-advantage",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4097,7 +4097,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/fiscal-policy",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/fiscal-policy",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4111,7 +4111,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/flappening",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/flappening",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4125,7 +4125,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/flashbots",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/flashbots",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4139,7 +4139,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/flippening",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/flippening",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4153,7 +4153,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/flow-variable",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/flow-variable",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4167,7 +4167,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/forced-liquidation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/forced-liquidation",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4181,7 +4181,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/forex-fx",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/forex-fx",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4195,7 +4195,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/fork",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/fork",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4209,7 +4209,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/formal-verification",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/formal-verification",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4223,7 +4223,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4237,7 +4237,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/fraud-proof",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/fraud-proof",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4251,7 +4251,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/fren",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/fren",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4265,7 +4265,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4279,7 +4279,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/full-node",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/full-node",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4293,7 +4293,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/fully-diluted-valuation-fdv",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/fully-diluted-valuation-fdv",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4307,7 +4307,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/fundamental-analysis",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/fundamental-analysis",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4321,7 +4321,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/funding-fees",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/funding-fees",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4335,7 +4335,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/fungibility",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/fungibility",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4349,7 +4349,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/futures-contract",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/futures-contract",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4363,7 +4363,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/gamefi",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/gamefi",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4377,7 +4377,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4391,7 +4391,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/gas",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/gas",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4405,7 +4405,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4419,7 +4419,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/gas-limit",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/gas-limit",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4433,7 +4433,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4447,7 +4447,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4461,7 +4461,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4475,7 +4475,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/gdp-deflator",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/gdp-deflator",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4489,7 +4489,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/general-public-license",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/general-public-license",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4503,7 +4503,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/genesis-block",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/genesis-block",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4517,7 +4517,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4531,7 +4531,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/github",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/github",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4545,7 +4545,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/gm-good-morning",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/gm-good-morning",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4559,7 +4559,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4573,7 +4573,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/golden-cross",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/golden-cross",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4587,7 +4587,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/golden-ratio",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/golden-ratio",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4601,7 +4601,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/goldilocks",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/goldilocks",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4615,7 +4615,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/gossip-protocol",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/gossip-protocol",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4629,7 +4629,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4643,7 +4643,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/gross-domestic-product-gdp",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/gross-domestic-product-gdp",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4657,7 +4657,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4671,7 +4671,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/gwei",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/gwei",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4685,7 +4685,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/hackathon",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/hackathon",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4699,7 +4699,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/hacker",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/hacker",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4713,7 +4713,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/haha-money-printer-go-brrrrr",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/haha-money-printer-go-brrrrr",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4727,7 +4727,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/halving",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/halving",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4741,7 +4741,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/hard-cap",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/hard-cap",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4755,7 +4755,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4769,7 +4769,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/hard-landing",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/hard-landing",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4783,7 +4783,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4797,7 +4797,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4811,7 +4811,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/hash",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/hash",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4825,7 +4825,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/hash-rate",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/hash-rate",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4839,7 +4839,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/hashed-timelock-contract",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/hashed-timelock-contract",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4853,7 +4853,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4867,7 +4867,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/herd-instinct",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/herd-instinct",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4881,7 +4881,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4895,7 +4895,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/high-frequency-trading-hft",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/high-frequency-trading-hft",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4909,7 +4909,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/hodl",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/hodl",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4923,7 +4923,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/honeypot",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/honeypot",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4937,7 +4937,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4951,7 +4951,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4965,7 +4965,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4979,7 +4979,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4993,7 +4993,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5007,7 +5007,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/iceberg-order",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/iceberg-order",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5021,7 +5021,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5035,7 +5035,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5049,7 +5049,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/immutability",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/immutability",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5063,7 +5063,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/index-funds",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/index-funds",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5077,7 +5077,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5091,7 +5091,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/initial-coin-offering",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/initial-coin-offering",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5105,7 +5105,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/initial-dex-offering-ido",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/initial-dex-offering-ido",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5119,7 +5119,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/initial-exchange-offering",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/initial-exchange-offering",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5133,7 +5133,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/initial-public-offering",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/initial-public-offering",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5147,7 +5147,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/inscription",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/inscription",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5161,7 +5161,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5175,7 +5175,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/integrated-circuit",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/integrated-circuit",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5189,7 +5189,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/interest-rates",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/interest-rates",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5203,7 +5203,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5217,7 +5217,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/interoperability",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/interoperability",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5231,7 +5231,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5245,7 +5245,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/interplanetary-file-system-ipfs",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/interplanetary-file-system-ipfs",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5259,7 +5259,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/iou",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/iou",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5273,7 +5273,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5287,7 +5287,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5301,7 +5301,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5315,7 +5315,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/isolated-margin",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/isolated-margin",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5329,7 +5329,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/issuance",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/issuance",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5343,7 +5343,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5357,7 +5357,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5371,7 +5371,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/keccak",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/keccak",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5385,7 +5385,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5399,7 +5399,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/know-your-customer",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/know-your-customer",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5413,7 +5413,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5427,7 +5427,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5441,7 +5441,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5455,7 +5455,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5469,7 +5469,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/laspeyres-index",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/laspeyres-index",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5483,7 +5483,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/latency",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/latency",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5497,7 +5497,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5511,7 +5511,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5525,7 +5525,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/law-of-demand",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/law-of-demand",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5539,7 +5539,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5553,7 +5553,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/layer-2",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/layer-2",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5567,7 +5567,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/ledger",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/ledger",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5581,7 +5581,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5595,7 +5595,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5609,7 +5609,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/leveraged-tokens",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/leveraged-tokens",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5623,7 +5623,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/library",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/library",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5637,7 +5637,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5651,7 +5651,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5665,7 +5665,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/lightning-network",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/lightning-network",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5679,7 +5679,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/limit-order",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/limit-order",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5693,7 +5693,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5707,7 +5707,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/linux",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/linux",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5721,7 +5721,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/liquid-staking",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/liquid-staking",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5735,7 +5735,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/liquid-staking-token-lst",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/liquid-staking-token-lst",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5749,7 +5749,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5763,7 +5763,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/liquidity",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/liquidity",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5777,7 +5777,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/liquidity-crisis",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/liquidity-crisis",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5791,7 +5791,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5805,7 +5805,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/liquidity-provider",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/liquidity-provider",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5819,7 +5819,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/liquidity-ratios",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/liquidity-ratios",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5833,7 +5833,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5847,7 +5847,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/listing",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/listing",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5861,7 +5861,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/mainnet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/mainnet",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5875,7 +5875,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/mainnet-swap",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/mainnet-swap",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5889,7 +5889,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/maker",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/maker",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5903,7 +5903,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5917,7 +5917,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/malware",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/malware",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5931,7 +5931,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/margin-trading",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/margin-trading",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5945,7 +5945,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5959,7 +5959,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/market-capitalization",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/market-capitalization",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5973,7 +5973,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/market-momentum",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/market-momentum",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5987,7 +5987,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/market-order",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/market-order",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6001,7 +6001,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/masternode",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/masternode",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6015,7 +6015,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/matching-engine",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/matching-engine",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6029,7 +6029,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6043,7 +6043,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/maximum-supply",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/maximum-supply",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6057,7 +6057,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6071,7 +6071,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/mempool",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/mempool",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6085,7 +6085,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6099,7 +6099,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6113,7 +6113,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/merged-mining",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/merged-mining",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6127,7 +6127,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6141,7 +6141,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/merkle-tree",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/merkle-tree",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6155,7 +6155,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6169,7 +6169,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/metadata",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/metadata",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6183,7 +6183,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6197,7 +6197,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6211,7 +6211,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6225,7 +6225,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6239,7 +6239,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6253,7 +6253,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/metaverse",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/metaverse",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6267,7 +6267,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6281,7 +6281,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6295,7 +6295,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/microtransactions",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/microtransactions",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6309,7 +6309,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6323,7 +6323,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6337,7 +6337,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/mining",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/mining",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6351,7 +6351,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/mining-farm",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/mining-farm",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6365,7 +6365,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/mint",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/mint",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6379,7 +6379,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6393,7 +6393,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6407,7 +6407,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6421,7 +6421,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/monetary-policy",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/monetary-policy",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6435,7 +6435,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/money-markets",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/money-markets",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6449,7 +6449,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/monitoring-tag",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/monitoring-tag",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6463,7 +6463,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/moon",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/moon",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6477,7 +6477,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6491,7 +6491,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/moving-average-envelopes",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/moving-average-envelopes",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6505,7 +6505,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/moving-average-ribbon",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/moving-average-ribbon",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6519,7 +6519,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/mt-gox",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/mt-gox",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6533,7 +6533,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6547,7 +6547,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6561,7 +6561,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/multisignature",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/multisignature",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6575,7 +6575,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/nakamoto-consensus",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/nakamoto-consensus",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6589,7 +6589,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6603,7 +6603,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/net-asset-value-nav",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/net-asset-value-nav",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6617,7 +6617,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6631,7 +6631,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6645,7 +6645,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6659,7 +6659,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6673,7 +6673,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6687,7 +6687,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6701,7 +6701,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/nft-floor-prices",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/nft-floor-prices",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6715,7 +6715,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/nft-mystery-boxes",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/nft-mystery-boxes",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6729,7 +6729,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/ngmi",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/ngmi",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6743,7 +6743,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6757,7 +6757,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/node",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/node",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6771,7 +6771,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6785,7 +6785,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/non-fungible-token-nft",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/non-fungible-token-nft",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6799,7 +6799,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/nonce",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/nonce",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6813,7 +6813,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/oco-order",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/oco-order",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6827,7 +6827,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/off-chain",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/off-chain",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6841,7 +6841,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6855,7 +6855,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/offline-signing-orchestrator-oso",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/offline-signing-orchestrator-oso",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6869,7 +6869,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/offshore-account",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/offshore-account",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6883,7 +6883,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6897,7 +6897,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/on-chain",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/on-chain",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6911,7 +6911,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6925,7 +6925,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6939,7 +6939,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/opbnb",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/opbnb",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6953,7 +6953,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/open-source-software-oss",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/open-source-software-oss",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6967,7 +6967,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6981,7 +6981,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6995,7 +6995,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/opportunity-cost",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/opportunity-cost",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7009,7 +7009,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7023,7 +7023,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7037,7 +7037,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/oracle",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/oracle",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7051,7 +7051,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/orc-20-tokens",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/orc-20-tokens",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7065,7 +7065,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/order-book",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/order-book",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7079,7 +7079,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/ordinals",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/ordinals",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7093,7 +7093,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/orphan-block",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/orphan-block",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7107,7 +7107,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7121,7 +7121,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7135,7 +7135,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/pancakeswap",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/pancakeswap",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7149,7 +7149,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/paper-wallet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/paper-wallet",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7163,7 +7163,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/parallelization",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/parallelization",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7177,7 +7177,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7191,7 +7191,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7205,7 +7205,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/passive-management",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/passive-management",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7219,7 +7219,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7233,7 +7233,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7247,7 +7247,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7261,7 +7261,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7275,7 +7275,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/peer-to-peer",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/peer-to-peer",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7289,7 +7289,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/pegged-currency",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/pegged-currency",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7303,7 +7303,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7317,7 +7317,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/permissionless-blockchain",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/permissionless-blockchain",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7331,7 +7331,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/phishing",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/phishing",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7345,7 +7345,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7359,7 +7359,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/plasma",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/plasma",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7373,7 +7373,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7387,7 +7387,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/polkadot-crowdloan",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/polkadot-crowdloan",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7401,7 +7401,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7415,7 +7415,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/ponzi-scheme",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/ponzi-scheme",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7429,7 +7429,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7443,7 +7443,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7457,7 +7457,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/premining",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/premining",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7471,7 +7471,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/price-action",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/price-action",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7485,7 +7485,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/prisoners-dilemma",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/prisoners-dilemma",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7499,7 +7499,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7513,7 +7513,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7527,7 +7527,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/private-key",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/private-key",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7541,7 +7541,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/private-sale",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/private-sale",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7555,7 +7555,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/progressive-web-application",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/progressive-web-application",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7569,7 +7569,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/proof-of-attendance-protocol-poap",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/proof-of-attendance-protocol-poap",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7583,7 +7583,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/proof-of-reserves-por",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/proof-of-reserves-por",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7597,7 +7597,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/proof-of-stake",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/proof-of-stake",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7611,7 +7611,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/proof-of-staked-authority-posa",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/proof-of-staked-authority-posa",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7625,7 +7625,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/proof-of-work",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/proof-of-work",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7639,7 +7639,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/proposer-builder-separation-pbs",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/proposer-builder-separation-pbs",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7653,7 +7653,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/proto-danksharding",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/proto-danksharding",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7667,7 +7667,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7681,7 +7681,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/pseudorandom",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/pseudorandom",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7695,7 +7695,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7709,7 +7709,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7723,7 +7723,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/public-key",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/public-key",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7737,7 +7737,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7751,7 +7751,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/pump-and-dump",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/pump-and-dump",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7765,7 +7765,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7779,7 +7779,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/quantitative-easing-qe",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/quantitative-easing-qe",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7793,7 +7793,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/quantitative-tightening-qt",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/quantitative-tightening-qt",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7807,7 +7807,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/quantum-computing",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/quantum-computing",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7821,7 +7821,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7835,7 +7835,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/race-attack",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/race-attack",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7849,7 +7849,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/ransomware",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/ransomware",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7863,7 +7863,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7877,7 +7877,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/real-world-assets-rwas",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/real-world-assets-rwas",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7891,7 +7891,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/recession",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/recession",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7905,7 +7905,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/recursive-inscription",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/recursive-inscription",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7919,7 +7919,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/rekt",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/rekt",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7933,7 +7933,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/relative-strength-index",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/relative-strength-index",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7947,7 +7947,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7961,7 +7961,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7975,7 +7975,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/resistance",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/resistance",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7989,7 +7989,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/return-on-investment",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/return-on-investment",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8003,7 +8003,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/revenge-trading",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/revenge-trading",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8017,7 +8017,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8031,7 +8031,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/risk-premium",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/risk-premium",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8045,7 +8045,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/roadmap",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/roadmap",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8059,7 +8059,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8073,7 +8073,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8087,7 +8087,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8101,7 +8101,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/routing-attack",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/routing-attack",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8115,7 +8115,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8129,7 +8129,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/rug-pull",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/rug-pull",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8143,7 +8143,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8157,7 +8157,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/sahm-rule",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/sahm-rule",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8171,7 +8171,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8185,7 +8185,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8199,7 +8199,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/sandwich-trading",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/sandwich-trading",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8213,7 +8213,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8227,7 +8227,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/satoshi",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/satoshi",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8241,7 +8241,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/satoshi-nakamoto",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/satoshi-nakamoto",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8255,7 +8255,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8269,7 +8269,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8283,7 +8283,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8297,7 +8297,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8311,7 +8311,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8325,7 +8325,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8339,7 +8339,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8353,7 +8353,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/secure-asset-fund-for-users",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/secure-asset-fund-for-users",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8367,7 +8367,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/securities-and-exchange-commission",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/securities-and-exchange-commission",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8381,7 +8381,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/security-audit",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/security-audit",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8395,7 +8395,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8409,7 +8409,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8423,7 +8423,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/security-token-offering-sto",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/security-token-offering-sto",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8437,7 +8437,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/seed-phrase",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/seed-phrase",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8451,7 +8451,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/seed-tag",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/seed-tag",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8465,7 +8465,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/segregated-witness",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/segregated-witness",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8479,7 +8479,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8493,7 +8493,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8507,7 +8507,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/selfish-mining",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/selfish-mining",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8521,7 +8521,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/sell-wall",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/sell-wall",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8535,7 +8535,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/sentiment",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/sentiment",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8549,7 +8549,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8563,7 +8563,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8577,7 +8577,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8591,7 +8591,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8605,7 +8605,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/sharding",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/sharding",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8619,7 +8619,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/sharpe-ratio",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/sharpe-ratio",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8633,7 +8633,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8647,7 +8647,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8661,7 +8661,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/sidechains",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/sidechains",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8675,7 +8675,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/simple-moving-average-sma",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/simple-moving-average-sma",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8689,7 +8689,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/slashing",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/slashing",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8703,7 +8703,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8717,7 +8717,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/slippage",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/slippage",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8731,7 +8731,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8745,7 +8745,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/smart-contract",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/smart-contract",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8759,7 +8759,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/smart-contract-wallet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/smart-contract-wallet",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8773,7 +8773,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/snapshot",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/snapshot",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8787,7 +8787,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/social-recovery-wallet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/social-recovery-wallet",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8801,7 +8801,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/social-trading",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/social-trading",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8815,7 +8815,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/socialfi",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/socialfi",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8829,7 +8829,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8843,7 +8843,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/soft-landing",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/soft-landing",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8857,7 +8857,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/solidity",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/solidity",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8871,7 +8871,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/source-code",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/source-code",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8885,7 +8885,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/spl",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/spl",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8899,7 +8899,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/src-20-tokens",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/src-20-tokens",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8913,7 +8913,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/stablecoin",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/stablecoin",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8927,7 +8927,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/stagflation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/stagflation",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8941,7 +8941,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8955,7 +8955,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8969,7 +8969,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/staking-pool",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/staking-pool",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8983,7 +8983,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8997,7 +8997,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/state-channel",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/state-channel",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9011,7 +9011,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9025,7 +9025,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/steth",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/steth",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9039,7 +9039,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9053,7 +9053,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/stock-variable",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/stock-variable",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9067,7 +9067,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/store-of-value",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/store-of-value",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9081,7 +9081,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9095,7 +9095,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/supercomputer",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/supercomputer",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9109,7 +9109,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/supply-chain",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/supply-chain",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9123,7 +9123,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/support",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/support",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9137,7 +9137,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9151,7 +9151,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/sybil-attack",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/sybil-attack",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9165,7 +9165,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9179,7 +9179,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/taker",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/taker",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9193,7 +9193,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/tank",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/tank",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9207,7 +9207,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9221,7 +9221,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9235,7 +9235,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/testnet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/testnet",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9249,7 +9249,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9263,7 +9263,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9277,7 +9277,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9291,7 +9291,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/ticker",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/ticker",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9305,7 +9305,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/ticker-symbol",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/ticker-symbol",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9319,7 +9319,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/token",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/token",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9333,7 +9333,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/token-generation-event-tge",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/token-generation-event-tge",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9347,7 +9347,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/token-lockup",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/token-lockup",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9361,7 +9361,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/token-merge",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/token-merge",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9375,7 +9375,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/token-sale",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/token-sale",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9389,7 +9389,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9403,7 +9403,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/token-standards",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/token-standards",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9417,7 +9417,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/tokenization",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/tokenization",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9431,7 +9431,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/tokenomics",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/tokenomics",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9445,7 +9445,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/total-supply",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/total-supply",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9459,7 +9459,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/total-value-locked-tvl",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/total-value-locked-tvl",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9473,7 +9473,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/tradfi",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/tradfi",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9487,7 +9487,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9501,7 +9501,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9515,7 +9515,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9529,7 +9529,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/transaction-id",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/transaction-id",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9543,7 +9543,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9557,7 +9557,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/transactions-per-second-tps",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/transactions-per-second-tps",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9571,7 +9571,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9585,7 +9585,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/treasury-bills-t-bills",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/treasury-bills-t-bills",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9599,7 +9599,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9613,7 +9613,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/trueusd-tusd",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/trueusd-tusd",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9627,7 +9627,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9641,7 +9641,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/trustless",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/trustless",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9655,7 +9655,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/turing-complete",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/turing-complete",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9669,7 +9669,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9683,7 +9683,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9697,7 +9697,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9711,7 +9711,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/understanding-cz-s-number-4",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/understanding-cz-s-number-4",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9725,7 +9725,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9739,7 +9739,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9753,7 +9753,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/unit-of-account",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/unit-of-account",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9767,7 +9767,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9781,7 +9781,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/unspent-transaction-output-utxo",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/unspent-transaction-output-utxo",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9795,7 +9795,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9809,7 +9809,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9823,7 +9823,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9837,7 +9837,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9851,7 +9851,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/user-interface",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/user-interface",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9865,7 +9865,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/utility-token",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/utility-token",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9879,7 +9879,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9893,7 +9893,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9907,7 +9907,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9921,7 +9921,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/verification-code",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/verification-code",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9935,7 +9935,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9949,7 +9949,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9963,7 +9963,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/virtual-machine",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/virtual-machine",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9977,7 +9977,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/vladimir-club",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/vladimir-club",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9991,7 +9991,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/volatility",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/volatility",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10005,7 +10005,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/volume",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/volume",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10019,7 +10019,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/wagmi",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/wagmi",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10033,7 +10033,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/wallet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/wallet",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10047,7 +10047,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10061,7 +10061,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10075,7 +10075,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/wash-trading",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/wash-trading",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10089,7 +10089,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/weak-hands",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/weak-hands",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10103,7 +10103,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/weak-subjectivity",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/weak-subjectivity",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10117,7 +10117,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/web-1",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/web-1",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10131,7 +10131,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10145,7 +10145,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10159,7 +10159,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10173,7 +10173,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10187,7 +10187,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10201,7 +10201,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/wei",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/wei",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10215,7 +10215,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/weighted-moving-average-wma",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/weighted-moving-average-wma",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10229,7 +10229,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/whale",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/whale",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10243,7 +10243,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/whiskers",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/whiskers",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10257,7 +10257,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/whitelist",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/whitelist",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10271,7 +10271,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10285,7 +10285,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/wick",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/wick",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10299,7 +10299,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/win-rate",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/win-rate",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10313,7 +10313,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/wrapped-ether",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/wrapped-ether",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10327,7 +10327,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10341,7 +10341,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/wyckoff",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/wyckoff",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10355,7 +10355,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10369,7 +10369,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10383,7 +10383,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10397,7 +10397,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10411,7 +10411,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/yield-farming",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/yield-farming",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10425,7 +10425,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10439,7 +10439,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10453,7 +10453,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/zero-knowledge-proofs",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/zero-knowledge-proofs",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10467,7 +10467,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10481,7 +10481,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/zk-rollup",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/zk-rollup",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10495,7 +10495,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/zk-snarks",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/zk-snarks",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10509,7 +10509,7 @@
       "definitionSource": "https://academy.binance.com/id/glossary/zk-starks",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/id/glossary/zk-starks",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""

--- a/locales/id-ID/id-ID.json
+++ b/locales/id-ID/id-ID.json
@@ -9576,7 +9576,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "treasury-bills-t-bills": {
+    "treasury-bills": {
       "term": "Surat Perbendaharaan Negara (SPN)",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/it-IT/it-IT.json
+++ b/locales/it-IT/it-IT.json
@@ -9562,7 +9562,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "treasury-bills-t-bills": {
+    "treasury-bills": {
       "term": "Buoni del tesoro (T-Bill)",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/it-IT/it-IT.json
+++ b/locales/it-IT/it-IT.json
@@ -9,7 +9,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -23,7 +23,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -37,7 +37,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -51,7 +51,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -65,7 +65,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -79,7 +79,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -93,7 +93,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -107,7 +107,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/absolute-advantage",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/absolute-advantage",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -121,7 +121,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -135,7 +135,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -149,7 +149,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/active-management",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/active-management",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -163,7 +163,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/actively-validated-services-avs",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/actively-validated-services-avs",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -177,7 +177,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/ad-hoc",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/ad-hoc",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -191,7 +191,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/address",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/address",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -205,7 +205,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -219,7 +219,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -233,7 +233,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -247,7 +247,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/airdrop",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/airdrop",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -261,7 +261,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -275,7 +275,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -289,7 +289,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/algorithm",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/algorithm",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -303,7 +303,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/all-or-none-order",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/all-or-none-order",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -317,7 +317,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/all-time-high",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/all-time-high",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -331,7 +331,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/allocation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/allocation",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -345,7 +345,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/alpha",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/alpha",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -359,7 +359,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/altcoin",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/altcoin",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -373,7 +373,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -387,7 +387,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/angel-investor",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/angel-investor",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -401,7 +401,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/anti-money-laundering",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/anti-money-laundering",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -415,7 +415,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -429,7 +429,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -443,7 +443,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -457,7 +457,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/application-programming-interface",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/application-programming-interface",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -471,7 +471,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/application-specific-integrated-circuit",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/application-specific-integrated-circuit",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -485,7 +485,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/arbitrage",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/arbitrage",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -499,7 +499,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -513,7 +513,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/arc-20",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/arc-20",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -527,7 +527,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/artificial-intelligence-ai",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/artificial-intelligence-ai",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -541,7 +541,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -555,7 +555,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/asic-resistant",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/asic-resistant",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -569,7 +569,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/asking-price",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/asking-price",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -583,7 +583,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/asset-management",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/asset-management",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -597,7 +597,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -611,7 +611,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/assets-under-management-aum",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/assets-under-management-aum",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -625,7 +625,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/asynchronous",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/asynchronous",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -639,7 +639,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/atomic-swap",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/atomic-swap",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -653,7 +653,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/attack-surface",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/attack-surface",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -667,7 +667,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -681,7 +681,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/auction",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/auction",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -695,7 +695,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -709,7 +709,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/automated-market-maker-amm",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/automated-market-maker-amm",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -723,7 +723,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -737,7 +737,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -751,7 +751,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -765,7 +765,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/b-tokens",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/b-tokens",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -779,7 +779,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/bags",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/bags",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -793,7 +793,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -807,7 +807,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/beacon-chain",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/beacon-chain",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -821,7 +821,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/bear-market",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/bear-market",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -835,7 +835,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/benchmark",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/benchmark",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -849,7 +849,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/bep-1155",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/bep-1155",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -863,7 +863,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/bep-20",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/bep-20",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -877,7 +877,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/bep-721",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/bep-721",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -891,7 +891,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/bep-95",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/bep-95",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -905,7 +905,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -919,7 +919,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/beta-coefficient",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/beta-coefficient",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -933,7 +933,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/beta-release",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/beta-release",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -947,7 +947,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/bid-ask-spread",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/bid-ask-spread",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -961,7 +961,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/bid-price",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/bid-price",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -975,7 +975,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -989,7 +989,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/binance-blockchain-charity-foundation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/binance-blockchain-charity-foundation",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1003,7 +1003,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/binance-ecosystem-fund",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/binance-ecosystem-fund",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1017,7 +1017,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/binancian",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/binancian",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1031,7 +1031,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/bitcoin",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/bitcoin",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1045,7 +1045,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/bitcoin-core",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/bitcoin-core",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1059,7 +1059,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/bitcoin-dominance",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/bitcoin-dominance",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1073,7 +1073,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/bitcoin-maximalists",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/bitcoin-maximalists",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1087,7 +1087,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/bitcoin-pizza",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/bitcoin-pizza",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1101,7 +1101,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/black-swan-event",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/black-swan-event",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1115,7 +1115,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/block",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/block",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1129,7 +1129,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/block-explorer",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/block-explorer",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1143,7 +1143,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/block-header",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/block-header",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1157,7 +1157,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/block-height",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/block-height",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1171,7 +1171,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/block-reward",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/block-reward",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1185,7 +1185,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1199,7 +1199,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1213,7 +1213,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/blockchain",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/blockchain",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1227,7 +1227,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1241,7 +1241,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1255,7 +1255,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/bloom-filter",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/bloom-filter",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1269,7 +1269,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/blue-chip-token",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/blue-chip-token",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1283,7 +1283,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/bnb",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/bnb",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1297,7 +1297,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1311,7 +1311,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/bnsol",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/bnsol",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1325,7 +1325,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/bollinger-bands",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/bollinger-bands",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1339,7 +1339,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/bond",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/bond",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1353,7 +1353,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/bounty",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/bounty",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1367,7 +1367,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1381,7 +1381,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1395,7 +1395,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/brc-20-tokens",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/brc-20-tokens",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1409,7 +1409,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/break-even-point",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/break-even-point",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1423,7 +1423,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/breakeven-multiple",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/breakeven-multiple",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1437,7 +1437,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/breakout",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/breakout",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1451,7 +1451,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1465,7 +1465,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/bscscan",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/bscscan",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1479,7 +1479,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1493,7 +1493,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/btc-wallet-address",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/btc-wallet-address",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1507,7 +1507,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/buidl",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/buidl",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1521,7 +1521,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/bull-market",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/bull-market",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1535,7 +1535,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/burner-wallet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/burner-wallet",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1549,7 +1549,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/buy-wall",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/buy-wall",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1563,7 +1563,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1577,7 +1577,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1591,7 +1591,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1605,7 +1605,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/candidate-block",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/candidate-block",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1619,7 +1619,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/candlestick",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/candlestick",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1633,7 +1633,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/capitulation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/capitulation",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1647,7 +1647,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1661,7 +1661,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/censorship-resistance",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/censorship-resistance",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1675,7 +1675,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/central-bank",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/central-bank",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1689,7 +1689,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/central-bank-digital-currency-cbdc",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/central-bank-digital-currency-cbdc",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1703,7 +1703,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/central-processing-unit",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/central-processing-unit",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1717,7 +1717,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/centralized",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/centralized",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1731,7 +1731,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/centralized-exchange",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/centralized-exchange",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1745,7 +1745,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1759,7 +1759,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1773,7 +1773,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/chatgpt",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/chatgpt",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1787,7 +1787,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1801,7 +1801,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/cipher",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/cipher",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1815,7 +1815,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/circulating-supply",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/circulating-supply",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1829,7 +1829,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1843,7 +1843,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/cloud",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/cloud",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1857,7 +1857,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1871,7 +1871,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/coin",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/coin",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1885,7 +1885,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1899,7 +1899,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1913,7 +1913,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/cold-storage",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/cold-storage",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1927,7 +1927,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1941,7 +1941,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/collateral",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/collateral",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1955,7 +1955,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/colocation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/colocation",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1969,7 +1969,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/commodity-futures-trading-commission",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/commodity-futures-trading-commission",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1983,7 +1983,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1997,7 +1997,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2011,7 +2011,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/compound-interest",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/compound-interest",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2025,7 +2025,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2039,7 +2039,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/confirmation-time",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/confirmation-time",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2053,7 +2053,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/confluence",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/confluence",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2067,7 +2067,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2081,7 +2081,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/consensus-algorithm",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/consensus-algorithm",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2095,7 +2095,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2109,7 +2109,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2123,7 +2123,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2137,7 +2137,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2151,7 +2151,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2165,7 +2165,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/consumer-price-index-(cpi)",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/consumer-price-index-(cpi)",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2179,7 +2179,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/contango-and-backwardation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/contango-and-backwardation",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2193,7 +2193,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2207,7 +2207,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2221,7 +2221,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2235,7 +2235,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/copy-trading",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/copy-trading",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2249,7 +2249,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/counterparty-risk",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/counterparty-risk",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2263,7 +2263,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/credentials",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/credentials",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2277,7 +2277,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/cross-chain-bridges",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/cross-chain-bridges",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2291,7 +2291,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2305,7 +2305,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2319,7 +2319,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2333,7 +2333,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2347,7 +2347,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/crypto-etfs",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/crypto-etfs",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2361,7 +2361,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/crypto-fear-and-greed-index",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/crypto-fear-and-greed-index",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2375,7 +2375,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2389,7 +2389,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/crypto-protocol",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/crypto-protocol",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2403,7 +2403,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2417,7 +2417,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/crypto-winter",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/crypto-winter",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2431,7 +2431,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2445,7 +2445,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/cryptocurrency",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/cryptocurrency",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2459,7 +2459,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2473,7 +2473,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/cryptography",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/cryptography",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2487,7 +2487,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2501,7 +2501,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/custody",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/custody",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2515,7 +2515,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2529,7 +2529,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/daemon",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/daemon",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2543,7 +2543,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2557,7 +2557,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/danksharding",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/danksharding",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2571,7 +2571,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2585,7 +2585,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2599,7 +2599,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2613,7 +2613,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/dead-cat-bounce",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/dead-cat-bounce",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2627,7 +2627,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/death-cross",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/death-cross",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2641,7 +2641,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2655,7 +2655,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/decentralized-application",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/decentralized-application",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2669,7 +2669,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/decentralized-autonomous-cooperative",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/decentralized-autonomous-cooperative",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2683,7 +2683,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/decentralized-autonomous-organization",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/decentralized-autonomous-organization",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2697,7 +2697,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/decentralized-exchange",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/decentralized-exchange",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2711,7 +2711,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2725,7 +2725,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/decentralized-indexes",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/decentralized-indexes",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2739,7 +2739,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2753,7 +2753,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/decryption",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/decryption",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2767,7 +2767,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/deep-web",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/deep-web",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2781,7 +2781,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2795,7 +2795,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2809,7 +2809,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/delisting",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/delisting",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2823,7 +2823,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2837,7 +2837,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/depeg",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/depeg",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2851,7 +2851,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2865,7 +2865,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/depression",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/depression",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2879,7 +2879,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2893,7 +2893,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/design-flaw-attack",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/design-flaw-attack",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2907,7 +2907,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2921,7 +2921,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2935,7 +2935,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2949,7 +2949,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2963,7 +2963,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/diamond-hands",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/diamond-hands",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2977,7 +2977,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/difficulty",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/difficulty",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2991,7 +2991,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/difficulty-bomb",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/difficulty-bomb",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3005,7 +3005,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3019,7 +3019,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3033,7 +3033,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/digital-signature",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/digital-signature",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3047,7 +3047,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3061,7 +3061,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/direct-market-access-dma",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/direct-market-access-dma",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3075,7 +3075,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3089,7 +3089,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/divergence",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/divergence",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3103,7 +3103,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/diversification",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/diversification",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3117,7 +3117,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3131,7 +3131,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/do-your-own-research",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/do-your-own-research",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3145,7 +3145,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/dollar-cost-averaging",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/dollar-cost-averaging",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3159,7 +3159,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/dot-plot",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/dot-plot",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3173,7 +3173,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3187,7 +3187,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/double-spending",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/double-spending",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3201,7 +3201,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/eclipse-attack",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/eclipse-attack",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3215,7 +3215,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3229,7 +3229,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3243,7 +3243,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/efficient-market-hypothesis-emh",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/efficient-market-hypothesis-emh",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3257,7 +3257,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/eigenlayer",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/eigenlayer",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3271,7 +3271,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/eip",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/eip",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3285,7 +3285,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3299,7 +3299,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/eip-3074",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/eip-3074",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3313,7 +3313,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/eip-4844",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/eip-4844",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3327,7 +3327,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/eip-7251",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/eip-7251",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3341,7 +3341,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/eip-7702",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/eip-7702",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3355,7 +3355,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/elasticity",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/elasticity",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3369,7 +3369,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3383,7 +3383,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/encryption",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/encryption",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3397,7 +3397,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/endogenous-variable",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/endogenous-variable",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3411,7 +3411,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3425,7 +3425,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3439,7 +3439,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3453,7 +3453,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3467,7 +3467,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/erc-1155",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/erc-1155",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3481,7 +3481,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/erc-20",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/erc-20",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3495,7 +3495,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/erc-404",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/erc-404",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3509,7 +3509,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/erc-721",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/erc-721",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3523,7 +3523,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/etf",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/etf",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3537,7 +3537,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3551,7 +3551,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3565,7 +3565,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3579,7 +3579,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3593,7 +3593,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/ethereum-classic",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/ethereum-classic",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3607,7 +3607,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/ethereum-foundation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/ethereum-foundation",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3621,7 +3621,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3635,7 +3635,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3649,7 +3649,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3663,7 +3663,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3677,7 +3677,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/ethereum-virtual-machine-evm",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/ethereum-virtual-machine-evm",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3691,7 +3691,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3705,7 +3705,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3719,7 +3719,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3733,7 +3733,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/exchange",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/exchange",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3747,7 +3747,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3761,7 +3761,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3775,7 +3775,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/exogenous-variable",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/exogenous-variable",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3789,7 +3789,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/exponential-moving-average-ema",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/exponential-moving-average-ema",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3803,7 +3803,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/externally-owned-account-eoa",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/externally-owned-account-eoa",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3817,7 +3817,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/fakeout",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/fakeout",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3831,7 +3831,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/falling-knife",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/falling-knife",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3845,7 +3845,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/fan-tokens",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/fan-tokens",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3859,7 +3859,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3873,7 +3873,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3887,7 +3887,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3901,7 +3901,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/fear-of-missing-out",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/fear-of-missing-out",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3915,7 +3915,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/fear-uncertainty-and-doubt",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/fear-uncertainty-and-doubt",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3929,7 +3929,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/fiat",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/fiat",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3943,7 +3943,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3957,7 +3957,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/fibonacci-retracement",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/fibonacci-retracement",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3971,7 +3971,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/fill-or-kill-order",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/fill-or-kill-order",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3985,7 +3985,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/finality",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/finality",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3999,7 +3999,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4013,7 +4013,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4027,7 +4027,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4041,7 +4041,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4055,7 +4055,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4069,7 +4069,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4083,7 +4083,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/first-mover-advantage",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/first-mover-advantage",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4097,7 +4097,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/fiscal-policy",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/fiscal-policy",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4111,7 +4111,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/flappening",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/flappening",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4125,7 +4125,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/flashbots",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/flashbots",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4139,7 +4139,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/flippening",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/flippening",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4153,7 +4153,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/flow-variable",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/flow-variable",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4167,7 +4167,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/forced-liquidation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/forced-liquidation",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4181,7 +4181,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/forex-fx",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/forex-fx",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4195,7 +4195,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/fork",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/fork",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4209,7 +4209,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/formal-verification",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/formal-verification",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4223,7 +4223,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4237,7 +4237,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/fraud-proof",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/fraud-proof",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4251,7 +4251,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/fren",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/fren",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4265,7 +4265,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4279,7 +4279,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/full-node",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/full-node",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4293,7 +4293,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/fully-diluted-valuation-fdv",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/fully-diluted-valuation-fdv",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4307,7 +4307,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/fundamental-analysis",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/fundamental-analysis",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4321,7 +4321,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/funding-fees",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/funding-fees",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4335,7 +4335,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/fungibility",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/fungibility",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4349,7 +4349,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/futures-contract",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/futures-contract",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4363,7 +4363,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/gamefi",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/gamefi",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4377,7 +4377,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4391,7 +4391,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/gas",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/gas",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4405,7 +4405,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4419,7 +4419,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/gas-limit",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/gas-limit",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4433,7 +4433,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4447,7 +4447,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4461,7 +4461,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4475,7 +4475,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/gdp-deflator",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/gdp-deflator",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4489,7 +4489,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/general-public-license",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/general-public-license",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4503,7 +4503,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/genesis-block",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/genesis-block",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4517,7 +4517,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4531,7 +4531,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/github",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/github",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4545,7 +4545,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/gm-good-morning",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/gm-good-morning",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4559,7 +4559,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4573,7 +4573,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/golden-cross",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/golden-cross",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4587,7 +4587,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/golden-ratio",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/golden-ratio",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4601,7 +4601,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/goldilocks",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/goldilocks",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4615,7 +4615,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/gossip-protocol",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/gossip-protocol",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4629,7 +4629,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4643,7 +4643,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/gross-domestic-product-gdp",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/gross-domestic-product-gdp",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4657,7 +4657,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4671,7 +4671,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/gwei",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/gwei",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4685,7 +4685,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/hackathon",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/hackathon",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4699,7 +4699,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/hacker",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/hacker",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4713,7 +4713,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/haha-money-printer-go-brrrrr",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/haha-money-printer-go-brrrrr",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4727,7 +4727,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/halving",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/halving",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4741,7 +4741,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/hard-cap",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/hard-cap",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4755,7 +4755,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4769,7 +4769,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/hard-landing",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/hard-landing",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4783,7 +4783,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4797,7 +4797,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4811,7 +4811,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/hash",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/hash",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4825,7 +4825,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/hash-rate",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/hash-rate",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4839,7 +4839,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/hashed-timelock-contract",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/hashed-timelock-contract",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4853,7 +4853,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4867,7 +4867,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/herd-instinct",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/herd-instinct",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4881,7 +4881,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4895,7 +4895,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/high-frequency-trading-hft",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/high-frequency-trading-hft",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4909,7 +4909,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/hodl",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/hodl",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4923,7 +4923,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/honeypot",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/honeypot",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4937,7 +4937,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4951,7 +4951,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4965,7 +4965,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4979,7 +4979,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4993,7 +4993,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5007,7 +5007,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/iceberg-order",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/iceberg-order",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5021,7 +5021,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5035,7 +5035,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5049,7 +5049,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/immutability",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/immutability",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5063,7 +5063,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/index-funds",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/index-funds",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5077,7 +5077,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5091,7 +5091,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/initial-coin-offering",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/initial-coin-offering",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5105,7 +5105,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/initial-dex-offering-ido",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/initial-dex-offering-ido",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5119,7 +5119,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/initial-exchange-offering",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/initial-exchange-offering",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5133,7 +5133,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/initial-public-offering",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/initial-public-offering",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5147,7 +5147,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/inscription",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/inscription",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5161,7 +5161,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5175,7 +5175,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/integrated-circuit",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/integrated-circuit",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5189,7 +5189,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/interest-rates",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/interest-rates",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5203,7 +5203,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5217,7 +5217,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/interoperability",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/interoperability",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5231,7 +5231,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5245,7 +5245,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/interplanetary-file-system-ipfs",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/interplanetary-file-system-ipfs",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5259,7 +5259,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/iou",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/iou",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5273,7 +5273,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5287,7 +5287,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5301,7 +5301,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5315,7 +5315,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/isolated-margin",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/isolated-margin",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5329,7 +5329,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/issuance",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/issuance",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5343,7 +5343,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5357,7 +5357,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5371,7 +5371,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/keccak",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/keccak",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5385,7 +5385,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5399,7 +5399,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/know-your-customer",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/know-your-customer",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5413,7 +5413,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5427,7 +5427,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5441,7 +5441,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5455,7 +5455,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5469,7 +5469,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/laspeyres-index",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/laspeyres-index",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5483,7 +5483,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/latency",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/latency",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5497,7 +5497,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5511,7 +5511,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5525,7 +5525,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/law-of-demand",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/law-of-demand",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5539,7 +5539,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5553,7 +5553,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/layer-2",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/layer-2",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5567,7 +5567,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/ledger",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/ledger",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5581,7 +5581,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5595,7 +5595,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5609,7 +5609,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/leveraged-tokens",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/leveraged-tokens",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5623,7 +5623,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/library",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/library",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5637,7 +5637,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5651,7 +5651,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5665,7 +5665,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/lightning-network",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/lightning-network",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5679,7 +5679,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/limit-order",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/limit-order",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5693,7 +5693,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5707,7 +5707,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/linux",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/linux",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5721,7 +5721,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/liquid-staking",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/liquid-staking",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5735,7 +5735,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/liquid-staking-token-lst",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/liquid-staking-token-lst",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5749,7 +5749,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5763,7 +5763,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/liquidity",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/liquidity",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5777,7 +5777,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/liquidity-crisis",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/liquidity-crisis",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5791,7 +5791,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5805,7 +5805,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/liquidity-provider",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/liquidity-provider",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5819,7 +5819,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/liquidity-ratios",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/liquidity-ratios",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5833,7 +5833,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5847,7 +5847,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/listing",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/listing",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5861,7 +5861,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/mainnet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/mainnet",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5875,7 +5875,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/mainnet-swap",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/mainnet-swap",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5889,7 +5889,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/maker",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/maker",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5903,7 +5903,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5917,7 +5917,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/malware",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/malware",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5931,7 +5931,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/margin-trading",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/margin-trading",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5945,7 +5945,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5959,7 +5959,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/market-capitalization",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/market-capitalization",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5973,7 +5973,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/market-momentum",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/market-momentum",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5987,7 +5987,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/market-order",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/market-order",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6001,7 +6001,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/masternode",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/masternode",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6015,7 +6015,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/matching-engine",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/matching-engine",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6029,7 +6029,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6043,7 +6043,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/maximum-supply",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/maximum-supply",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6057,7 +6057,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6071,7 +6071,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/mempool",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/mempool",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6085,7 +6085,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6099,7 +6099,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6113,7 +6113,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/merged-mining",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/merged-mining",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6127,7 +6127,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6141,7 +6141,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/merkle-tree",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/merkle-tree",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6155,7 +6155,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6169,7 +6169,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/metadata",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/metadata",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6183,7 +6183,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6197,7 +6197,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6211,7 +6211,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6225,7 +6225,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6239,7 +6239,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6253,7 +6253,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/metaverse",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/metaverse",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6267,7 +6267,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6281,7 +6281,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6295,7 +6295,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/microtransactions",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/microtransactions",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6309,7 +6309,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6323,7 +6323,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6337,7 +6337,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/mining",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/mining",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6351,7 +6351,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/mining-farm",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/mining-farm",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6365,7 +6365,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/mint",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/mint",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6379,7 +6379,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6393,7 +6393,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6407,7 +6407,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6421,7 +6421,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/monetary-policy",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/monetary-policy",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6435,7 +6435,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/monitoring-tag",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/monitoring-tag",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6449,7 +6449,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/moon",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/moon",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6463,7 +6463,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6477,7 +6477,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/moving-average-envelopes",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/moving-average-envelopes",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6491,7 +6491,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/moving-average-ribbon",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/moving-average-ribbon",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6505,7 +6505,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/mt-gox",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/mt-gox",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6519,7 +6519,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6533,7 +6533,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6547,7 +6547,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/multisignature",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/multisignature",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6561,7 +6561,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/nakamoto-consensus",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/nakamoto-consensus",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6575,7 +6575,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6589,7 +6589,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/net-asset-value-nav",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/net-asset-value-nav",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6603,7 +6603,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6617,7 +6617,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6631,7 +6631,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6645,7 +6645,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6659,7 +6659,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6673,7 +6673,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6687,7 +6687,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/nft-floor-prices",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/nft-floor-prices",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6701,7 +6701,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/nft-mystery-boxes",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/nft-mystery-boxes",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6715,7 +6715,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/ngmi",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/ngmi",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6729,7 +6729,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6743,7 +6743,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/node",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/node",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6757,7 +6757,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6771,7 +6771,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/non-fungible-token-nft",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/non-fungible-token-nft",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6785,7 +6785,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/nonce",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/nonce",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6799,7 +6799,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/oco-order",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/oco-order",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6813,7 +6813,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/off-chain",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/off-chain",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6827,7 +6827,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6841,7 +6841,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/offline-signing-orchestrator-oso",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/offline-signing-orchestrator-oso",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6855,7 +6855,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/offshore-account",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/offshore-account",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6869,7 +6869,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6883,7 +6883,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/on-chain",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/on-chain",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6897,7 +6897,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6911,7 +6911,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6925,7 +6925,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/opbnb",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/opbnb",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6939,7 +6939,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/open-source-software-oss",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/open-source-software-oss",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6953,7 +6953,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6967,7 +6967,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6981,7 +6981,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/opportunity-cost",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/opportunity-cost",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6995,7 +6995,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7009,7 +7009,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7023,7 +7023,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/oracle",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/oracle",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7037,7 +7037,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/orc-20-tokens",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/orc-20-tokens",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7051,7 +7051,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/order-book",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/order-book",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7065,7 +7065,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/ordinals",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/ordinals",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7079,7 +7079,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/orphan-block",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/orphan-block",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7093,7 +7093,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7107,7 +7107,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7121,7 +7121,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/pancakeswap",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/pancakeswap",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7135,7 +7135,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/paper-wallet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/paper-wallet",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7149,7 +7149,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/parallelization",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/parallelization",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7163,7 +7163,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7177,7 +7177,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7191,7 +7191,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/passive-management",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/passive-management",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7205,7 +7205,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7219,7 +7219,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7233,7 +7233,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7247,7 +7247,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7261,7 +7261,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/peer-to-peer",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/peer-to-peer",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7275,7 +7275,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/pegged-currency",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/pegged-currency",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7289,7 +7289,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7303,7 +7303,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/permissionless-blockchain",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/permissionless-blockchain",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7317,7 +7317,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/phishing",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/phishing",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7331,7 +7331,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7345,7 +7345,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/plasma",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/plasma",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7359,7 +7359,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7373,7 +7373,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/polkadot-crowdloan",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/polkadot-crowdloan",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7387,7 +7387,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7401,7 +7401,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/ponzi-scheme",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/ponzi-scheme",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7415,7 +7415,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7429,7 +7429,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7443,7 +7443,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/premining",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/premining",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7457,7 +7457,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/price-action",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/price-action",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7471,7 +7471,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/prisoners-dilemma",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/prisoners-dilemma",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7485,7 +7485,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7499,7 +7499,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7513,7 +7513,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/private-key",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/private-key",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7527,7 +7527,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/private-sale",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/private-sale",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7541,7 +7541,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/progressive-web-application",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/progressive-web-application",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7555,7 +7555,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/proof-of-attendance-protocol-poap",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/proof-of-attendance-protocol-poap",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7569,7 +7569,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/proof-of-reserves-por",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/proof-of-reserves-por",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7583,7 +7583,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/proof-of-stake",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/proof-of-stake",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7597,7 +7597,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/proof-of-staked-authority-posa",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/proof-of-staked-authority-posa",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7611,7 +7611,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/proof-of-work",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/proof-of-work",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7625,7 +7625,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/proposer-builder-separation-pbs",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/proposer-builder-separation-pbs",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7639,7 +7639,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/proto-danksharding",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/proto-danksharding",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7653,7 +7653,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7667,7 +7667,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/pseudorandom",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/pseudorandom",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7681,7 +7681,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7695,7 +7695,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7709,7 +7709,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/public-key",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/public-key",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7723,7 +7723,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7737,7 +7737,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/pump-and-dump",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/pump-and-dump",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7751,7 +7751,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7765,7 +7765,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/quantitative-easing-qe",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/quantitative-easing-qe",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7779,7 +7779,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/quantitative-tightening-qt",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/quantitative-tightening-qt",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7793,7 +7793,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/quantum-computing",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/quantum-computing",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7807,7 +7807,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7821,7 +7821,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/race-attack",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/race-attack",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7835,7 +7835,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/ransomware",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/ransomware",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7849,7 +7849,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7863,7 +7863,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/real-world-assets-rwas",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/real-world-assets-rwas",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7877,7 +7877,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/recession",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/recession",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7891,7 +7891,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/recursive-inscription",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/recursive-inscription",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7905,7 +7905,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/rekt",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/rekt",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7919,7 +7919,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/relative-strength-index",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/relative-strength-index",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7933,7 +7933,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7947,7 +7947,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7961,7 +7961,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/resistance",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/resistance",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7975,7 +7975,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/return-on-investment",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/return-on-investment",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7989,7 +7989,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/revenge-trading",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/revenge-trading",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8003,7 +8003,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8017,7 +8017,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/risk-premium",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/risk-premium",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8031,7 +8031,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/roadmap",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/roadmap",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8045,7 +8045,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8059,7 +8059,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8073,7 +8073,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8087,7 +8087,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/routing-attack",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/routing-attack",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8101,7 +8101,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8115,7 +8115,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/rug-pull",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/rug-pull",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8129,7 +8129,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8143,7 +8143,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/sahm-rule",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/sahm-rule",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8157,7 +8157,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8171,7 +8171,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8185,7 +8185,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/sandwich-trading",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/sandwich-trading",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8199,7 +8199,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8213,7 +8213,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/satoshi",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/satoshi",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8227,7 +8227,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/satoshi-nakamoto",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/satoshi-nakamoto",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8241,7 +8241,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8255,7 +8255,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8269,7 +8269,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8283,7 +8283,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8297,7 +8297,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8311,7 +8311,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8325,7 +8325,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8339,7 +8339,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/secure-asset-fund-for-users",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/secure-asset-fund-for-users",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8353,7 +8353,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/securities-and-exchange-commission",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/securities-and-exchange-commission",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8367,7 +8367,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/security-audit",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/security-audit",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8381,7 +8381,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8395,7 +8395,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8409,7 +8409,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/security-token-offering-sto",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/security-token-offering-sto",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8423,7 +8423,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/seed-phrase",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/seed-phrase",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8437,7 +8437,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/seed-tag",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/seed-tag",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8451,7 +8451,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/segregated-witness",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/segregated-witness",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8465,7 +8465,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8479,7 +8479,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8493,7 +8493,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/selfish-mining",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/selfish-mining",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8507,7 +8507,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/sell-wall",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/sell-wall",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8521,7 +8521,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/sentiment",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/sentiment",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8535,7 +8535,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8549,7 +8549,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8563,7 +8563,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8577,7 +8577,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8591,7 +8591,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/sharding",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/sharding",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8605,7 +8605,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/sharpe-ratio",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/sharpe-ratio",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8619,7 +8619,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8633,7 +8633,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8647,7 +8647,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/sidechains",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/sidechains",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8661,7 +8661,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/simple-moving-average-sma",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/simple-moving-average-sma",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8675,7 +8675,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/slashing",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/slashing",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8689,7 +8689,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8703,7 +8703,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/slippage",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/slippage",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8717,7 +8717,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8731,7 +8731,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/smart-contract",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/smart-contract",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8745,7 +8745,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/smart-contract-wallet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/smart-contract-wallet",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8759,7 +8759,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/snapshot",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/snapshot",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8773,7 +8773,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/social-recovery-wallet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/social-recovery-wallet",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8787,7 +8787,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/social-trading",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/social-trading",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8801,7 +8801,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/socialfi",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/socialfi",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8815,7 +8815,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8829,7 +8829,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/soft-landing",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/soft-landing",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8843,7 +8843,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/solidity",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/solidity",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8857,7 +8857,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/source-code",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/source-code",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8871,7 +8871,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/spl",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/spl",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8885,7 +8885,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/src-20-tokens",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/src-20-tokens",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8899,7 +8899,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/stablecoin",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/stablecoin",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8913,7 +8913,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/stagflation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/stagflation",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8927,7 +8927,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8941,7 +8941,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8955,7 +8955,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/staking-pool",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/staking-pool",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8969,7 +8969,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8983,7 +8983,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/state-channel",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/state-channel",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8997,7 +8997,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9011,7 +9011,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/steth",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/steth",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9025,7 +9025,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9039,7 +9039,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/stock-variable",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/stock-variable",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9053,7 +9053,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/store-of-value",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/store-of-value",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9067,7 +9067,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9081,7 +9081,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/supercomputer",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/supercomputer",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9095,7 +9095,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/supply-chain",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/supply-chain",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9109,7 +9109,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/support",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/support",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9123,7 +9123,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9137,7 +9137,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/sybil-attack",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/sybil-attack",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9151,7 +9151,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9165,7 +9165,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/taker",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/taker",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9179,7 +9179,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/tank",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/tank",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9193,7 +9193,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9207,7 +9207,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9221,7 +9221,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/testnet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/testnet",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9235,7 +9235,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9249,7 +9249,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9263,7 +9263,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9277,7 +9277,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/ticker",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/ticker",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9291,7 +9291,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/ticker-symbol",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/ticker-symbol",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9305,7 +9305,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/token",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/token",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9319,7 +9319,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/token-generation-event-tge",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/token-generation-event-tge",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9333,7 +9333,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/token-lockup",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/token-lockup",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9347,7 +9347,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/token-merge",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/token-merge",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9361,7 +9361,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/token-sale",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/token-sale",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9375,7 +9375,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9389,7 +9389,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/token-standards",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/token-standards",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9403,7 +9403,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/tokenization",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/tokenization",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9417,7 +9417,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/tokenomics",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/tokenomics",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9431,7 +9431,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/total-supply",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/total-supply",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9445,7 +9445,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/total-value-locked-tvl",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/total-value-locked-tvl",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9459,7 +9459,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/tradfi",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/tradfi",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9473,7 +9473,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9487,7 +9487,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9501,7 +9501,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9515,7 +9515,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/transaction-id",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/transaction-id",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9529,7 +9529,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9543,7 +9543,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/transactions-per-second-tps",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/transactions-per-second-tps",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9557,7 +9557,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9571,7 +9571,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/treasury-bills-t-bills",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/treasury-bills-t-bills",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9585,7 +9585,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9599,7 +9599,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/trueusd-tusd",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/trueusd-tusd",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9613,7 +9613,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9627,7 +9627,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/trustless",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/trustless",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9641,7 +9641,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/turing-complete",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/turing-complete",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9655,7 +9655,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9669,7 +9669,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9683,7 +9683,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9697,7 +9697,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/understanding-cz-s-number-4",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/understanding-cz-s-number-4",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9711,7 +9711,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9725,7 +9725,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9739,7 +9739,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/unit-of-account",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/unit-of-account",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9753,7 +9753,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9767,7 +9767,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/unspent-transaction-output-utxo",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/unspent-transaction-output-utxo",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9781,7 +9781,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9795,7 +9795,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9809,7 +9809,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9823,7 +9823,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9837,7 +9837,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/user-interface",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/user-interface",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9851,7 +9851,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/utility-token",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/utility-token",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9865,7 +9865,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9879,7 +9879,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9893,7 +9893,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9907,7 +9907,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/verification-code",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/verification-code",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9921,7 +9921,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9935,7 +9935,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9949,7 +9949,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/virtual-machine",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/virtual-machine",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9963,7 +9963,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/vladimir-club",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/vladimir-club",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9977,7 +9977,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/volatility",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/volatility",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9991,7 +9991,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/volume",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/volume",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10005,7 +10005,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/wagmi",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/wagmi",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10019,7 +10019,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/wallet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/wallet",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10033,7 +10033,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10047,7 +10047,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10061,7 +10061,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/wash-trading",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/wash-trading",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10075,7 +10075,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/weak-hands",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/weak-hands",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10089,7 +10089,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/weak-subjectivity",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/weak-subjectivity",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10103,7 +10103,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/web-1",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/web-1",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10117,7 +10117,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10131,7 +10131,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10145,7 +10145,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10159,7 +10159,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10173,7 +10173,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10187,7 +10187,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/wei",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/wei",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10201,7 +10201,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/weighted-moving-average-wma",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/weighted-moving-average-wma",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10215,7 +10215,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/whale",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/whale",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10229,7 +10229,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/whiskers",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/whiskers",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10243,7 +10243,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/whitelist",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/whitelist",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10257,7 +10257,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10271,7 +10271,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/wick",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/wick",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10285,7 +10285,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/win-rate",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/win-rate",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10299,7 +10299,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/wrapped-ether",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/wrapped-ether",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10313,7 +10313,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10327,7 +10327,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/wyckoff",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/wyckoff",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10341,7 +10341,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10355,7 +10355,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10369,7 +10369,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10383,7 +10383,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10397,7 +10397,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/yield-farming",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/yield-farming",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10411,7 +10411,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10425,7 +10425,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10439,7 +10439,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/zero-knowledge-proofs",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/zero-knowledge-proofs",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10453,7 +10453,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10467,7 +10467,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/zk-rollup",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/zk-rollup",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10481,7 +10481,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/zk-snarks",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/zk-snarks",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10495,7 +10495,7 @@
       "definitionSource": "https://academy.binance.com/it/glossary/zk-starks",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/it/glossary/zk-starks",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""

--- a/locales/ja-JP/ja-JP.json
+++ b/locales/ja-JP/ja-JP.json
@@ -9,7 +9,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -23,7 +23,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -37,7 +37,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -51,7 +51,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -65,7 +65,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -79,7 +79,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -93,7 +93,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -107,7 +107,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -121,7 +121,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -135,7 +135,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -149,7 +149,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -163,7 +163,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -177,7 +177,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -191,7 +191,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -205,7 +205,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -219,7 +219,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -233,7 +233,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -247,7 +247,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -261,7 +261,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -275,7 +275,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -289,7 +289,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -303,7 +303,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -317,7 +317,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -331,7 +331,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -345,7 +345,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -359,7 +359,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -373,7 +373,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -387,7 +387,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -401,7 +401,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -415,7 +415,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -429,7 +429,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -443,7 +443,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -457,7 +457,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -471,7 +471,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -485,7 +485,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -499,7 +499,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -513,7 +513,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -527,7 +527,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -541,7 +541,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -555,7 +555,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -569,7 +569,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -583,7 +583,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -597,7 +597,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -611,7 +611,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -625,7 +625,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -639,7 +639,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -653,7 +653,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -667,7 +667,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -681,7 +681,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -695,7 +695,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -709,7 +709,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -723,7 +723,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -737,7 +737,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -751,7 +751,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -765,7 +765,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -779,7 +779,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -793,7 +793,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -807,7 +807,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -821,7 +821,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -835,7 +835,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -849,7 +849,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -863,7 +863,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -877,7 +877,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -891,7 +891,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -905,7 +905,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -919,7 +919,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -933,7 +933,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -947,7 +947,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -961,7 +961,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -975,7 +975,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -989,7 +989,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1003,7 +1003,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1017,7 +1017,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1031,7 +1031,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1045,7 +1045,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1059,7 +1059,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1073,7 +1073,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1087,7 +1087,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1101,7 +1101,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1115,7 +1115,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1129,7 +1129,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1143,7 +1143,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1157,7 +1157,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1171,7 +1171,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1185,7 +1185,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1199,7 +1199,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1213,7 +1213,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1227,7 +1227,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1241,7 +1241,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1255,7 +1255,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1269,7 +1269,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1283,7 +1283,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1297,7 +1297,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1311,7 +1311,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1325,7 +1325,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1339,7 +1339,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1353,7 +1353,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1367,7 +1367,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1381,7 +1381,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1395,7 +1395,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1409,7 +1409,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1423,7 +1423,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1437,7 +1437,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1451,7 +1451,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1465,7 +1465,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1479,7 +1479,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1493,7 +1493,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1507,7 +1507,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1521,7 +1521,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1535,7 +1535,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1549,7 +1549,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1563,7 +1563,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1577,7 +1577,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1591,7 +1591,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1605,7 +1605,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1619,7 +1619,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1633,7 +1633,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1647,7 +1647,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1661,7 +1661,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1675,7 +1675,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1689,7 +1689,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1703,7 +1703,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1717,7 +1717,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1731,7 +1731,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1745,7 +1745,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1759,7 +1759,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1773,7 +1773,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1787,7 +1787,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1801,7 +1801,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1815,7 +1815,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1829,7 +1829,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1843,7 +1843,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1857,7 +1857,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1871,7 +1871,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1885,7 +1885,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1899,7 +1899,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1913,7 +1913,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1927,7 +1927,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1941,7 +1941,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1955,7 +1955,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1969,7 +1969,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1983,7 +1983,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1997,7 +1997,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2011,7 +2011,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2025,7 +2025,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2039,7 +2039,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2053,7 +2053,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2067,7 +2067,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2081,7 +2081,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2095,7 +2095,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2109,7 +2109,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2123,7 +2123,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2137,7 +2137,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2151,7 +2151,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2165,7 +2165,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2179,7 +2179,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2193,7 +2193,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2207,7 +2207,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2221,7 +2221,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2235,7 +2235,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2249,7 +2249,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2263,7 +2263,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2277,7 +2277,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2291,7 +2291,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2305,7 +2305,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2319,7 +2319,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2333,7 +2333,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2347,7 +2347,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2361,7 +2361,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2375,7 +2375,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2389,7 +2389,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2403,7 +2403,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2417,7 +2417,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2431,7 +2431,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2445,7 +2445,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2459,7 +2459,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2473,7 +2473,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2487,7 +2487,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2501,7 +2501,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2515,7 +2515,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2529,7 +2529,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2543,7 +2543,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2557,7 +2557,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2571,7 +2571,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2585,7 +2585,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2599,7 +2599,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2613,7 +2613,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2627,7 +2627,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2641,7 +2641,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2655,7 +2655,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2669,7 +2669,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2683,7 +2683,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2697,7 +2697,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2711,7 +2711,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2725,7 +2725,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2739,7 +2739,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2753,7 +2753,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2767,7 +2767,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2781,7 +2781,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2795,7 +2795,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2809,7 +2809,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2823,7 +2823,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2837,7 +2837,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2851,7 +2851,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2865,7 +2865,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2879,7 +2879,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2893,7 +2893,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2907,7 +2907,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2921,7 +2921,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2935,7 +2935,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2949,7 +2949,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2963,7 +2963,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2977,7 +2977,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2991,7 +2991,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3005,7 +3005,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3019,7 +3019,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3033,7 +3033,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3047,7 +3047,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3061,7 +3061,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3075,7 +3075,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3089,7 +3089,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3103,7 +3103,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3117,7 +3117,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3131,7 +3131,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3145,7 +3145,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3159,7 +3159,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3173,7 +3173,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3187,7 +3187,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3201,7 +3201,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3215,7 +3215,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3229,7 +3229,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3243,7 +3243,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3257,7 +3257,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3271,7 +3271,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3285,7 +3285,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3299,7 +3299,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3313,7 +3313,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3327,7 +3327,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3341,7 +3341,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3355,7 +3355,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3369,7 +3369,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3383,7 +3383,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3397,7 +3397,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3411,7 +3411,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3425,7 +3425,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3439,7 +3439,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3453,7 +3453,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3467,7 +3467,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3481,7 +3481,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3495,7 +3495,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3509,7 +3509,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3523,7 +3523,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3537,7 +3537,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3551,7 +3551,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3565,7 +3565,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3579,7 +3579,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3593,7 +3593,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3607,7 +3607,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3621,7 +3621,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3635,7 +3635,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3649,7 +3649,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3663,7 +3663,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3677,7 +3677,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3691,7 +3691,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3705,7 +3705,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3719,7 +3719,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3733,7 +3733,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3747,7 +3747,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3761,7 +3761,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3775,7 +3775,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3789,7 +3789,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3803,7 +3803,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3817,7 +3817,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3831,7 +3831,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3845,7 +3845,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3859,7 +3859,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3873,7 +3873,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3887,7 +3887,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3901,7 +3901,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3915,7 +3915,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3929,7 +3929,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3943,7 +3943,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3957,7 +3957,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3971,7 +3971,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3985,7 +3985,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3999,7 +3999,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4013,7 +4013,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4027,7 +4027,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4041,7 +4041,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4055,7 +4055,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4069,7 +4069,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4083,7 +4083,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4097,7 +4097,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4111,7 +4111,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4125,7 +4125,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4139,7 +4139,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4153,7 +4153,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4167,7 +4167,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4181,7 +4181,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4195,7 +4195,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4209,7 +4209,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4223,7 +4223,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4237,7 +4237,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4251,7 +4251,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4265,7 +4265,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4279,7 +4279,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4293,7 +4293,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4307,7 +4307,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4321,7 +4321,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4335,7 +4335,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4349,7 +4349,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4363,7 +4363,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4377,7 +4377,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4391,7 +4391,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4405,7 +4405,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4419,7 +4419,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4433,7 +4433,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4447,7 +4447,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4461,7 +4461,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4475,7 +4475,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4489,7 +4489,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4503,7 +4503,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4517,7 +4517,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4531,7 +4531,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4545,7 +4545,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4559,7 +4559,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4573,7 +4573,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4587,7 +4587,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4601,7 +4601,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4615,7 +4615,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4629,7 +4629,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4643,7 +4643,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4657,7 +4657,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4671,7 +4671,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4685,7 +4685,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4699,7 +4699,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4713,7 +4713,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4727,7 +4727,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4741,7 +4741,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4755,7 +4755,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4769,7 +4769,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4783,7 +4783,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4797,7 +4797,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4811,7 +4811,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4825,7 +4825,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4839,7 +4839,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4853,7 +4853,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4867,7 +4867,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4881,7 +4881,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4895,7 +4895,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4909,7 +4909,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4923,7 +4923,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4937,7 +4937,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4951,7 +4951,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4965,7 +4965,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4979,7 +4979,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4993,7 +4993,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5007,7 +5007,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5021,7 +5021,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5035,7 +5035,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5049,7 +5049,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5063,7 +5063,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5077,7 +5077,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5091,7 +5091,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5105,7 +5105,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5119,7 +5119,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5133,7 +5133,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5147,7 +5147,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5161,7 +5161,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5175,7 +5175,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5189,7 +5189,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5203,7 +5203,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5217,7 +5217,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5231,7 +5231,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5245,7 +5245,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5259,7 +5259,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5273,7 +5273,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5287,7 +5287,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5301,7 +5301,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5315,7 +5315,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5329,7 +5329,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5343,7 +5343,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5357,7 +5357,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5371,7 +5371,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5385,7 +5385,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5399,7 +5399,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5413,7 +5413,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5427,7 +5427,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5441,7 +5441,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5455,7 +5455,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5469,7 +5469,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5483,7 +5483,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5497,7 +5497,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5511,7 +5511,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5525,7 +5525,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5539,7 +5539,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5553,7 +5553,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5567,7 +5567,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5581,7 +5581,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5595,7 +5595,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5609,7 +5609,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5623,7 +5623,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5637,7 +5637,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5651,7 +5651,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5665,7 +5665,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5679,7 +5679,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""

--- a/locales/ko-KR/ko-KR.json
+++ b/locales/ko-KR/ko-KR.json
@@ -9,7 +9,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -23,7 +23,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -37,7 +37,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -51,7 +51,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -65,7 +65,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -79,7 +79,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -93,7 +93,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -107,7 +107,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -121,7 +121,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -135,7 +135,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -149,7 +149,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -163,7 +163,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -177,7 +177,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -191,7 +191,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -205,7 +205,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -219,7 +219,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -233,7 +233,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -247,7 +247,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -261,7 +261,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -275,7 +275,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -289,7 +289,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -303,7 +303,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -317,7 +317,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -331,7 +331,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -345,7 +345,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -359,7 +359,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -373,7 +373,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -387,7 +387,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -401,7 +401,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -415,7 +415,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -429,7 +429,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -443,7 +443,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -457,7 +457,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -471,7 +471,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -485,7 +485,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -499,7 +499,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -513,7 +513,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -527,7 +527,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -541,7 +541,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -555,7 +555,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -569,7 +569,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -583,7 +583,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -597,7 +597,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -611,7 +611,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -625,7 +625,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -639,7 +639,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -653,7 +653,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -667,7 +667,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -681,7 +681,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -695,7 +695,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -709,7 +709,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -723,7 +723,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -737,7 +737,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -751,7 +751,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -765,7 +765,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -779,7 +779,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -793,7 +793,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -807,7 +807,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -821,7 +821,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -835,7 +835,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -849,7 +849,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -863,7 +863,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -877,7 +877,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -891,7 +891,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -905,7 +905,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -919,7 +919,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -933,7 +933,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -947,7 +947,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -961,7 +961,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -975,7 +975,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -989,7 +989,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1003,7 +1003,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1017,7 +1017,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1031,7 +1031,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1045,7 +1045,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1059,7 +1059,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1073,7 +1073,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1087,7 +1087,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1101,7 +1101,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1115,7 +1115,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1129,7 +1129,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1143,7 +1143,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1157,7 +1157,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1171,7 +1171,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1185,7 +1185,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1199,7 +1199,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1213,7 +1213,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1227,7 +1227,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1241,7 +1241,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1255,7 +1255,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1269,7 +1269,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1283,7 +1283,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1297,7 +1297,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1311,7 +1311,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1325,7 +1325,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1339,7 +1339,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1353,7 +1353,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1367,7 +1367,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1381,7 +1381,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1395,7 +1395,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1409,7 +1409,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1423,7 +1423,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1437,7 +1437,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1451,7 +1451,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1465,7 +1465,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1479,7 +1479,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1493,7 +1493,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1507,7 +1507,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1521,7 +1521,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1535,7 +1535,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1549,7 +1549,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1563,7 +1563,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1577,7 +1577,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1591,7 +1591,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1605,7 +1605,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1619,7 +1619,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1633,7 +1633,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1647,7 +1647,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1661,7 +1661,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1675,7 +1675,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1689,7 +1689,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1703,7 +1703,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1717,7 +1717,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1731,7 +1731,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1745,7 +1745,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1759,7 +1759,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1773,7 +1773,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1787,7 +1787,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1801,7 +1801,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1815,7 +1815,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1829,7 +1829,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1843,7 +1843,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1857,7 +1857,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1871,7 +1871,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1885,7 +1885,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1899,7 +1899,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1913,7 +1913,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1927,7 +1927,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1941,7 +1941,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1955,7 +1955,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1969,7 +1969,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1983,7 +1983,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1997,7 +1997,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2011,7 +2011,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2025,7 +2025,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2039,7 +2039,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2053,7 +2053,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2067,7 +2067,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2081,7 +2081,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2095,7 +2095,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2109,7 +2109,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2123,7 +2123,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2137,7 +2137,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2151,7 +2151,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2165,7 +2165,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2179,7 +2179,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2193,7 +2193,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2207,7 +2207,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2221,7 +2221,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2235,7 +2235,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2249,7 +2249,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2263,7 +2263,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2277,7 +2277,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2291,7 +2291,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2305,7 +2305,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2319,7 +2319,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2333,7 +2333,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2347,7 +2347,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2361,7 +2361,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2375,7 +2375,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2389,7 +2389,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2403,7 +2403,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2417,7 +2417,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2431,7 +2431,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2445,7 +2445,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2459,7 +2459,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2473,7 +2473,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2487,7 +2487,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2501,7 +2501,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2515,7 +2515,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2529,7 +2529,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2543,7 +2543,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2557,7 +2557,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2571,7 +2571,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2585,7 +2585,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2599,7 +2599,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2613,7 +2613,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2627,7 +2627,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2641,7 +2641,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2655,7 +2655,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2669,7 +2669,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2683,7 +2683,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2697,7 +2697,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2711,7 +2711,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2725,7 +2725,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2739,7 +2739,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2753,7 +2753,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2767,7 +2767,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2781,7 +2781,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2795,7 +2795,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2809,7 +2809,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2823,7 +2823,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2837,7 +2837,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2851,7 +2851,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2865,7 +2865,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2879,7 +2879,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2893,7 +2893,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2907,7 +2907,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2921,7 +2921,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2935,7 +2935,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2949,7 +2949,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2963,7 +2963,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2977,7 +2977,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2991,7 +2991,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3005,7 +3005,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3019,7 +3019,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3033,7 +3033,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3047,7 +3047,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3061,7 +3061,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3075,7 +3075,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3089,7 +3089,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3103,7 +3103,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3117,7 +3117,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3131,7 +3131,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3145,7 +3145,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3159,7 +3159,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3173,7 +3173,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3187,7 +3187,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3201,7 +3201,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3215,7 +3215,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3229,7 +3229,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3243,7 +3243,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3257,7 +3257,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3271,7 +3271,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3285,7 +3285,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3299,7 +3299,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3313,7 +3313,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3327,7 +3327,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3341,7 +3341,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3355,7 +3355,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3369,7 +3369,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3383,7 +3383,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3397,7 +3397,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3411,7 +3411,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3425,7 +3425,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3439,7 +3439,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3453,7 +3453,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3467,7 +3467,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3481,7 +3481,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3495,7 +3495,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3509,7 +3509,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3523,7 +3523,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3537,7 +3537,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3551,7 +3551,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3565,7 +3565,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3579,7 +3579,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3593,7 +3593,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3607,7 +3607,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3621,7 +3621,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3635,7 +3635,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3649,7 +3649,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3663,7 +3663,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3677,7 +3677,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3691,7 +3691,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3705,7 +3705,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3719,7 +3719,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3733,7 +3733,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3747,7 +3747,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3761,7 +3761,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3775,7 +3775,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3789,7 +3789,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3803,7 +3803,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3817,7 +3817,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3831,7 +3831,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3845,7 +3845,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3859,7 +3859,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3873,7 +3873,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3887,7 +3887,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3901,7 +3901,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3915,7 +3915,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3929,7 +3929,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3943,7 +3943,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3957,7 +3957,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3971,7 +3971,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3985,7 +3985,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3999,7 +3999,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4013,7 +4013,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4027,7 +4027,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4041,7 +4041,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4055,7 +4055,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4069,7 +4069,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4083,7 +4083,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4097,7 +4097,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4111,7 +4111,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4125,7 +4125,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4139,7 +4139,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4153,7 +4153,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4167,7 +4167,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4181,7 +4181,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4195,7 +4195,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4209,7 +4209,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4223,7 +4223,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4237,7 +4237,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4251,7 +4251,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4265,7 +4265,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4279,7 +4279,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4293,7 +4293,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4307,7 +4307,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4321,7 +4321,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4335,7 +4335,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4349,7 +4349,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4363,7 +4363,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4377,7 +4377,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4391,7 +4391,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4405,7 +4405,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4419,7 +4419,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4433,7 +4433,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4447,7 +4447,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4461,7 +4461,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4475,7 +4475,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4489,7 +4489,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4503,7 +4503,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4517,7 +4517,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4531,7 +4531,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4545,7 +4545,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4559,7 +4559,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4573,7 +4573,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4587,7 +4587,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4601,7 +4601,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4615,7 +4615,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4629,7 +4629,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4643,7 +4643,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4657,7 +4657,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4671,7 +4671,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4685,7 +4685,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4699,7 +4699,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4713,7 +4713,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4727,7 +4727,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4741,7 +4741,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4755,7 +4755,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4769,7 +4769,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4783,7 +4783,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4797,7 +4797,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4811,7 +4811,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4825,7 +4825,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4839,7 +4839,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4853,7 +4853,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4867,7 +4867,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4881,7 +4881,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4895,7 +4895,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4909,7 +4909,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4923,7 +4923,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4937,7 +4937,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4951,7 +4951,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4965,7 +4965,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4979,7 +4979,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4993,7 +4993,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5007,7 +5007,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5021,7 +5021,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5035,7 +5035,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5049,7 +5049,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5063,7 +5063,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5077,7 +5077,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5091,7 +5091,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5105,7 +5105,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5119,7 +5119,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5133,7 +5133,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5147,7 +5147,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5161,7 +5161,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5175,7 +5175,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5189,7 +5189,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5203,7 +5203,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5217,7 +5217,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5231,7 +5231,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5245,7 +5245,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5259,7 +5259,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5273,7 +5273,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5287,7 +5287,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5301,7 +5301,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5315,7 +5315,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5329,7 +5329,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5343,7 +5343,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5357,7 +5357,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5371,7 +5371,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5385,7 +5385,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5399,7 +5399,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5413,7 +5413,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5427,7 +5427,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5441,7 +5441,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5455,7 +5455,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5469,7 +5469,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5483,7 +5483,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5497,7 +5497,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5511,7 +5511,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5525,7 +5525,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5539,7 +5539,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5553,7 +5553,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5567,7 +5567,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5581,7 +5581,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5595,7 +5595,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5609,7 +5609,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5623,7 +5623,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5637,7 +5637,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5651,7 +5651,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5665,7 +5665,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5679,7 +5679,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""

--- a/locales/ms-MY/ms-MY.json
+++ b/locales/ms-MY/ms-MY.json
@@ -9,7 +9,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -23,7 +23,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -37,7 +37,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -51,7 +51,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -65,7 +65,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -79,7 +79,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -93,7 +93,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -107,7 +107,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -121,7 +121,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -135,7 +135,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -149,7 +149,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -163,7 +163,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -177,7 +177,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -191,7 +191,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -205,7 +205,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -219,7 +219,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -233,7 +233,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -247,7 +247,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -261,7 +261,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -275,7 +275,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -289,7 +289,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -303,7 +303,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -317,7 +317,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -331,7 +331,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -345,7 +345,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -359,7 +359,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -373,7 +373,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -387,7 +387,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -401,7 +401,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -415,7 +415,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -429,7 +429,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -443,7 +443,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -457,7 +457,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -471,7 +471,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -485,7 +485,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -499,7 +499,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -513,7 +513,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -527,7 +527,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -541,7 +541,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -555,7 +555,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -569,7 +569,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -583,7 +583,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -597,7 +597,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -611,7 +611,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -625,7 +625,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -639,7 +639,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -653,7 +653,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -667,7 +667,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -681,7 +681,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -695,7 +695,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -709,7 +709,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -723,7 +723,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -737,7 +737,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -751,7 +751,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -765,7 +765,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -779,7 +779,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -793,7 +793,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -807,7 +807,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -821,7 +821,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -835,7 +835,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -849,7 +849,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -863,7 +863,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -877,7 +877,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -891,7 +891,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -905,7 +905,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -919,7 +919,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -933,7 +933,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -947,7 +947,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -961,7 +961,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -975,7 +975,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -989,7 +989,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1003,7 +1003,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1017,7 +1017,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1031,7 +1031,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1045,7 +1045,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1059,7 +1059,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1073,7 +1073,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1087,7 +1087,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1101,7 +1101,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1115,7 +1115,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1129,7 +1129,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1143,7 +1143,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1157,7 +1157,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1171,7 +1171,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1185,7 +1185,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1199,7 +1199,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1213,7 +1213,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1227,7 +1227,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1241,7 +1241,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1255,7 +1255,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1269,7 +1269,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1283,7 +1283,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1297,7 +1297,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1311,7 +1311,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1325,7 +1325,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1339,7 +1339,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1353,7 +1353,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1367,7 +1367,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1381,7 +1381,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1395,7 +1395,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1409,7 +1409,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1423,7 +1423,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1437,7 +1437,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1451,7 +1451,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1465,7 +1465,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1479,7 +1479,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1493,7 +1493,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1507,7 +1507,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1521,7 +1521,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1535,7 +1535,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1549,7 +1549,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1563,7 +1563,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1577,7 +1577,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1591,7 +1591,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1605,7 +1605,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1619,7 +1619,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1633,7 +1633,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1647,7 +1647,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1661,7 +1661,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1675,7 +1675,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1689,7 +1689,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1703,7 +1703,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1717,7 +1717,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1731,7 +1731,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1745,7 +1745,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1759,7 +1759,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1773,7 +1773,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1787,7 +1787,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1801,7 +1801,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1815,7 +1815,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1829,7 +1829,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1843,7 +1843,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1857,7 +1857,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1871,7 +1871,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1885,7 +1885,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1899,7 +1899,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1913,7 +1913,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1927,7 +1927,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1941,7 +1941,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1955,7 +1955,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1969,7 +1969,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1983,7 +1983,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1997,7 +1997,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2011,7 +2011,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2025,7 +2025,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2039,7 +2039,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2053,7 +2053,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2067,7 +2067,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2081,7 +2081,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2095,7 +2095,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2109,7 +2109,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2123,7 +2123,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2137,7 +2137,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2151,7 +2151,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2165,7 +2165,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2179,7 +2179,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2193,7 +2193,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2207,7 +2207,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2221,7 +2221,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2235,7 +2235,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2249,7 +2249,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2263,7 +2263,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2277,7 +2277,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2291,7 +2291,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2305,7 +2305,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2319,7 +2319,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2333,7 +2333,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2347,7 +2347,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2361,7 +2361,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2375,7 +2375,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2389,7 +2389,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2403,7 +2403,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2417,7 +2417,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2431,7 +2431,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2445,7 +2445,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2459,7 +2459,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2473,7 +2473,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2487,7 +2487,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2501,7 +2501,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2515,7 +2515,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2529,7 +2529,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2543,7 +2543,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2557,7 +2557,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2571,7 +2571,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2585,7 +2585,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2599,7 +2599,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2613,7 +2613,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2627,7 +2627,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2641,7 +2641,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2655,7 +2655,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2669,7 +2669,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2683,7 +2683,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2697,7 +2697,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2711,7 +2711,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2725,7 +2725,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2739,7 +2739,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2753,7 +2753,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2767,7 +2767,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2781,7 +2781,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2795,7 +2795,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2809,7 +2809,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2823,7 +2823,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2837,7 +2837,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2851,7 +2851,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2865,7 +2865,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2879,7 +2879,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2893,7 +2893,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2907,7 +2907,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2921,7 +2921,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2935,7 +2935,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2949,7 +2949,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2963,7 +2963,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2977,7 +2977,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2991,7 +2991,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3005,7 +3005,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3019,7 +3019,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3033,7 +3033,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3047,7 +3047,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3061,7 +3061,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3075,7 +3075,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3089,7 +3089,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3103,7 +3103,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3117,7 +3117,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3131,7 +3131,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3145,7 +3145,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3159,7 +3159,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3173,7 +3173,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3187,7 +3187,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3201,7 +3201,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3215,7 +3215,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3229,7 +3229,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3243,7 +3243,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3257,7 +3257,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3271,7 +3271,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3285,7 +3285,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3299,7 +3299,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3313,7 +3313,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3327,7 +3327,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3341,7 +3341,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3355,7 +3355,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3369,7 +3369,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3383,7 +3383,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3397,7 +3397,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3411,7 +3411,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3425,7 +3425,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3439,7 +3439,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3453,7 +3453,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3467,7 +3467,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3481,7 +3481,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3495,7 +3495,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3509,7 +3509,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3523,7 +3523,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3537,7 +3537,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3551,7 +3551,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3565,7 +3565,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3579,7 +3579,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3593,7 +3593,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3607,7 +3607,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3621,7 +3621,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3635,7 +3635,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3649,7 +3649,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3663,7 +3663,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3677,7 +3677,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3691,7 +3691,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3705,7 +3705,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3719,7 +3719,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3733,7 +3733,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3747,7 +3747,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3761,7 +3761,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3775,7 +3775,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3789,7 +3789,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3803,7 +3803,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3817,7 +3817,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3831,7 +3831,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3845,7 +3845,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3859,7 +3859,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3873,7 +3873,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3887,7 +3887,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3901,7 +3901,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3915,7 +3915,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3929,7 +3929,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3943,7 +3943,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3957,7 +3957,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3971,7 +3971,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3985,7 +3985,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3999,7 +3999,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4013,7 +4013,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4027,7 +4027,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4041,7 +4041,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4055,7 +4055,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4069,7 +4069,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4083,7 +4083,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4097,7 +4097,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4111,7 +4111,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4125,7 +4125,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4139,7 +4139,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4153,7 +4153,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4167,7 +4167,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4181,7 +4181,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4195,7 +4195,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4209,7 +4209,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4223,7 +4223,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4237,7 +4237,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4251,7 +4251,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4265,7 +4265,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4279,7 +4279,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4293,7 +4293,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4307,7 +4307,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4321,7 +4321,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4335,7 +4335,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4349,7 +4349,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4363,7 +4363,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4377,7 +4377,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4391,7 +4391,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4405,7 +4405,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4419,7 +4419,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4433,7 +4433,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4447,7 +4447,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4461,7 +4461,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4475,7 +4475,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4489,7 +4489,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4503,7 +4503,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4517,7 +4517,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4531,7 +4531,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4545,7 +4545,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4559,7 +4559,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4573,7 +4573,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4587,7 +4587,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4601,7 +4601,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4615,7 +4615,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4629,7 +4629,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4643,7 +4643,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4657,7 +4657,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4671,7 +4671,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4685,7 +4685,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4699,7 +4699,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4713,7 +4713,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4727,7 +4727,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4741,7 +4741,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4755,7 +4755,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4769,7 +4769,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4783,7 +4783,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4797,7 +4797,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4811,7 +4811,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4825,7 +4825,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4839,7 +4839,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4853,7 +4853,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4867,7 +4867,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4881,7 +4881,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4895,7 +4895,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4909,7 +4909,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4923,7 +4923,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4937,7 +4937,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4951,7 +4951,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4965,7 +4965,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4979,7 +4979,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4993,7 +4993,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5007,7 +5007,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5021,7 +5021,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5035,7 +5035,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5049,7 +5049,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5063,7 +5063,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5077,7 +5077,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5091,7 +5091,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5105,7 +5105,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5119,7 +5119,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5133,7 +5133,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5147,7 +5147,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5161,7 +5161,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5175,7 +5175,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5189,7 +5189,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5203,7 +5203,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5217,7 +5217,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5231,7 +5231,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5245,7 +5245,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5259,7 +5259,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5273,7 +5273,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5287,7 +5287,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5301,7 +5301,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5315,7 +5315,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5329,7 +5329,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5343,7 +5343,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5357,7 +5357,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5371,7 +5371,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5385,7 +5385,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5399,7 +5399,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5413,7 +5413,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5427,7 +5427,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5441,7 +5441,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5455,7 +5455,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5469,7 +5469,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5483,7 +5483,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5497,7 +5497,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5511,7 +5511,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5525,7 +5525,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5539,7 +5539,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5553,7 +5553,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5567,7 +5567,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5581,7 +5581,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5595,7 +5595,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5609,7 +5609,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5623,7 +5623,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5637,7 +5637,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5651,7 +5651,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5665,7 +5665,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5679,7 +5679,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""

--- a/locales/nl-NL/nl-NL.json
+++ b/locales/nl-NL/nl-NL.json
@@ -9,7 +9,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -23,7 +23,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -37,7 +37,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -51,7 +51,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -65,7 +65,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -79,7 +79,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -93,7 +93,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -107,7 +107,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -121,7 +121,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -135,7 +135,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -149,7 +149,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -163,7 +163,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -177,7 +177,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -191,7 +191,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -205,7 +205,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -219,7 +219,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -233,7 +233,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -247,7 +247,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -261,7 +261,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -275,7 +275,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -289,7 +289,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -303,7 +303,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -317,7 +317,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -331,7 +331,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -345,7 +345,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -359,7 +359,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -373,7 +373,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -387,7 +387,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -401,7 +401,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -415,7 +415,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -429,7 +429,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -443,7 +443,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -457,7 +457,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -471,7 +471,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -485,7 +485,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -499,7 +499,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -513,7 +513,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -527,7 +527,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -541,7 +541,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -555,7 +555,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -569,7 +569,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -583,7 +583,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -597,7 +597,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -611,7 +611,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -625,7 +625,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -639,7 +639,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -653,7 +653,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -667,7 +667,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -681,7 +681,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -695,7 +695,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -709,7 +709,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -723,7 +723,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -737,7 +737,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -751,7 +751,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -765,7 +765,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -779,7 +779,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -793,7 +793,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -807,7 +807,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -821,7 +821,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -835,7 +835,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -849,7 +849,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -863,7 +863,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -877,7 +877,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -891,7 +891,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -905,7 +905,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -919,7 +919,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -933,7 +933,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -947,7 +947,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -961,7 +961,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -975,7 +975,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -989,7 +989,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1003,7 +1003,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1017,7 +1017,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1031,7 +1031,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1045,7 +1045,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1059,7 +1059,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1073,7 +1073,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1087,7 +1087,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1101,7 +1101,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1115,7 +1115,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1129,7 +1129,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1143,7 +1143,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1157,7 +1157,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1171,7 +1171,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1185,7 +1185,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1199,7 +1199,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1213,7 +1213,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1227,7 +1227,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1241,7 +1241,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1255,7 +1255,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1269,7 +1269,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1283,7 +1283,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1297,7 +1297,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1311,7 +1311,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1325,7 +1325,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1339,7 +1339,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1353,7 +1353,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1367,7 +1367,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1381,7 +1381,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1395,7 +1395,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1409,7 +1409,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1423,7 +1423,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1437,7 +1437,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1451,7 +1451,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1465,7 +1465,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1479,7 +1479,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1493,7 +1493,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1507,7 +1507,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1521,7 +1521,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1535,7 +1535,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1549,7 +1549,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1563,7 +1563,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1577,7 +1577,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1591,7 +1591,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1605,7 +1605,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1619,7 +1619,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1633,7 +1633,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1647,7 +1647,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1661,7 +1661,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1675,7 +1675,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1689,7 +1689,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1703,7 +1703,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1717,7 +1717,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1731,7 +1731,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1745,7 +1745,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1759,7 +1759,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1773,7 +1773,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1787,7 +1787,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1801,7 +1801,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1815,7 +1815,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1829,7 +1829,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1843,7 +1843,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1857,7 +1857,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1871,7 +1871,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1885,7 +1885,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1899,7 +1899,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1913,7 +1913,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1927,7 +1927,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1941,7 +1941,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1955,7 +1955,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1969,7 +1969,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1983,7 +1983,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1997,7 +1997,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2011,7 +2011,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2025,7 +2025,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2039,7 +2039,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2053,7 +2053,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2067,7 +2067,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2081,7 +2081,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2095,7 +2095,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2109,7 +2109,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2123,7 +2123,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2137,7 +2137,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2151,7 +2151,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2165,7 +2165,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2179,7 +2179,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2193,7 +2193,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2207,7 +2207,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2221,7 +2221,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2235,7 +2235,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2249,7 +2249,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2263,7 +2263,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2277,7 +2277,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2291,7 +2291,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2305,7 +2305,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2319,7 +2319,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2333,7 +2333,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2347,7 +2347,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2361,7 +2361,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2375,7 +2375,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2389,7 +2389,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2403,7 +2403,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2417,7 +2417,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2431,7 +2431,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2445,7 +2445,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2459,7 +2459,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2473,7 +2473,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2487,7 +2487,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2501,7 +2501,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2515,7 +2515,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2529,7 +2529,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2543,7 +2543,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2557,7 +2557,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2571,7 +2571,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2585,7 +2585,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2599,7 +2599,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2613,7 +2613,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2627,7 +2627,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2641,7 +2641,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2655,7 +2655,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2669,7 +2669,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2683,7 +2683,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2697,7 +2697,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2711,7 +2711,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2725,7 +2725,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2739,7 +2739,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2753,7 +2753,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2767,7 +2767,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2781,7 +2781,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2795,7 +2795,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2809,7 +2809,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2823,7 +2823,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2837,7 +2837,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2851,7 +2851,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2865,7 +2865,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2879,7 +2879,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2893,7 +2893,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2907,7 +2907,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2921,7 +2921,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2935,7 +2935,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2949,7 +2949,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2963,7 +2963,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2977,7 +2977,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2991,7 +2991,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3005,7 +3005,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3019,7 +3019,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3033,7 +3033,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3047,7 +3047,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3061,7 +3061,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3075,7 +3075,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3089,7 +3089,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3103,7 +3103,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3117,7 +3117,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3131,7 +3131,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3145,7 +3145,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3159,7 +3159,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3173,7 +3173,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3187,7 +3187,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3201,7 +3201,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3215,7 +3215,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3229,7 +3229,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3243,7 +3243,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3257,7 +3257,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3271,7 +3271,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3285,7 +3285,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3299,7 +3299,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3313,7 +3313,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3327,7 +3327,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3341,7 +3341,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3355,7 +3355,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3369,7 +3369,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3383,7 +3383,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3397,7 +3397,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3411,7 +3411,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3425,7 +3425,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3439,7 +3439,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3453,7 +3453,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3467,7 +3467,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3481,7 +3481,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3495,7 +3495,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3509,7 +3509,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3523,7 +3523,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3537,7 +3537,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3551,7 +3551,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3565,7 +3565,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3579,7 +3579,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3593,7 +3593,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3607,7 +3607,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3621,7 +3621,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3635,7 +3635,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3649,7 +3649,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3663,7 +3663,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3677,7 +3677,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3691,7 +3691,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3705,7 +3705,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3719,7 +3719,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3733,7 +3733,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3747,7 +3747,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3761,7 +3761,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3775,7 +3775,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3789,7 +3789,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3803,7 +3803,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3817,7 +3817,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3831,7 +3831,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3845,7 +3845,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3859,7 +3859,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3873,7 +3873,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3887,7 +3887,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3901,7 +3901,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3915,7 +3915,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3929,7 +3929,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3943,7 +3943,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3957,7 +3957,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3971,7 +3971,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3985,7 +3985,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3999,7 +3999,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4013,7 +4013,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4027,7 +4027,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4041,7 +4041,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4055,7 +4055,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4069,7 +4069,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4083,7 +4083,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4097,7 +4097,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4111,7 +4111,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4125,7 +4125,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4139,7 +4139,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4153,7 +4153,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4167,7 +4167,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4181,7 +4181,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4195,7 +4195,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4209,7 +4209,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4223,7 +4223,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4237,7 +4237,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4251,7 +4251,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4265,7 +4265,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4279,7 +4279,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4293,7 +4293,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4307,7 +4307,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4321,7 +4321,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4335,7 +4335,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4349,7 +4349,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4363,7 +4363,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4377,7 +4377,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4391,7 +4391,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4405,7 +4405,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4419,7 +4419,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4433,7 +4433,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4447,7 +4447,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4461,7 +4461,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4475,7 +4475,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4489,7 +4489,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4503,7 +4503,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4517,7 +4517,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4531,7 +4531,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4545,7 +4545,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4559,7 +4559,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4573,7 +4573,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4587,7 +4587,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4601,7 +4601,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4615,7 +4615,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4629,7 +4629,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4643,7 +4643,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4657,7 +4657,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4671,7 +4671,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4685,7 +4685,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4699,7 +4699,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4713,7 +4713,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4727,7 +4727,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4741,7 +4741,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4755,7 +4755,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4769,7 +4769,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4783,7 +4783,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4797,7 +4797,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4811,7 +4811,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4825,7 +4825,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4839,7 +4839,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4853,7 +4853,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4867,7 +4867,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4881,7 +4881,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4895,7 +4895,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4909,7 +4909,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4923,7 +4923,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4937,7 +4937,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4951,7 +4951,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4965,7 +4965,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4979,7 +4979,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4993,7 +4993,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5007,7 +5007,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5021,7 +5021,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5035,7 +5035,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5049,7 +5049,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5063,7 +5063,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5077,7 +5077,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5091,7 +5091,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5105,7 +5105,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5119,7 +5119,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5133,7 +5133,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5147,7 +5147,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5161,7 +5161,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5175,7 +5175,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5189,7 +5189,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5203,7 +5203,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5217,7 +5217,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5231,7 +5231,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5245,7 +5245,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5259,7 +5259,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5273,7 +5273,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5287,7 +5287,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5301,7 +5301,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5315,7 +5315,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5329,7 +5329,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5343,7 +5343,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5357,7 +5357,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5371,7 +5371,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5385,7 +5385,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5399,7 +5399,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5413,7 +5413,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5427,7 +5427,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5441,7 +5441,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5455,7 +5455,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5469,7 +5469,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5483,7 +5483,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5497,7 +5497,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5511,7 +5511,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5525,7 +5525,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5539,7 +5539,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5553,7 +5553,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5567,7 +5567,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5581,7 +5581,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5595,7 +5595,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5609,7 +5609,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5623,7 +5623,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5637,7 +5637,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5651,7 +5651,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5665,7 +5665,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5679,7 +5679,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""

--- a/locales/pcm-NG/pcm-NG.json
+++ b/locales/pcm-NG/pcm-NG.json
@@ -9,7 +9,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -23,7 +23,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -37,7 +37,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -51,7 +51,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -65,7 +65,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -79,7 +79,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -93,7 +93,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -107,7 +107,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -121,7 +121,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -135,7 +135,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -149,7 +149,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -163,7 +163,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -177,7 +177,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -191,7 +191,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -205,7 +205,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -219,7 +219,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -233,7 +233,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -247,7 +247,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -261,7 +261,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -275,7 +275,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -289,7 +289,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -303,7 +303,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -317,7 +317,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -331,7 +331,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -345,7 +345,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -359,7 +359,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -373,7 +373,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -387,7 +387,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -401,7 +401,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -415,7 +415,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -429,7 +429,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -443,7 +443,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -457,7 +457,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -471,7 +471,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -485,7 +485,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -499,7 +499,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -513,7 +513,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -527,7 +527,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -541,7 +541,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -555,7 +555,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -569,7 +569,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -583,7 +583,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -597,7 +597,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -611,7 +611,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -625,7 +625,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -639,7 +639,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -653,7 +653,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -667,7 +667,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -681,7 +681,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -695,7 +695,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -709,7 +709,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -723,7 +723,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -737,7 +737,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -751,7 +751,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -765,7 +765,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -779,7 +779,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -793,7 +793,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -807,7 +807,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -821,7 +821,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -835,7 +835,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -849,7 +849,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -863,7 +863,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -877,7 +877,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -891,7 +891,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -905,7 +905,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -919,7 +919,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -933,7 +933,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -947,7 +947,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -961,7 +961,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -975,7 +975,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -989,7 +989,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1003,7 +1003,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1017,7 +1017,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1031,7 +1031,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1045,7 +1045,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1059,7 +1059,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1073,7 +1073,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1087,7 +1087,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1101,7 +1101,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1115,7 +1115,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1129,7 +1129,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1143,7 +1143,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1157,7 +1157,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1171,7 +1171,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1185,7 +1185,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1199,7 +1199,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1213,7 +1213,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1227,7 +1227,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1241,7 +1241,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1255,7 +1255,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1269,7 +1269,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1283,7 +1283,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1297,7 +1297,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1311,7 +1311,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1325,7 +1325,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1339,7 +1339,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1353,7 +1353,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1367,7 +1367,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1381,7 +1381,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1395,7 +1395,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1409,7 +1409,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1423,7 +1423,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1437,7 +1437,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1451,7 +1451,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1465,7 +1465,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1479,7 +1479,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1493,7 +1493,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1507,7 +1507,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1521,7 +1521,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1535,7 +1535,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1549,7 +1549,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1563,7 +1563,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1577,7 +1577,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1591,7 +1591,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1605,7 +1605,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1619,7 +1619,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1633,7 +1633,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1647,7 +1647,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1661,7 +1661,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1675,7 +1675,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1689,7 +1689,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1703,7 +1703,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1717,7 +1717,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1731,7 +1731,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1745,7 +1745,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1759,7 +1759,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1773,7 +1773,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1787,7 +1787,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1801,7 +1801,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1815,7 +1815,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1829,7 +1829,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1843,7 +1843,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1857,7 +1857,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1871,7 +1871,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1885,7 +1885,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1899,7 +1899,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1913,7 +1913,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1927,7 +1927,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1941,7 +1941,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1955,7 +1955,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1969,7 +1969,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1983,7 +1983,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1997,7 +1997,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2011,7 +2011,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2025,7 +2025,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2039,7 +2039,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2053,7 +2053,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2067,7 +2067,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2081,7 +2081,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2095,7 +2095,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2109,7 +2109,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2123,7 +2123,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2137,7 +2137,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2151,7 +2151,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2165,7 +2165,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2179,7 +2179,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2193,7 +2193,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2207,7 +2207,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2221,7 +2221,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2235,7 +2235,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2249,7 +2249,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2263,7 +2263,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2277,7 +2277,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2291,7 +2291,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2305,7 +2305,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2319,7 +2319,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2333,7 +2333,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2347,7 +2347,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2361,7 +2361,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2375,7 +2375,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2389,7 +2389,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2403,7 +2403,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2417,7 +2417,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2431,7 +2431,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2445,7 +2445,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2459,7 +2459,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2473,7 +2473,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2487,7 +2487,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2501,7 +2501,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2515,7 +2515,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2529,7 +2529,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2543,7 +2543,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2557,7 +2557,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2571,7 +2571,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2585,7 +2585,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2599,7 +2599,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2613,7 +2613,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2627,7 +2627,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2641,7 +2641,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2655,7 +2655,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2669,7 +2669,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2683,7 +2683,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2697,7 +2697,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2711,7 +2711,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2725,7 +2725,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2739,7 +2739,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2753,7 +2753,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2767,7 +2767,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2781,7 +2781,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2795,7 +2795,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2809,7 +2809,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2823,7 +2823,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2837,7 +2837,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2851,7 +2851,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2865,7 +2865,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2879,7 +2879,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2893,7 +2893,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2907,7 +2907,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2921,7 +2921,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2935,7 +2935,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2949,7 +2949,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2963,7 +2963,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2977,7 +2977,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2991,7 +2991,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3005,7 +3005,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3019,7 +3019,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3033,7 +3033,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3047,7 +3047,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3061,7 +3061,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3075,7 +3075,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3089,7 +3089,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3103,7 +3103,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3117,7 +3117,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3131,7 +3131,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3145,7 +3145,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3159,7 +3159,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3173,7 +3173,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3187,7 +3187,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3201,7 +3201,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3215,7 +3215,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3229,7 +3229,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3243,7 +3243,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3257,7 +3257,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3271,7 +3271,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3285,7 +3285,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3299,7 +3299,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3313,7 +3313,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3327,7 +3327,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3341,7 +3341,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3355,7 +3355,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3369,7 +3369,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3383,7 +3383,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3397,7 +3397,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3411,7 +3411,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3425,7 +3425,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3439,7 +3439,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3453,7 +3453,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3467,7 +3467,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3481,7 +3481,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3495,7 +3495,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3509,7 +3509,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3523,7 +3523,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3537,7 +3537,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3551,7 +3551,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3565,7 +3565,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3579,7 +3579,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3593,7 +3593,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3607,7 +3607,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3621,7 +3621,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3635,7 +3635,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3649,7 +3649,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3663,7 +3663,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3677,7 +3677,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3691,7 +3691,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3705,7 +3705,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3719,7 +3719,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3733,7 +3733,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3747,7 +3747,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3761,7 +3761,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3775,7 +3775,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3789,7 +3789,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3803,7 +3803,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3817,7 +3817,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3831,7 +3831,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3845,7 +3845,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3859,7 +3859,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3873,7 +3873,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3887,7 +3887,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3901,7 +3901,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3915,7 +3915,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3929,7 +3929,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3943,7 +3943,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3957,7 +3957,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3971,7 +3971,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3985,7 +3985,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3999,7 +3999,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4013,7 +4013,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4027,7 +4027,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4041,7 +4041,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4055,7 +4055,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4069,7 +4069,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4083,7 +4083,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4097,7 +4097,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4111,7 +4111,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4125,7 +4125,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4139,7 +4139,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4153,7 +4153,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4167,7 +4167,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4181,7 +4181,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4195,7 +4195,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4209,7 +4209,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4223,7 +4223,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4237,7 +4237,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4251,7 +4251,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4265,7 +4265,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4279,7 +4279,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4293,7 +4293,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4307,7 +4307,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4321,7 +4321,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4335,7 +4335,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4349,7 +4349,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4363,7 +4363,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4377,7 +4377,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4391,7 +4391,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4405,7 +4405,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4419,7 +4419,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4433,7 +4433,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4447,7 +4447,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4461,7 +4461,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4475,7 +4475,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4489,7 +4489,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4503,7 +4503,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4517,7 +4517,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4531,7 +4531,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4545,7 +4545,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4559,7 +4559,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4573,7 +4573,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4587,7 +4587,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4601,7 +4601,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4615,7 +4615,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4629,7 +4629,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4643,7 +4643,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4657,7 +4657,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4671,7 +4671,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4685,7 +4685,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4699,7 +4699,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4713,7 +4713,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4727,7 +4727,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4741,7 +4741,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4755,7 +4755,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4769,7 +4769,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4783,7 +4783,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4797,7 +4797,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4811,7 +4811,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4825,7 +4825,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4839,7 +4839,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4853,7 +4853,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4867,7 +4867,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4881,7 +4881,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4895,7 +4895,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4909,7 +4909,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4923,7 +4923,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4937,7 +4937,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4951,7 +4951,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4965,7 +4965,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4979,7 +4979,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4993,7 +4993,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5007,7 +5007,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5021,7 +5021,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5035,7 +5035,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5049,7 +5049,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5063,7 +5063,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5077,7 +5077,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5091,7 +5091,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5105,7 +5105,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5119,7 +5119,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5133,7 +5133,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5147,7 +5147,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5161,7 +5161,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5175,7 +5175,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5189,7 +5189,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5203,7 +5203,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5217,7 +5217,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5231,7 +5231,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5245,7 +5245,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5259,7 +5259,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5273,7 +5273,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5287,7 +5287,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5301,7 +5301,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5315,7 +5315,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5329,7 +5329,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5343,7 +5343,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5357,7 +5357,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5371,7 +5371,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5385,7 +5385,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5399,7 +5399,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5413,7 +5413,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5427,7 +5427,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5441,7 +5441,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5455,7 +5455,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5469,7 +5469,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5483,7 +5483,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5497,7 +5497,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5511,7 +5511,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5525,7 +5525,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5539,7 +5539,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5553,7 +5553,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5567,7 +5567,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5581,7 +5581,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5595,7 +5595,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5609,7 +5609,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5623,7 +5623,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5637,7 +5637,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5651,7 +5651,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5665,7 +5665,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5679,7 +5679,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""

--- a/locales/pl-PL/pl-PL.json
+++ b/locales/pl-PL/pl-PL.json
@@ -9,7 +9,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -23,7 +23,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -37,7 +37,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -51,7 +51,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -65,7 +65,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -79,7 +79,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -93,7 +93,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -107,7 +107,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -121,7 +121,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -135,7 +135,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -149,7 +149,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -163,7 +163,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -177,7 +177,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -191,7 +191,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -205,7 +205,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -219,7 +219,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -233,7 +233,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -247,7 +247,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -261,7 +261,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -275,7 +275,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -289,7 +289,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -303,7 +303,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -317,7 +317,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -331,7 +331,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -345,7 +345,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -359,7 +359,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -373,7 +373,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -387,7 +387,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -401,7 +401,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -415,7 +415,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -429,7 +429,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -443,7 +443,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -457,7 +457,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -471,7 +471,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -485,7 +485,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -499,7 +499,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -513,7 +513,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -527,7 +527,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -541,7 +541,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -555,7 +555,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -569,7 +569,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -583,7 +583,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -597,7 +597,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -611,7 +611,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -625,7 +625,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -639,7 +639,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -653,7 +653,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -667,7 +667,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -681,7 +681,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -695,7 +695,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -709,7 +709,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -723,7 +723,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -737,7 +737,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -751,7 +751,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -765,7 +765,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -779,7 +779,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -793,7 +793,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -807,7 +807,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -821,7 +821,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -835,7 +835,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -849,7 +849,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -863,7 +863,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -877,7 +877,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -891,7 +891,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -905,7 +905,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -919,7 +919,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -933,7 +933,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -947,7 +947,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -961,7 +961,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -975,7 +975,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -989,7 +989,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1003,7 +1003,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1017,7 +1017,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1031,7 +1031,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1045,7 +1045,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1059,7 +1059,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1073,7 +1073,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1087,7 +1087,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1101,7 +1101,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1115,7 +1115,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1129,7 +1129,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1143,7 +1143,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1157,7 +1157,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1171,7 +1171,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1185,7 +1185,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1199,7 +1199,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1213,7 +1213,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1227,7 +1227,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1241,7 +1241,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1255,7 +1255,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1269,7 +1269,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1283,7 +1283,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1297,7 +1297,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1311,7 +1311,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1325,7 +1325,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1339,7 +1339,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1353,7 +1353,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1367,7 +1367,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1381,7 +1381,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1395,7 +1395,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1409,7 +1409,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1423,7 +1423,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1437,7 +1437,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1451,7 +1451,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1465,7 +1465,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1479,7 +1479,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1493,7 +1493,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1507,7 +1507,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1521,7 +1521,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1535,7 +1535,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1549,7 +1549,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1563,7 +1563,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1577,7 +1577,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1591,7 +1591,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1605,7 +1605,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1619,7 +1619,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1633,7 +1633,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1647,7 +1647,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1661,7 +1661,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1675,7 +1675,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1689,7 +1689,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1703,7 +1703,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1717,7 +1717,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1731,7 +1731,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1745,7 +1745,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1759,7 +1759,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1773,7 +1773,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1787,7 +1787,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1801,7 +1801,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1815,7 +1815,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1829,7 +1829,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1843,7 +1843,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1857,7 +1857,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1871,7 +1871,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1885,7 +1885,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1899,7 +1899,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1913,7 +1913,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1927,7 +1927,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1941,7 +1941,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1955,7 +1955,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1969,7 +1969,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1983,7 +1983,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1997,7 +1997,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2011,7 +2011,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2025,7 +2025,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2039,7 +2039,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2053,7 +2053,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2067,7 +2067,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2081,7 +2081,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2095,7 +2095,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2109,7 +2109,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2123,7 +2123,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2137,7 +2137,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2151,7 +2151,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2165,7 +2165,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2179,7 +2179,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2193,7 +2193,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2207,7 +2207,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2221,7 +2221,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2235,7 +2235,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2249,7 +2249,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2263,7 +2263,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2277,7 +2277,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2291,7 +2291,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2305,7 +2305,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2319,7 +2319,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2333,7 +2333,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2347,7 +2347,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2361,7 +2361,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2375,7 +2375,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2389,7 +2389,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2403,7 +2403,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2417,7 +2417,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2431,7 +2431,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2445,7 +2445,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2459,7 +2459,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2473,7 +2473,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2487,7 +2487,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2501,7 +2501,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2515,7 +2515,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2529,7 +2529,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2543,7 +2543,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2557,7 +2557,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2571,7 +2571,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2585,7 +2585,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2599,7 +2599,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2613,7 +2613,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2627,7 +2627,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2641,7 +2641,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2655,7 +2655,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2669,7 +2669,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2683,7 +2683,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2697,7 +2697,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2711,7 +2711,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2725,7 +2725,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2739,7 +2739,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2753,7 +2753,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2767,7 +2767,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2781,7 +2781,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2795,7 +2795,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2809,7 +2809,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2823,7 +2823,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2837,7 +2837,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2851,7 +2851,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2865,7 +2865,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2879,7 +2879,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2893,7 +2893,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2907,7 +2907,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2921,7 +2921,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2935,7 +2935,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2949,7 +2949,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2963,7 +2963,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2977,7 +2977,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2991,7 +2991,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3005,7 +3005,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3019,7 +3019,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3033,7 +3033,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3047,7 +3047,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3061,7 +3061,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3075,7 +3075,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3089,7 +3089,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3103,7 +3103,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3117,7 +3117,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3131,7 +3131,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3145,7 +3145,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3159,7 +3159,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3173,7 +3173,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3187,7 +3187,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3201,7 +3201,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3215,7 +3215,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3229,7 +3229,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3243,7 +3243,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3257,7 +3257,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3271,7 +3271,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3285,7 +3285,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3299,7 +3299,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3313,7 +3313,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3327,7 +3327,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3341,7 +3341,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3355,7 +3355,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3369,7 +3369,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3383,7 +3383,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3397,7 +3397,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3411,7 +3411,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3425,7 +3425,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3439,7 +3439,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3453,7 +3453,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3467,7 +3467,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3481,7 +3481,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3495,7 +3495,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3509,7 +3509,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3523,7 +3523,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3537,7 +3537,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3551,7 +3551,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3565,7 +3565,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3579,7 +3579,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3593,7 +3593,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3607,7 +3607,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3621,7 +3621,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3635,7 +3635,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3649,7 +3649,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3663,7 +3663,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3677,7 +3677,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3691,7 +3691,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3705,7 +3705,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3719,7 +3719,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3733,7 +3733,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3747,7 +3747,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3761,7 +3761,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3775,7 +3775,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3789,7 +3789,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3803,7 +3803,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3817,7 +3817,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3831,7 +3831,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3845,7 +3845,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3859,7 +3859,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3873,7 +3873,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3887,7 +3887,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3901,7 +3901,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3915,7 +3915,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3929,7 +3929,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3943,7 +3943,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3957,7 +3957,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3971,7 +3971,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3985,7 +3985,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3999,7 +3999,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4013,7 +4013,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4027,7 +4027,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4041,7 +4041,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4055,7 +4055,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4069,7 +4069,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4083,7 +4083,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4097,7 +4097,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4111,7 +4111,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4125,7 +4125,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4139,7 +4139,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4153,7 +4153,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4167,7 +4167,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4181,7 +4181,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4195,7 +4195,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4209,7 +4209,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4223,7 +4223,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4237,7 +4237,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4251,7 +4251,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4265,7 +4265,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4279,7 +4279,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4293,7 +4293,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4307,7 +4307,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4321,7 +4321,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4335,7 +4335,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4349,7 +4349,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4363,7 +4363,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4377,7 +4377,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4391,7 +4391,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4405,7 +4405,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4419,7 +4419,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4433,7 +4433,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4447,7 +4447,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4461,7 +4461,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4475,7 +4475,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4489,7 +4489,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4503,7 +4503,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4517,7 +4517,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4531,7 +4531,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4545,7 +4545,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4559,7 +4559,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4573,7 +4573,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4587,7 +4587,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4601,7 +4601,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4615,7 +4615,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4629,7 +4629,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4643,7 +4643,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4657,7 +4657,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4671,7 +4671,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4685,7 +4685,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4699,7 +4699,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4713,7 +4713,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4727,7 +4727,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4741,7 +4741,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4755,7 +4755,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4769,7 +4769,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4783,7 +4783,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4797,7 +4797,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4811,7 +4811,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4825,7 +4825,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4839,7 +4839,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4853,7 +4853,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4867,7 +4867,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4881,7 +4881,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4895,7 +4895,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4909,7 +4909,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4923,7 +4923,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4937,7 +4937,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4951,7 +4951,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4965,7 +4965,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4979,7 +4979,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4993,7 +4993,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5007,7 +5007,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5021,7 +5021,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5035,7 +5035,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5049,7 +5049,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5063,7 +5063,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5077,7 +5077,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5091,7 +5091,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5105,7 +5105,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5119,7 +5119,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5133,7 +5133,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5147,7 +5147,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5161,7 +5161,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5175,7 +5175,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5189,7 +5189,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5203,7 +5203,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5217,7 +5217,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5231,7 +5231,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5245,7 +5245,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5259,7 +5259,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5273,7 +5273,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5287,7 +5287,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5301,7 +5301,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5315,7 +5315,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5329,7 +5329,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5343,7 +5343,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5357,7 +5357,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5371,7 +5371,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5385,7 +5385,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5399,7 +5399,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5413,7 +5413,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5427,7 +5427,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5441,7 +5441,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5455,7 +5455,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5469,7 +5469,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5483,7 +5483,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5497,7 +5497,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5511,7 +5511,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5525,7 +5525,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5539,7 +5539,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5553,7 +5553,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5567,7 +5567,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5581,7 +5581,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5595,7 +5595,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5609,7 +5609,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5623,7 +5623,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5637,7 +5637,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5651,7 +5651,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5665,7 +5665,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5679,7 +5679,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""

--- a/locales/pt-BR/pt-BR.json
+++ b/locales/pt-BR/pt-BR.json
@@ -9,7 +9,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -23,7 +23,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -37,7 +37,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -51,7 +51,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -65,7 +65,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -79,7 +79,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -93,7 +93,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -107,7 +107,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -121,7 +121,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -135,7 +135,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -149,7 +149,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -163,7 +163,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -177,7 +177,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -191,7 +191,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -205,7 +205,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -219,7 +219,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -233,7 +233,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -247,7 +247,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -261,7 +261,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -275,7 +275,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -289,7 +289,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -303,7 +303,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -317,7 +317,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -331,7 +331,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -345,7 +345,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -359,7 +359,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -373,7 +373,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -387,7 +387,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -401,7 +401,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -415,7 +415,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -429,7 +429,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -443,7 +443,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -457,7 +457,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -471,7 +471,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -485,7 +485,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -499,7 +499,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -513,7 +513,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -527,7 +527,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -541,7 +541,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -555,7 +555,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -569,7 +569,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -583,7 +583,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -597,7 +597,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -611,7 +611,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -625,7 +625,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -639,7 +639,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -653,7 +653,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -667,7 +667,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -681,7 +681,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -695,7 +695,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -709,7 +709,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -723,7 +723,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -737,7 +737,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -751,7 +751,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -765,7 +765,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -779,7 +779,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -793,7 +793,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -807,7 +807,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -821,7 +821,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -835,7 +835,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -849,7 +849,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -863,7 +863,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -877,7 +877,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -891,7 +891,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -905,7 +905,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -919,7 +919,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -933,7 +933,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -947,7 +947,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -961,7 +961,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -975,7 +975,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -989,7 +989,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1003,7 +1003,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1017,7 +1017,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1031,7 +1031,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1045,7 +1045,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1059,7 +1059,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1073,7 +1073,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1087,7 +1087,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1101,7 +1101,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1115,7 +1115,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1129,7 +1129,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1143,7 +1143,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1157,7 +1157,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1171,7 +1171,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1185,7 +1185,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1199,7 +1199,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1213,7 +1213,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1227,7 +1227,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1241,7 +1241,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1255,7 +1255,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1269,7 +1269,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1283,7 +1283,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1297,7 +1297,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1311,7 +1311,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1325,7 +1325,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1339,7 +1339,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1353,7 +1353,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1367,7 +1367,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1381,7 +1381,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1395,7 +1395,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1409,7 +1409,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1423,7 +1423,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1437,7 +1437,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1451,7 +1451,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1465,7 +1465,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1479,7 +1479,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1493,7 +1493,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1507,7 +1507,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1521,7 +1521,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1535,7 +1535,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1549,7 +1549,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1563,7 +1563,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1577,7 +1577,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1591,7 +1591,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1605,7 +1605,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1619,7 +1619,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1633,7 +1633,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1647,7 +1647,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1661,7 +1661,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1675,7 +1675,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1689,7 +1689,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1703,7 +1703,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1717,7 +1717,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1731,7 +1731,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1745,7 +1745,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1759,7 +1759,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1773,7 +1773,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1787,7 +1787,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1801,7 +1801,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1815,7 +1815,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1829,7 +1829,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1843,7 +1843,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1857,7 +1857,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1871,7 +1871,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1885,7 +1885,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1899,7 +1899,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1913,7 +1913,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1927,7 +1927,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1941,7 +1941,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1955,7 +1955,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1969,7 +1969,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1983,7 +1983,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1997,7 +1997,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2011,7 +2011,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2025,7 +2025,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2039,7 +2039,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2053,7 +2053,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2067,7 +2067,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2081,7 +2081,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2095,7 +2095,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2109,7 +2109,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2123,7 +2123,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2137,7 +2137,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2151,7 +2151,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2165,7 +2165,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2179,7 +2179,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2193,7 +2193,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2207,7 +2207,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2221,7 +2221,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2235,7 +2235,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2249,7 +2249,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2263,7 +2263,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2277,7 +2277,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2291,7 +2291,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2305,7 +2305,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2319,7 +2319,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2333,7 +2333,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2347,7 +2347,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2361,7 +2361,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2375,7 +2375,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2389,7 +2389,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2403,7 +2403,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2417,7 +2417,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2431,7 +2431,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2445,7 +2445,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2459,7 +2459,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2473,7 +2473,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2487,7 +2487,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2501,7 +2501,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2515,7 +2515,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2529,7 +2529,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2543,7 +2543,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2557,7 +2557,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2571,7 +2571,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2585,7 +2585,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2599,7 +2599,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2613,7 +2613,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2627,7 +2627,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2641,7 +2641,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2655,7 +2655,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2669,7 +2669,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2683,7 +2683,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2697,7 +2697,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2711,7 +2711,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2725,7 +2725,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2739,7 +2739,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2753,7 +2753,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2767,7 +2767,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2781,7 +2781,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2795,7 +2795,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2809,7 +2809,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2823,7 +2823,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2837,7 +2837,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2851,7 +2851,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2865,7 +2865,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2879,7 +2879,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2893,7 +2893,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2907,7 +2907,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2921,7 +2921,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2935,7 +2935,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2949,7 +2949,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2963,7 +2963,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2977,7 +2977,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2991,7 +2991,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3005,7 +3005,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3019,7 +3019,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3033,7 +3033,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3047,7 +3047,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3061,7 +3061,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3075,7 +3075,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3089,7 +3089,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3103,7 +3103,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3117,7 +3117,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3131,7 +3131,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3145,7 +3145,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3159,7 +3159,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3173,7 +3173,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3187,7 +3187,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3201,7 +3201,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3215,7 +3215,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3229,7 +3229,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3243,7 +3243,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3257,7 +3257,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3271,7 +3271,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3285,7 +3285,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3299,7 +3299,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3313,7 +3313,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3327,7 +3327,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3341,7 +3341,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3355,7 +3355,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3369,7 +3369,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3383,7 +3383,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3397,7 +3397,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3411,7 +3411,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3425,7 +3425,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3439,7 +3439,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3453,7 +3453,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3467,7 +3467,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3481,7 +3481,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3495,7 +3495,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3509,7 +3509,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3523,7 +3523,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3537,7 +3537,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3551,7 +3551,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3565,7 +3565,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3579,7 +3579,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3593,7 +3593,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3607,7 +3607,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3621,7 +3621,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3635,7 +3635,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3649,7 +3649,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3663,7 +3663,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3677,7 +3677,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3691,7 +3691,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3705,7 +3705,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3719,7 +3719,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3733,7 +3733,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3747,7 +3747,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3761,7 +3761,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3775,7 +3775,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3789,7 +3789,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3803,7 +3803,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3817,7 +3817,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3831,7 +3831,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3845,7 +3845,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3859,7 +3859,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3873,7 +3873,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3887,7 +3887,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3901,7 +3901,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3915,7 +3915,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3929,7 +3929,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3943,7 +3943,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3957,7 +3957,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3971,7 +3971,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3985,7 +3985,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3999,7 +3999,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4013,7 +4013,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4027,7 +4027,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4041,7 +4041,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4055,7 +4055,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4069,7 +4069,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4083,7 +4083,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4097,7 +4097,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4111,7 +4111,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4125,7 +4125,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4139,7 +4139,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4153,7 +4153,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4167,7 +4167,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4181,7 +4181,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4195,7 +4195,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4209,7 +4209,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4223,7 +4223,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4237,7 +4237,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4251,7 +4251,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4265,7 +4265,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4279,7 +4279,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4293,7 +4293,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4307,7 +4307,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4321,7 +4321,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4335,7 +4335,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4349,7 +4349,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4363,7 +4363,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4377,7 +4377,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4391,7 +4391,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4405,7 +4405,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4419,7 +4419,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4433,7 +4433,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4447,7 +4447,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4461,7 +4461,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4475,7 +4475,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4489,7 +4489,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4503,7 +4503,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4517,7 +4517,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4531,7 +4531,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4545,7 +4545,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4559,7 +4559,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4573,7 +4573,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4587,7 +4587,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4601,7 +4601,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4615,7 +4615,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4629,7 +4629,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4643,7 +4643,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4657,7 +4657,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4671,7 +4671,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4685,7 +4685,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4699,7 +4699,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4713,7 +4713,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4727,7 +4727,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4741,7 +4741,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4755,7 +4755,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4769,7 +4769,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4783,7 +4783,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4797,7 +4797,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4811,7 +4811,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4825,7 +4825,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4839,7 +4839,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4853,7 +4853,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4867,7 +4867,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4881,7 +4881,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4895,7 +4895,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4909,7 +4909,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4923,7 +4923,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4937,7 +4937,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4951,7 +4951,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4965,7 +4965,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4979,7 +4979,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4993,7 +4993,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5007,7 +5007,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5021,7 +5021,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5035,7 +5035,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5049,7 +5049,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5063,7 +5063,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5077,7 +5077,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5091,7 +5091,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5105,7 +5105,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5119,7 +5119,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5133,7 +5133,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5147,7 +5147,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5161,7 +5161,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5175,7 +5175,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5189,7 +5189,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5203,7 +5203,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5217,7 +5217,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5231,7 +5231,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5245,7 +5245,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5259,7 +5259,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5273,7 +5273,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5287,7 +5287,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5301,7 +5301,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5315,7 +5315,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5329,7 +5329,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5343,7 +5343,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5357,7 +5357,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5371,7 +5371,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5385,7 +5385,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5399,7 +5399,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5413,7 +5413,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5427,7 +5427,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5441,7 +5441,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5455,7 +5455,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5469,7 +5469,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5483,7 +5483,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5497,7 +5497,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5511,7 +5511,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5525,7 +5525,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5539,7 +5539,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5553,7 +5553,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5567,7 +5567,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5581,7 +5581,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5595,7 +5595,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5609,7 +5609,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5623,7 +5623,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5637,7 +5637,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5651,7 +5651,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5665,7 +5665,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5679,7 +5679,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""

--- a/locales/ro-RO/ro-RO.json
+++ b/locales/ro-RO/ro-RO.json
@@ -9,7 +9,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -23,7 +23,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -37,7 +37,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -51,7 +51,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -65,7 +65,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -79,7 +79,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -93,7 +93,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -107,7 +107,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/absolute-advantage",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/absolute-advantage",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -121,7 +121,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -135,7 +135,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -149,7 +149,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/active-management",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/active-management",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -163,7 +163,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/actively-validated-services-avs",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/actively-validated-services-avs",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -177,7 +177,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/ad-hoc",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/ad-hoc",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -191,7 +191,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/address",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/address",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -205,7 +205,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -219,7 +219,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -233,7 +233,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -247,7 +247,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/airdrop",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/airdrop",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -261,7 +261,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -275,7 +275,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -289,7 +289,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/algorithm",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/algorithm",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -303,7 +303,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/all-or-none-order",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/all-or-none-order",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -317,7 +317,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/all-time-high",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/all-time-high",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -331,7 +331,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/allocation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/allocation",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -345,7 +345,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/alpha",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/alpha",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -359,7 +359,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/altcoin",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/altcoin",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -373,7 +373,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -387,7 +387,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/angel-investor",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/angel-investor",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -401,7 +401,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/anti-money-laundering",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/anti-money-laundering",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -415,7 +415,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -429,7 +429,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -443,7 +443,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -457,7 +457,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/application-programming-interface",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/application-programming-interface",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -471,7 +471,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/application-specific-integrated-circuit",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/application-specific-integrated-circuit",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -485,7 +485,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/arbitrage",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/arbitrage",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -499,7 +499,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -513,7 +513,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/arc-20",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/arc-20",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -527,7 +527,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/artificial-intelligence-ai",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/artificial-intelligence-ai",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -541,7 +541,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -555,7 +555,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/asic-resistant",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/asic-resistant",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -569,7 +569,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/asking-price",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/asking-price",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -583,7 +583,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/asset-management",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/asset-management",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -597,7 +597,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -611,7 +611,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/assets-under-management-aum",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/assets-under-management-aum",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -625,7 +625,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/asynchronous",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/asynchronous",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -639,7 +639,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/atomic-swap",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/atomic-swap",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -653,7 +653,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/attack-surface",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/attack-surface",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -667,7 +667,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -681,7 +681,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/auction",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/auction",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -695,7 +695,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -709,7 +709,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/automated-market-maker-amm",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/automated-market-maker-amm",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -723,7 +723,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -737,7 +737,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -751,7 +751,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -765,7 +765,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/b-tokens",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/b-tokens",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -779,7 +779,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/bags",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/bags",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -793,7 +793,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -807,7 +807,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/beacon-chain",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/beacon-chain",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -821,7 +821,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/bear-market",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/bear-market",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -835,7 +835,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/benchmark",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/benchmark",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -849,7 +849,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/bep-1155",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/bep-1155",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -863,7 +863,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/bep-20",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/bep-20",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -877,7 +877,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/bep-721",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/bep-721",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -891,7 +891,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/bep-95",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/bep-95",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -905,7 +905,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -919,7 +919,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/beta-coefficient",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/beta-coefficient",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -933,7 +933,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/beta-release",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/beta-release",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -947,7 +947,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/bid-ask-spread",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/bid-ask-spread",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -961,7 +961,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/bid-price",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/bid-price",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -975,7 +975,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -989,7 +989,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/binance-blockchain-charity-foundation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/binance-blockchain-charity-foundation",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -1003,7 +1003,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/binance-ecosystem-fund",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/binance-ecosystem-fund",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -1017,7 +1017,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/binancian",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/binancian",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -1031,7 +1031,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/bitcoin",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/bitcoin",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -1045,7 +1045,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/bitcoin-core",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/bitcoin-core",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -1059,7 +1059,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/bitcoin-dominance",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/bitcoin-dominance",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -1073,7 +1073,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/bitcoin-maximalists",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/bitcoin-maximalists",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -1087,7 +1087,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/bitcoin-pizza",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/bitcoin-pizza",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -1101,7 +1101,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/black-swan-event",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/black-swan-event",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -1115,7 +1115,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/block",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/block",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -1129,7 +1129,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/block-explorer",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/block-explorer",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -1143,7 +1143,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/block-header",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/block-header",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -1157,7 +1157,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/block-height",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/block-height",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -1171,7 +1171,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/block-reward",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/block-reward",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -1185,7 +1185,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1199,7 +1199,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1213,7 +1213,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/blockchain",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/blockchain",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -1227,7 +1227,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1241,7 +1241,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1255,7 +1255,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/bloom-filter",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/bloom-filter",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -1269,7 +1269,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/blue-chip-token",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/blue-chip-token",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -1283,7 +1283,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/bnb",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/bnb",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -1297,7 +1297,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1311,7 +1311,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/bnsol",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/bnsol",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -1325,7 +1325,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/bollinger-bands",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/bollinger-bands",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -1339,7 +1339,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/bond",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/bond",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -1353,7 +1353,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/bounty",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/bounty",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -1367,7 +1367,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1381,7 +1381,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1395,7 +1395,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/brc-20-tokens",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/brc-20-tokens",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -1409,7 +1409,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/break-even-point",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/break-even-point",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -1423,7 +1423,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/breakeven-multiple",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/breakeven-multiple",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -1437,7 +1437,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/breakout",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/breakout",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -1451,7 +1451,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1465,7 +1465,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/bscscan",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/bscscan",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -1479,7 +1479,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1493,7 +1493,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/btc-wallet-address",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/btc-wallet-address",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -1507,7 +1507,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/buidl",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/buidl",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -1521,7 +1521,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/bull-market",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/bull-market",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -1535,7 +1535,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/burner-wallet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/burner-wallet",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -1549,7 +1549,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/buy-wall",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/buy-wall",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -1563,7 +1563,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1577,7 +1577,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1591,7 +1591,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1605,7 +1605,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/candidate-block",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/candidate-block",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -1619,7 +1619,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/candlestick",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/candlestick",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -1633,7 +1633,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/capitulation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/capitulation",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -1647,7 +1647,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1661,7 +1661,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/censorship-resistance",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/censorship-resistance",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -1675,7 +1675,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/central-bank",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/central-bank",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -1689,7 +1689,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/central-bank-digital-currency-cbdc",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/central-bank-digital-currency-cbdc",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -1703,7 +1703,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/central-processing-unit",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/central-processing-unit",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -1717,7 +1717,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/centralized",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/centralized",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -1731,7 +1731,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/centralized-exchange",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/centralized-exchange",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -1745,7 +1745,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1759,7 +1759,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1773,7 +1773,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/chatgpt",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/chatgpt",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -1787,7 +1787,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1801,7 +1801,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/cipher",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/cipher",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -1815,7 +1815,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/circulating-supply",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/circulating-supply",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -1829,7 +1829,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1843,7 +1843,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/cloud",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/cloud",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -1857,7 +1857,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1871,7 +1871,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/coin",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/coin",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -1885,7 +1885,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1899,7 +1899,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1913,7 +1913,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/cold-storage",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/cold-storage",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -1927,7 +1927,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1941,7 +1941,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/collateral",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/collateral",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -1955,7 +1955,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/colocation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/colocation",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -1969,7 +1969,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/commodity-futures-trading-commission",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/commodity-futures-trading-commission",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -1983,7 +1983,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1997,7 +1997,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2011,7 +2011,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/compound-interest",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/compound-interest",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -2025,7 +2025,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2039,7 +2039,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/confirmation-time",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/confirmation-time",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -2053,7 +2053,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/confluence",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/confluence",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -2067,7 +2067,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2081,7 +2081,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/consensus-algorithm",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/consensus-algorithm",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -2095,7 +2095,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2109,7 +2109,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2123,7 +2123,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2137,7 +2137,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2151,7 +2151,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2165,7 +2165,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/consumer-price-index-(cpi)",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/consumer-price-index-(cpi)",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -2179,7 +2179,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/contango-and-backwardation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/contango-and-backwardation",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -2193,7 +2193,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2207,7 +2207,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2221,7 +2221,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2235,7 +2235,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/copy-trading",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/copy-trading",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -2249,7 +2249,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/counterparty-risk",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/counterparty-risk",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -2263,7 +2263,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/credentials",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/credentials",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -2277,7 +2277,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/cross-chain-bridges",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/cross-chain-bridges",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -2291,7 +2291,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2305,7 +2305,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2319,7 +2319,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2333,7 +2333,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2347,7 +2347,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/crypto-etfs",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/crypto-etfs",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -2361,7 +2361,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/crypto-fear-and-greed-index",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/crypto-fear-and-greed-index",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -2375,7 +2375,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2389,7 +2389,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/crypto-protocol",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/crypto-protocol",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -2403,7 +2403,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2417,7 +2417,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/crypto-winter",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/crypto-winter",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -2431,7 +2431,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2445,7 +2445,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/cryptocurrency",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/cryptocurrency",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -2459,7 +2459,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2473,7 +2473,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/cryptography",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/cryptography",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -2487,7 +2487,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2501,7 +2501,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/custody",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/custody",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -2515,7 +2515,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2529,7 +2529,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/daemon",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/daemon",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -2543,7 +2543,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2557,7 +2557,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/danksharding",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/danksharding",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -2571,7 +2571,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2585,7 +2585,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2599,7 +2599,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2613,7 +2613,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/dead-cat-bounce",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/dead-cat-bounce",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -2627,7 +2627,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/death-cross",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/death-cross",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -2641,7 +2641,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2655,7 +2655,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/decentralized-application",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/decentralized-application",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -2669,7 +2669,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/decentralized-autonomous-cooperative",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/decentralized-autonomous-cooperative",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -2683,7 +2683,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/decentralized-autonomous-organization",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/decentralized-autonomous-organization",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -2697,7 +2697,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/decentralized-exchange",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/decentralized-exchange",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -2711,7 +2711,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2725,7 +2725,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/decentralized-indexes",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/decentralized-indexes",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -2739,7 +2739,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2753,7 +2753,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/decryption",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/decryption",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -2767,7 +2767,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/deep-web",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/deep-web",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -2781,7 +2781,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2795,7 +2795,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2809,7 +2809,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/delisting",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/delisting",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -2823,7 +2823,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2837,7 +2837,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/depeg",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/depeg",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -2851,7 +2851,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2865,7 +2865,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/depression",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/depression",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -2879,7 +2879,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2893,7 +2893,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/design-flaw-attack",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/design-flaw-attack",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -2907,7 +2907,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2921,7 +2921,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2935,7 +2935,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2949,7 +2949,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2963,7 +2963,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/diamond-hands",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/diamond-hands",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -2977,7 +2977,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/difficulty",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/difficulty",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -2991,7 +2991,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/difficulty-bomb",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/difficulty-bomb",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -3005,7 +3005,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3019,7 +3019,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3033,7 +3033,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/digital-signature",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/digital-signature",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -3047,7 +3047,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3061,7 +3061,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/direct-market-access-dma",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/direct-market-access-dma",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -3075,7 +3075,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3089,7 +3089,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/divergence",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/divergence",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -3103,7 +3103,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/diversification",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/diversification",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -3117,7 +3117,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3131,7 +3131,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/do-your-own-research",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/do-your-own-research",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -3145,7 +3145,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/dollar-cost-averaging",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/dollar-cost-averaging",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -3159,7 +3159,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/dot-plot",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/dot-plot",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -3173,7 +3173,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3187,7 +3187,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/double-spending",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/double-spending",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -3201,7 +3201,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/eclipse-attack",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/eclipse-attack",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -3215,7 +3215,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3229,7 +3229,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3243,7 +3243,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/efficient-market-hypothesis-emh",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/efficient-market-hypothesis-emh",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -3257,7 +3257,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/eigenlayer",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/eigenlayer",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -3271,7 +3271,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/eip",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/eip",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -3285,7 +3285,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3299,7 +3299,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/eip-3074",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/eip-3074",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -3313,7 +3313,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/eip-4844",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/eip-4844",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -3327,7 +3327,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/eip-7251",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/eip-7251",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -3341,7 +3341,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/eip-7702",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/eip-7702",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -3355,7 +3355,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/elasticity",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/elasticity",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -3369,7 +3369,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3383,7 +3383,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/encryption",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/encryption",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -3397,7 +3397,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/endogenous-variable",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/endogenous-variable",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -3411,7 +3411,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3425,7 +3425,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3439,7 +3439,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3453,7 +3453,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3467,7 +3467,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/erc-1155",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/erc-1155",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -3481,7 +3481,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/erc-20",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/erc-20",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -3495,7 +3495,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/erc-404",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/erc-404",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -3509,7 +3509,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/erc-721",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/erc-721",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -3523,7 +3523,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/etf",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/etf",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -3537,7 +3537,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3551,7 +3551,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3565,7 +3565,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3579,7 +3579,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3593,7 +3593,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/ethereum-classic",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/ethereum-classic",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -3607,7 +3607,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/ethereum-foundation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/ethereum-foundation",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -3621,7 +3621,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3635,7 +3635,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3649,7 +3649,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3663,7 +3663,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3677,7 +3677,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/ethereum-virtual-machine-evm",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/ethereum-virtual-machine-evm",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -3691,7 +3691,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3705,7 +3705,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3719,7 +3719,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3733,7 +3733,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/exchange",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/exchange",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -3747,7 +3747,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3761,7 +3761,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3775,7 +3775,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/exogenous-variable",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/exogenous-variable",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -3789,7 +3789,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/exponential-moving-average-ema",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/exponential-moving-average-ema",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -3803,7 +3803,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/externally-owned-account-eoa",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/externally-owned-account-eoa",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -3817,7 +3817,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/fakeout",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/fakeout",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -3831,7 +3831,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/falling-knife",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/falling-knife",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -3845,7 +3845,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/fan-tokens",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/fan-tokens",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -3859,7 +3859,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3873,7 +3873,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3887,7 +3887,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3901,7 +3901,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/fear-of-missing-out",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/fear-of-missing-out",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -3915,7 +3915,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/fear-uncertainty-and-doubt",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/fear-uncertainty-and-doubt",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -3929,7 +3929,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/fiat",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/fiat",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -3943,7 +3943,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3957,7 +3957,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/fibonacci-retracement",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/fibonacci-retracement",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -3971,7 +3971,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/fill-or-kill-order",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/fill-or-kill-order",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -3985,7 +3985,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/finality",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/finality",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -3999,7 +3999,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4013,7 +4013,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4027,7 +4027,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4041,7 +4041,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4055,7 +4055,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4069,7 +4069,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4083,7 +4083,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/first-mover-advantage",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/first-mover-advantage",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -4097,7 +4097,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/fiscal-policy",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/fiscal-policy",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -4111,7 +4111,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/flappening",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/flappening",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -4125,7 +4125,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/flashbots",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/flashbots",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -4139,7 +4139,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/flippening",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/flippening",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -4153,7 +4153,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/flow-variable",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/flow-variable",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -4167,7 +4167,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/forced-liquidation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/forced-liquidation",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -4181,7 +4181,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/forex-fx",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/forex-fx",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -4195,7 +4195,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/fork",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/fork",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -4209,7 +4209,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/formal-verification",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/formal-verification",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -4223,7 +4223,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4237,7 +4237,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/fraud-proof",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/fraud-proof",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -4251,7 +4251,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/fren",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/fren",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -4265,7 +4265,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4279,7 +4279,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/full-node",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/full-node",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -4293,7 +4293,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/fully-diluted-valuation-fdv",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/fully-diluted-valuation-fdv",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -4307,7 +4307,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/fundamental-analysis",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/fundamental-analysis",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -4321,7 +4321,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/funding-fees",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/funding-fees",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -4335,7 +4335,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/fungibility",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/fungibility",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -4349,7 +4349,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/futures-contract",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/futures-contract",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -4363,7 +4363,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/gamefi",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/gamefi",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -4377,7 +4377,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4391,7 +4391,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/gas",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/gas",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -4405,7 +4405,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4419,7 +4419,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/gas-limit",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/gas-limit",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -4433,7 +4433,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4447,7 +4447,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4461,7 +4461,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4475,7 +4475,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/gdp-deflator",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/gdp-deflator",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -4489,7 +4489,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/general-public-license",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/general-public-license",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -4503,7 +4503,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/genesis-block",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/genesis-block",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -4517,7 +4517,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4531,7 +4531,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/github",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/github",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -4545,7 +4545,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/gm-good-morning",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/gm-good-morning",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -4559,7 +4559,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4573,7 +4573,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/golden-cross",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/golden-cross",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -4587,7 +4587,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/golden-ratio",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/golden-ratio",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -4601,7 +4601,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/goldilocks",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/goldilocks",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -4615,7 +4615,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/gossip-protocol",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/gossip-protocol",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -4629,7 +4629,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4643,7 +4643,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/gross-domestic-product-gdp",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/gross-domestic-product-gdp",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -4657,7 +4657,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4671,7 +4671,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/gwei",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/gwei",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -4685,7 +4685,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/hackathon",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/hackathon",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -4699,7 +4699,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/hacker",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/hacker",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -4713,7 +4713,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/haha-money-printer-go-brrrrr",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/haha-money-printer-go-brrrrr",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -4727,7 +4727,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/halving",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/halving",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -4741,7 +4741,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/hard-cap",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/hard-cap",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -4755,7 +4755,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4769,7 +4769,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/hard-landing",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/hard-landing",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -4783,7 +4783,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4797,7 +4797,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4811,7 +4811,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/hash",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/hash",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -4825,7 +4825,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/hash-rate",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/hash-rate",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -4839,7 +4839,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/hashed-timelock-contract",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/hashed-timelock-contract",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -4853,7 +4853,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4867,7 +4867,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/herd-instinct",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/herd-instinct",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -4881,7 +4881,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4895,7 +4895,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/high-frequency-trading-hft",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/high-frequency-trading-hft",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -4909,7 +4909,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/hodl",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/hodl",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -4923,7 +4923,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/honeypot",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/honeypot",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -4937,7 +4937,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4951,7 +4951,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4965,7 +4965,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4979,7 +4979,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4993,7 +4993,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5007,7 +5007,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/iceberg-order",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/iceberg-order",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -5021,7 +5021,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5035,7 +5035,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5049,7 +5049,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/immutability",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/immutability",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -5063,7 +5063,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/index-funds",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/index-funds",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -5077,7 +5077,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5091,7 +5091,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/initial-coin-offering",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/initial-coin-offering",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -5105,7 +5105,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/initial-dex-offering-ido",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/initial-dex-offering-ido",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -5119,7 +5119,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/initial-exchange-offering",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/initial-exchange-offering",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -5133,7 +5133,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/initial-public-offering",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/initial-public-offering",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -5147,7 +5147,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/inscription",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/inscription",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -5161,7 +5161,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5175,7 +5175,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/integrated-circuit",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/integrated-circuit",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -5189,7 +5189,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/interest-rates",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/interest-rates",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -5203,7 +5203,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5217,7 +5217,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/interoperability",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/interoperability",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -5231,7 +5231,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5245,7 +5245,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/interplanetary-file-system-ipfs",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/interplanetary-file-system-ipfs",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -5259,7 +5259,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/iou",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/iou",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -5273,7 +5273,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5287,7 +5287,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5301,7 +5301,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5315,7 +5315,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/isolated-margin",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/isolated-margin",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -5329,7 +5329,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/issuance",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/issuance",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -5343,7 +5343,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5357,7 +5357,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5371,7 +5371,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/keccak",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/keccak",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -5385,7 +5385,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5399,7 +5399,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/know-your-customer",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/know-your-customer",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -5413,7 +5413,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5427,7 +5427,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5441,7 +5441,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5455,7 +5455,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5469,7 +5469,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/laspeyres-index",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/laspeyres-index",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -5483,7 +5483,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/latency",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/latency",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -5497,7 +5497,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5511,7 +5511,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5525,7 +5525,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/law-of-demand",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/law-of-demand",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -5539,7 +5539,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5553,7 +5553,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/layer-2",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/layer-2",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -5567,7 +5567,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/ledger",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/ledger",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -5581,7 +5581,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5595,7 +5595,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5609,7 +5609,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/leveraged-tokens",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/leveraged-tokens",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -5623,7 +5623,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/library",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/library",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -5637,7 +5637,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5651,7 +5651,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5665,7 +5665,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/lightning-network",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/lightning-network",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -5679,7 +5679,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/limit-order",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/limit-order",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -5693,7 +5693,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5707,7 +5707,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/linux",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/linux",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -5721,7 +5721,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/liquid-staking",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/liquid-staking",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -5735,7 +5735,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/liquid-staking-token-lst",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/liquid-staking-token-lst",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -5749,7 +5749,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5763,7 +5763,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/liquidity",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/liquidity",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -5777,7 +5777,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/liquidity-crisis",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/liquidity-crisis",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -5791,7 +5791,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5805,7 +5805,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/liquidity-provider",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/liquidity-provider",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -5819,7 +5819,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/liquidity-ratios",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/liquidity-ratios",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -5833,7 +5833,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5847,7 +5847,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/listing",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/listing",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -5861,7 +5861,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/mainnet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/mainnet",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -5875,7 +5875,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/mainnet-swap",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/mainnet-swap",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -5889,7 +5889,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/maker",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/maker",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -5903,7 +5903,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5917,7 +5917,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/malware",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/malware",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -5931,7 +5931,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/margin-trading",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/margin-trading",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -5945,7 +5945,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5959,7 +5959,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/market-capitalization",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/market-capitalization",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -5973,7 +5973,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/market-momentum",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/market-momentum",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -5987,7 +5987,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/market-order",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/market-order",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -6001,7 +6001,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/masternode",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/masternode",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -6015,7 +6015,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/matching-engine",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/matching-engine",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -6029,7 +6029,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6043,7 +6043,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/maximum-supply",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/maximum-supply",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -6057,7 +6057,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6071,7 +6071,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/mempool",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/mempool",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -6085,7 +6085,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6099,7 +6099,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6113,7 +6113,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/merged-mining",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/merged-mining",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -6127,7 +6127,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6141,7 +6141,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/merkle-tree",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/merkle-tree",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -6155,7 +6155,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6169,7 +6169,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/metadata",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/metadata",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -6183,7 +6183,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6197,7 +6197,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6211,7 +6211,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6225,7 +6225,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6239,7 +6239,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6253,7 +6253,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/metaverse",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/metaverse",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -6267,7 +6267,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6281,7 +6281,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6295,7 +6295,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/microtransactions",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/microtransactions",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -6309,7 +6309,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6323,7 +6323,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6337,7 +6337,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/mining",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/mining",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -6351,7 +6351,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/mining-farm",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/mining-farm",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -6365,7 +6365,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/mint",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/mint",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -6379,7 +6379,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6393,7 +6393,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6407,7 +6407,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6421,7 +6421,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/monetary-policy",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/monetary-policy",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -6435,7 +6435,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/money-markets",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/money-markets",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -6449,7 +6449,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/monitoring-tag",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/monitoring-tag",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -6463,7 +6463,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/moon",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/moon",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -6477,7 +6477,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6491,7 +6491,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/moving-average-envelopes",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/moving-average-envelopes",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -6505,7 +6505,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/moving-average-ribbon",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/moving-average-ribbon",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -6519,7 +6519,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/mt-gox",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/mt-gox",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -6533,7 +6533,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6547,7 +6547,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6561,7 +6561,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/multisignature",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/multisignature",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -6575,7 +6575,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/nakamoto-consensus",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/nakamoto-consensus",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -6589,7 +6589,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6603,7 +6603,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/net-asset-value-nav",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/net-asset-value-nav",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -6617,7 +6617,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6631,7 +6631,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6645,7 +6645,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6659,7 +6659,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6673,7 +6673,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6687,7 +6687,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6701,7 +6701,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/nft-floor-prices",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/nft-floor-prices",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -6715,7 +6715,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/nft-mystery-boxes",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/nft-mystery-boxes",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -6729,7 +6729,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/ngmi",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/ngmi",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -6743,7 +6743,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6757,7 +6757,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/node",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/node",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -6771,7 +6771,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6785,7 +6785,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/non-fungible-token-nft",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/non-fungible-token-nft",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -6799,7 +6799,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/nonce",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/nonce",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -6813,7 +6813,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/oco-order",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/oco-order",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -6827,7 +6827,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/off-chain",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/off-chain",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -6841,7 +6841,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6855,7 +6855,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/offline-signing-orchestrator-oso",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/offline-signing-orchestrator-oso",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -6869,7 +6869,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/offshore-account",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/offshore-account",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -6883,7 +6883,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6897,7 +6897,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/on-chain",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/on-chain",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -6911,7 +6911,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6925,7 +6925,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6939,7 +6939,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/opbnb",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/opbnb",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -6953,7 +6953,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/open-source-software-oss",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/open-source-software-oss",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -6967,7 +6967,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6981,7 +6981,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6995,7 +6995,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/opportunity-cost",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/opportunity-cost",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -7009,7 +7009,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7023,7 +7023,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7037,7 +7037,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/oracle",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/oracle",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -7051,7 +7051,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/orc-20-tokens",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/orc-20-tokens",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -7065,7 +7065,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/order-book",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/order-book",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -7079,7 +7079,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/ordinals",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/ordinals",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -7093,7 +7093,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/orphan-block",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/orphan-block",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -7107,7 +7107,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7121,7 +7121,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7135,7 +7135,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/pancakeswap",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/pancakeswap",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -7149,7 +7149,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/paper-wallet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/paper-wallet",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -7163,7 +7163,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/parallelization",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/parallelization",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -7177,7 +7177,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7191,7 +7191,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7205,7 +7205,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/passive-management",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/passive-management",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -7219,7 +7219,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7233,7 +7233,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7247,7 +7247,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7261,7 +7261,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7275,7 +7275,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/peer-to-peer",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/peer-to-peer",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -7289,7 +7289,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/pegged-currency",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/pegged-currency",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -7303,7 +7303,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7317,7 +7317,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/permissionless-blockchain",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/permissionless-blockchain",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -7331,7 +7331,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/phishing",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/phishing",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -7345,7 +7345,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7359,7 +7359,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/plasma",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/plasma",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -7373,7 +7373,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7387,7 +7387,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/polkadot-crowdloan",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/polkadot-crowdloan",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -7401,7 +7401,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7415,7 +7415,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/ponzi-scheme",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/ponzi-scheme",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -7429,7 +7429,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7443,7 +7443,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7457,7 +7457,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/premining",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/premining",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -7471,7 +7471,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/price-action",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/price-action",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -7485,7 +7485,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/prisoners-dilemma",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/prisoners-dilemma",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -7499,7 +7499,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7513,7 +7513,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7527,7 +7527,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/private-key",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/private-key",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -7541,7 +7541,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/private-sale",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/private-sale",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -7555,7 +7555,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/progressive-web-application",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/progressive-web-application",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -7569,7 +7569,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/proof-of-attendance-protocol-poap",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/proof-of-attendance-protocol-poap",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -7583,7 +7583,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/proof-of-reserves-por",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/proof-of-reserves-por",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -7597,7 +7597,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/proof-of-stake",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/proof-of-stake",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -7611,7 +7611,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/proof-of-staked-authority-posa",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/proof-of-staked-authority-posa",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -7625,7 +7625,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/proof-of-work",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/proof-of-work",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -7639,7 +7639,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/proposer-builder-separation-pbs",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/proposer-builder-separation-pbs",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -7653,7 +7653,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/proto-danksharding",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/proto-danksharding",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -7667,7 +7667,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7681,7 +7681,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/pseudorandom",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/pseudorandom",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -7695,7 +7695,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7709,7 +7709,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7723,7 +7723,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/public-key",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/public-key",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -7737,7 +7737,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7751,7 +7751,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/pump-and-dump",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/pump-and-dump",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -7765,7 +7765,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7779,7 +7779,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/quantitative-easing-qe",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/quantitative-easing-qe",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -7793,7 +7793,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/quantitative-tightening-qt",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/quantitative-tightening-qt",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -7807,7 +7807,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/quantum-computing",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/quantum-computing",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -7821,7 +7821,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7835,7 +7835,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/race-attack",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/race-attack",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -7849,7 +7849,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/ransomware",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/ransomware",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -7863,7 +7863,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7877,7 +7877,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/real-world-assets-rwas",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/real-world-assets-rwas",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -7891,7 +7891,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/recession",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/recession",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -7905,7 +7905,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/recursive-inscription",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/recursive-inscription",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -7919,7 +7919,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/rekt",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/rekt",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -7933,7 +7933,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/relative-strength-index",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/relative-strength-index",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -7947,7 +7947,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7961,7 +7961,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7975,7 +7975,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/resistance",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/resistance",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -7989,7 +7989,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/return-on-investment",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/return-on-investment",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -8003,7 +8003,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/revenge-trading",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/revenge-trading",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -8017,7 +8017,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8031,7 +8031,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/risk-premium",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/risk-premium",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -8045,7 +8045,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/roadmap",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/roadmap",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -8059,7 +8059,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8073,7 +8073,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8087,7 +8087,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8101,7 +8101,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/routing-attack",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/routing-attack",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -8115,7 +8115,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8129,7 +8129,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/rug-pull",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/rug-pull",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -8143,7 +8143,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8157,7 +8157,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/sahm-rule",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/sahm-rule",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -8171,7 +8171,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8185,7 +8185,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8199,7 +8199,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/sandwich-trading",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/sandwich-trading",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -8213,7 +8213,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8227,7 +8227,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/satoshi",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/satoshi",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -8241,7 +8241,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/satoshi-nakamoto",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/satoshi-nakamoto",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -8255,7 +8255,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8269,7 +8269,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8283,7 +8283,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8297,7 +8297,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8311,7 +8311,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8325,7 +8325,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8339,7 +8339,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8353,7 +8353,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/secure-asset-fund-for-users",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/secure-asset-fund-for-users",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -8367,7 +8367,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/securities-and-exchange-commission",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/securities-and-exchange-commission",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -8381,7 +8381,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/security-audit",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/security-audit",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -8395,7 +8395,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8409,7 +8409,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8423,7 +8423,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/security-token-offering-sto",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/security-token-offering-sto",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -8437,7 +8437,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/seed-phrase",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/seed-phrase",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -8451,7 +8451,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/seed-tag",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/seed-tag",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -8465,7 +8465,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/segregated-witness",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/segregated-witness",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -8479,7 +8479,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8493,7 +8493,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8507,7 +8507,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/selfish-mining",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/selfish-mining",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -8521,7 +8521,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/sell-wall",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/sell-wall",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -8535,7 +8535,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/sentiment",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/sentiment",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -8549,7 +8549,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8563,7 +8563,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8577,7 +8577,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8591,7 +8591,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8605,7 +8605,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/sharding",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/sharding",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -8619,7 +8619,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/sharpe-ratio",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/sharpe-ratio",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -8633,7 +8633,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8647,7 +8647,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8661,7 +8661,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/sidechains",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/sidechains",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -8675,7 +8675,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/simple-moving-average-sma",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/simple-moving-average-sma",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -8689,7 +8689,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/slashing",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/slashing",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -8703,7 +8703,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8717,7 +8717,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/slippage",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/slippage",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -8731,7 +8731,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8745,7 +8745,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/smart-contract",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/smart-contract",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -8759,7 +8759,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/smart-contract-wallet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/smart-contract-wallet",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -8773,7 +8773,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/snapshot",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/snapshot",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -8787,7 +8787,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/social-recovery-wallet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/social-recovery-wallet",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -8801,7 +8801,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/social-trading",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/social-trading",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -8815,7 +8815,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/socialfi",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/socialfi",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -8829,7 +8829,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8843,7 +8843,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/soft-landing",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/soft-landing",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -8857,7 +8857,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/solidity",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/solidity",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -8871,7 +8871,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/source-code",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/source-code",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -8885,7 +8885,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/spl",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/spl",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -8899,7 +8899,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/src-20-tokens",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/src-20-tokens",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -8913,7 +8913,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/stablecoin",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/stablecoin",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -8927,7 +8927,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/stagflation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/stagflation",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -8941,7 +8941,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8955,7 +8955,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8969,7 +8969,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/staking-pool",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/staking-pool",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -8983,7 +8983,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8997,7 +8997,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/state-channel",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/state-channel",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -9011,7 +9011,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9025,7 +9025,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/steth",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/steth",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -9039,7 +9039,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9053,7 +9053,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/stock-variable",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/stock-variable",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -9067,7 +9067,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/store-of-value",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/store-of-value",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -9081,7 +9081,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9095,7 +9095,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/supercomputer",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/supercomputer",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -9109,7 +9109,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/supply-chain",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/supply-chain",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -9123,7 +9123,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/support",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/support",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -9137,7 +9137,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9151,7 +9151,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/sybil-attack",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/sybil-attack",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -9165,7 +9165,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9179,7 +9179,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/taker",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/taker",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -9193,7 +9193,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/tank",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/tank",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -9207,7 +9207,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9221,7 +9221,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9235,7 +9235,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/testnet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/testnet",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -9249,7 +9249,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9263,7 +9263,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9277,7 +9277,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9291,7 +9291,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/ticker",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/ticker",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -9305,7 +9305,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/ticker-symbol",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/ticker-symbol",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -9319,7 +9319,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/token",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/token",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -9333,7 +9333,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/token-generation-event-tge",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/token-generation-event-tge",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -9347,7 +9347,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/token-lockup",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/token-lockup",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -9361,7 +9361,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/token-merge",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/token-merge",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -9375,7 +9375,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/token-sale",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/token-sale",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -9389,7 +9389,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9403,7 +9403,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/token-standards",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/token-standards",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -9417,7 +9417,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/tokenization",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/tokenization",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -9431,7 +9431,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/tokenomics",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/tokenomics",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -9445,7 +9445,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/total-supply",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/total-supply",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -9459,7 +9459,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/total-value-locked-tvl",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/total-value-locked-tvl",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -9473,7 +9473,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/tradfi",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/tradfi",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -9487,7 +9487,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9501,7 +9501,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9515,7 +9515,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9529,7 +9529,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/transaction-id",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/transaction-id",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -9543,7 +9543,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9557,7 +9557,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/transactions-per-second-tps",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/transactions-per-second-tps",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -9571,7 +9571,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9585,7 +9585,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/treasury-bills-t-bills",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/treasury-bills-t-bills",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -9599,7 +9599,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9613,7 +9613,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/trueusd-tusd",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/trueusd-tusd",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -9627,7 +9627,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9641,7 +9641,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/trustless",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/trustless",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -9655,7 +9655,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/turing-complete",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/turing-complete",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -9669,7 +9669,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9683,7 +9683,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9697,7 +9697,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9711,7 +9711,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/understanding-cz-s-number-4",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/understanding-cz-s-number-4",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -9725,7 +9725,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9739,7 +9739,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9753,7 +9753,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/unit-of-account",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/unit-of-account",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -9767,7 +9767,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9781,7 +9781,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/unspent-transaction-output-utxo",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/unspent-transaction-output-utxo",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -9795,7 +9795,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9809,7 +9809,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9823,7 +9823,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9837,7 +9837,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9851,7 +9851,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/user-interface",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/user-interface",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -9865,7 +9865,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/utility-token",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/utility-token",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -9879,7 +9879,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9893,7 +9893,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9907,7 +9907,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9921,7 +9921,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/verification-code",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/verification-code",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -9935,7 +9935,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9949,7 +9949,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9963,7 +9963,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/virtual-machine",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/virtual-machine",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -9977,7 +9977,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/vladimir-club",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/vladimir-club",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -9991,7 +9991,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/volatility",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/volatility",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -10005,7 +10005,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/volume",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/volume",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -10019,7 +10019,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/wagmi",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/wagmi",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -10033,7 +10033,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/wallet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/wallet",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -10047,7 +10047,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10061,7 +10061,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10075,7 +10075,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/wash-trading",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/wash-trading",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -10089,7 +10089,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/weak-hands",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/weak-hands",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -10103,7 +10103,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/weak-subjectivity",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/weak-subjectivity",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -10117,7 +10117,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/web-1",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/web-1",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -10131,7 +10131,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10145,7 +10145,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10159,7 +10159,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10173,7 +10173,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10187,7 +10187,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10201,7 +10201,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/wei",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/wei",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -10215,7 +10215,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/weighted-moving-average-wma",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/weighted-moving-average-wma",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -10229,7 +10229,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/whale",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/whale",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -10243,7 +10243,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/whiskers",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/whiskers",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -10257,7 +10257,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/whitelist",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/whitelist",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -10271,7 +10271,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10285,7 +10285,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/wick",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/wick",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -10299,7 +10299,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/win-rate",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/win-rate",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -10313,7 +10313,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/wrapped-ether",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/wrapped-ether",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -10327,7 +10327,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10341,7 +10341,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/wyckoff",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/wyckoff",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -10355,7 +10355,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10369,7 +10369,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10383,7 +10383,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10397,7 +10397,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10411,7 +10411,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/yield-farming",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/yield-farming",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -10425,7 +10425,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10439,7 +10439,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10453,7 +10453,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/zero-knowledge-proofs",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/zero-knowledge-proofs",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -10467,7 +10467,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10481,7 +10481,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/zk-rollup",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/zk-rollup",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -10495,7 +10495,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/zk-snarks",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/zk-snarks",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""
@@ -10509,7 +10509,7 @@
       "definitionSource": "https://academy.binance.com/ro/glossary/zk-starks",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/ro/glossary/zk-starks",
       "dateFirstRecorded": "2025-02-02",
       "commentary": ""

--- a/locales/ro-RO/ro-RO.json
+++ b/locales/ro-RO/ro-RO.json
@@ -9576,7 +9576,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "treasury-bills-t-bills": {
+    "treasury-bills": {
       "term": "Obligațiuni de stat (T-bills)",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/ru-RU/ru-RU.json
+++ b/locales/ru-RU/ru-RU.json
@@ -9,7 +9,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -23,7 +23,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -37,7 +37,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -51,7 +51,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -65,7 +65,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -79,7 +79,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -93,7 +93,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -107,7 +107,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -121,7 +121,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -135,7 +135,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -149,7 +149,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -163,7 +163,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -177,7 +177,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -191,7 +191,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -205,7 +205,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -219,7 +219,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -233,7 +233,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -247,7 +247,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -261,7 +261,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -275,7 +275,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -289,7 +289,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -303,7 +303,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -317,7 +317,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -331,7 +331,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -345,7 +345,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -359,7 +359,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -373,7 +373,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -387,7 +387,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -401,7 +401,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -415,7 +415,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -429,7 +429,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -443,7 +443,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -457,7 +457,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -471,7 +471,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -485,7 +485,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -499,7 +499,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -513,7 +513,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -527,7 +527,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -541,7 +541,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -555,7 +555,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -569,7 +569,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -583,7 +583,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -597,7 +597,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -611,7 +611,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -625,7 +625,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -639,7 +639,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -653,7 +653,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -667,7 +667,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -681,7 +681,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -695,7 +695,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -709,7 +709,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -723,7 +723,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -737,7 +737,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -751,7 +751,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -765,7 +765,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -779,7 +779,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -793,7 +793,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -807,7 +807,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -821,7 +821,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -835,7 +835,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -849,7 +849,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -863,7 +863,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -877,7 +877,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -891,7 +891,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -905,7 +905,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -919,7 +919,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -933,7 +933,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -947,7 +947,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -961,7 +961,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -975,7 +975,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -989,7 +989,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1003,7 +1003,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1017,7 +1017,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1031,7 +1031,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1045,7 +1045,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1059,7 +1059,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1073,7 +1073,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1087,7 +1087,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1101,7 +1101,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1115,7 +1115,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1129,7 +1129,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1143,7 +1143,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1157,7 +1157,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1171,7 +1171,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1185,7 +1185,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1199,7 +1199,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1213,7 +1213,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1227,7 +1227,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1241,7 +1241,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1255,7 +1255,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1269,7 +1269,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1283,7 +1283,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1297,7 +1297,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1311,7 +1311,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1325,7 +1325,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1339,7 +1339,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1353,7 +1353,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1367,7 +1367,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1381,7 +1381,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1395,7 +1395,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1409,7 +1409,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1423,7 +1423,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1437,7 +1437,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1451,7 +1451,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1465,7 +1465,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1479,7 +1479,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1493,7 +1493,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1507,7 +1507,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1521,7 +1521,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1535,7 +1535,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1549,7 +1549,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1563,7 +1563,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1577,7 +1577,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1591,7 +1591,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1605,7 +1605,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1619,7 +1619,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1633,7 +1633,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1647,7 +1647,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1661,7 +1661,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1675,7 +1675,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1689,7 +1689,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1703,7 +1703,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1717,7 +1717,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1731,7 +1731,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1745,7 +1745,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1759,7 +1759,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1773,7 +1773,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1787,7 +1787,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1801,7 +1801,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1815,7 +1815,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1829,7 +1829,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1843,7 +1843,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1857,7 +1857,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1871,7 +1871,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1885,7 +1885,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1899,7 +1899,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1913,7 +1913,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1927,7 +1927,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1941,7 +1941,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1955,7 +1955,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1969,7 +1969,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1983,7 +1983,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1997,7 +1997,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2011,7 +2011,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2025,7 +2025,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2039,7 +2039,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2053,7 +2053,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2067,7 +2067,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2081,7 +2081,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2095,7 +2095,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2109,7 +2109,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2123,7 +2123,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2137,7 +2137,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2151,7 +2151,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2165,7 +2165,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2179,7 +2179,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2193,7 +2193,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2207,7 +2207,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2221,7 +2221,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2235,7 +2235,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2249,7 +2249,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2263,7 +2263,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2277,7 +2277,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2291,7 +2291,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2305,7 +2305,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2319,7 +2319,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2333,7 +2333,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2347,7 +2347,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2361,7 +2361,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2375,7 +2375,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2389,7 +2389,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2403,7 +2403,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2417,7 +2417,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2431,7 +2431,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2445,7 +2445,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2459,7 +2459,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2473,7 +2473,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2487,7 +2487,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2501,7 +2501,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2515,7 +2515,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2529,7 +2529,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2543,7 +2543,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2557,7 +2557,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2571,7 +2571,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2585,7 +2585,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2599,7 +2599,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2613,7 +2613,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2627,7 +2627,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2641,7 +2641,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2655,7 +2655,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2669,7 +2669,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2683,7 +2683,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2697,7 +2697,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2711,7 +2711,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2725,7 +2725,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2739,7 +2739,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2753,7 +2753,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2767,7 +2767,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2781,7 +2781,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2795,7 +2795,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2809,7 +2809,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2823,7 +2823,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2837,7 +2837,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2851,7 +2851,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2865,7 +2865,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2879,7 +2879,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2893,7 +2893,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2907,7 +2907,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2921,7 +2921,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2935,7 +2935,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2949,7 +2949,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2963,7 +2963,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2977,7 +2977,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2991,7 +2991,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3005,7 +3005,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3019,7 +3019,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3033,7 +3033,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3047,7 +3047,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3061,7 +3061,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3075,7 +3075,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3089,7 +3089,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3103,7 +3103,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3117,7 +3117,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3131,7 +3131,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3145,7 +3145,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3159,7 +3159,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3173,7 +3173,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3187,7 +3187,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3201,7 +3201,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3215,7 +3215,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3229,7 +3229,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3243,7 +3243,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3257,7 +3257,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3271,7 +3271,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3285,7 +3285,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3299,7 +3299,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3313,7 +3313,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3327,7 +3327,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3341,7 +3341,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3355,7 +3355,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3369,7 +3369,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3383,7 +3383,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3397,7 +3397,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3411,7 +3411,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3425,7 +3425,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3439,7 +3439,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3453,7 +3453,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3467,7 +3467,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3481,7 +3481,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3495,7 +3495,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3509,7 +3509,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3523,7 +3523,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3537,7 +3537,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3551,7 +3551,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3565,7 +3565,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3579,7 +3579,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3593,7 +3593,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3607,7 +3607,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3621,7 +3621,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3635,7 +3635,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3649,7 +3649,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3663,7 +3663,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3677,7 +3677,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3691,7 +3691,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3705,7 +3705,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3719,7 +3719,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3733,7 +3733,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3747,7 +3747,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3761,7 +3761,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3775,7 +3775,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3789,7 +3789,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3803,7 +3803,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3817,7 +3817,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3831,7 +3831,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3845,7 +3845,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3859,7 +3859,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3873,7 +3873,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3887,7 +3887,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3901,7 +3901,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3915,7 +3915,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3929,7 +3929,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3943,7 +3943,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3957,7 +3957,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3971,7 +3971,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3985,7 +3985,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3999,7 +3999,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4013,7 +4013,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4027,7 +4027,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4041,7 +4041,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4055,7 +4055,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4069,7 +4069,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4083,7 +4083,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4097,7 +4097,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4111,7 +4111,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4125,7 +4125,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4139,7 +4139,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4153,7 +4153,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4167,7 +4167,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4181,7 +4181,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4195,7 +4195,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4209,7 +4209,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4223,7 +4223,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4237,7 +4237,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4251,7 +4251,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4265,7 +4265,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4279,7 +4279,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4293,7 +4293,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4307,7 +4307,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4321,7 +4321,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4335,7 +4335,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4349,7 +4349,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4363,7 +4363,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4377,7 +4377,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4391,7 +4391,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4405,7 +4405,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4419,7 +4419,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4433,7 +4433,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4447,7 +4447,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4461,7 +4461,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4475,7 +4475,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4489,7 +4489,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4503,7 +4503,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4517,7 +4517,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4531,7 +4531,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4545,7 +4545,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4559,7 +4559,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4573,7 +4573,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4587,7 +4587,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4601,7 +4601,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4615,7 +4615,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4629,7 +4629,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4643,7 +4643,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4657,7 +4657,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4671,7 +4671,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4685,7 +4685,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4699,7 +4699,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4713,7 +4713,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4727,7 +4727,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4741,7 +4741,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4755,7 +4755,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4769,7 +4769,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4783,7 +4783,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4797,7 +4797,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4811,7 +4811,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4825,7 +4825,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4839,7 +4839,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4853,7 +4853,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4867,7 +4867,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4881,7 +4881,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4895,7 +4895,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4909,7 +4909,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4923,7 +4923,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4937,7 +4937,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4951,7 +4951,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4965,7 +4965,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4979,7 +4979,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4993,7 +4993,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5007,7 +5007,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5021,7 +5021,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5035,7 +5035,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5049,7 +5049,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5063,7 +5063,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5077,7 +5077,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5091,7 +5091,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5105,7 +5105,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5119,7 +5119,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5133,7 +5133,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5147,7 +5147,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5161,7 +5161,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5175,7 +5175,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5189,7 +5189,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5203,7 +5203,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5217,7 +5217,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5231,7 +5231,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5245,7 +5245,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5259,7 +5259,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5273,7 +5273,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5287,7 +5287,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5301,7 +5301,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5315,7 +5315,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5329,7 +5329,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5343,7 +5343,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5357,7 +5357,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5371,7 +5371,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5385,7 +5385,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5399,7 +5399,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5413,7 +5413,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5427,7 +5427,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5441,7 +5441,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5455,7 +5455,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5469,7 +5469,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5483,7 +5483,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5497,7 +5497,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5511,7 +5511,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5525,7 +5525,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5539,7 +5539,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5553,7 +5553,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5567,7 +5567,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5581,7 +5581,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5595,7 +5595,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5609,7 +5609,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5623,7 +5623,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5637,7 +5637,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5651,7 +5651,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5665,7 +5665,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5679,7 +5679,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""

--- a/locales/th-TH/th-TH.json
+++ b/locales/th-TH/th-TH.json
@@ -9,7 +9,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -23,7 +23,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -37,7 +37,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -51,7 +51,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -65,7 +65,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -79,7 +79,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -93,7 +93,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -107,7 +107,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -121,7 +121,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -135,7 +135,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -149,7 +149,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -163,7 +163,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -177,7 +177,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -191,7 +191,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -205,7 +205,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -219,7 +219,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -233,7 +233,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -247,7 +247,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -261,7 +261,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -275,7 +275,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -289,7 +289,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -303,7 +303,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -317,7 +317,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -331,7 +331,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -345,7 +345,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -359,7 +359,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -373,7 +373,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -387,7 +387,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -401,7 +401,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -415,7 +415,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -429,7 +429,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -443,7 +443,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -457,7 +457,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -471,7 +471,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -485,7 +485,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -499,7 +499,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -513,7 +513,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -527,7 +527,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -541,7 +541,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -555,7 +555,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -569,7 +569,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -583,7 +583,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -597,7 +597,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -611,7 +611,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -625,7 +625,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -639,7 +639,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -653,7 +653,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -667,7 +667,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -681,7 +681,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -695,7 +695,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -709,7 +709,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -723,7 +723,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -737,7 +737,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -751,7 +751,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -765,7 +765,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -779,7 +779,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -793,7 +793,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -807,7 +807,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -821,7 +821,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -835,7 +835,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -849,7 +849,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -863,7 +863,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -877,7 +877,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -891,7 +891,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -905,7 +905,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -919,7 +919,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -933,7 +933,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -947,7 +947,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -961,7 +961,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -975,7 +975,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -989,7 +989,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1003,7 +1003,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1017,7 +1017,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1031,7 +1031,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1045,7 +1045,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1059,7 +1059,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1073,7 +1073,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1087,7 +1087,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1101,7 +1101,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1115,7 +1115,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1129,7 +1129,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1143,7 +1143,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1157,7 +1157,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1171,7 +1171,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1185,7 +1185,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1199,7 +1199,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1213,7 +1213,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1227,7 +1227,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1241,7 +1241,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1255,7 +1255,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1269,7 +1269,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1283,7 +1283,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1297,7 +1297,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1311,7 +1311,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1325,7 +1325,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1339,7 +1339,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1353,7 +1353,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1367,7 +1367,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1381,7 +1381,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1395,7 +1395,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1409,7 +1409,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1423,7 +1423,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1437,7 +1437,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1451,7 +1451,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1465,7 +1465,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1479,7 +1479,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1493,7 +1493,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1507,7 +1507,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1521,7 +1521,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1535,7 +1535,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1549,7 +1549,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1563,7 +1563,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1577,7 +1577,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1591,7 +1591,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1605,7 +1605,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1619,7 +1619,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1633,7 +1633,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1647,7 +1647,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1661,7 +1661,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1675,7 +1675,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1689,7 +1689,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1703,7 +1703,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1717,7 +1717,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1731,7 +1731,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1745,7 +1745,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1759,7 +1759,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1773,7 +1773,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1787,7 +1787,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1801,7 +1801,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1815,7 +1815,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1829,7 +1829,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1843,7 +1843,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1857,7 +1857,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1871,7 +1871,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1885,7 +1885,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1899,7 +1899,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1913,7 +1913,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1927,7 +1927,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1941,7 +1941,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1955,7 +1955,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1969,7 +1969,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1983,7 +1983,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1997,7 +1997,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2011,7 +2011,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2025,7 +2025,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2039,7 +2039,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2053,7 +2053,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2067,7 +2067,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2081,7 +2081,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2095,7 +2095,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2109,7 +2109,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2123,7 +2123,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2137,7 +2137,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2151,7 +2151,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2165,7 +2165,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2179,7 +2179,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2193,7 +2193,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2207,7 +2207,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2221,7 +2221,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2235,7 +2235,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2249,7 +2249,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2263,7 +2263,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2277,7 +2277,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2291,7 +2291,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2305,7 +2305,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2319,7 +2319,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2333,7 +2333,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2347,7 +2347,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2361,7 +2361,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2375,7 +2375,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2389,7 +2389,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2403,7 +2403,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2417,7 +2417,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2431,7 +2431,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2445,7 +2445,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2459,7 +2459,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2473,7 +2473,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2487,7 +2487,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2501,7 +2501,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2515,7 +2515,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2529,7 +2529,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2543,7 +2543,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2557,7 +2557,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2571,7 +2571,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2585,7 +2585,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2599,7 +2599,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2613,7 +2613,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2627,7 +2627,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2641,7 +2641,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2655,7 +2655,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2669,7 +2669,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2683,7 +2683,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2697,7 +2697,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2711,7 +2711,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2725,7 +2725,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2739,7 +2739,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2753,7 +2753,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2767,7 +2767,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2781,7 +2781,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2795,7 +2795,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2809,7 +2809,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2823,7 +2823,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2837,7 +2837,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2851,7 +2851,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2865,7 +2865,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2879,7 +2879,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2893,7 +2893,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2907,7 +2907,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2921,7 +2921,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2935,7 +2935,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2949,7 +2949,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2963,7 +2963,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2977,7 +2977,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2991,7 +2991,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3005,7 +3005,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3019,7 +3019,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3033,7 +3033,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3047,7 +3047,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3061,7 +3061,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3075,7 +3075,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3089,7 +3089,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3103,7 +3103,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3117,7 +3117,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3131,7 +3131,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3145,7 +3145,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3159,7 +3159,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3173,7 +3173,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3187,7 +3187,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3201,7 +3201,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3215,7 +3215,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3229,7 +3229,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3243,7 +3243,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3257,7 +3257,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3271,7 +3271,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3285,7 +3285,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3299,7 +3299,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3313,7 +3313,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3327,7 +3327,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3341,7 +3341,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3355,7 +3355,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3369,7 +3369,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3383,7 +3383,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3397,7 +3397,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3411,7 +3411,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3425,7 +3425,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3439,7 +3439,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3453,7 +3453,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3467,7 +3467,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3481,7 +3481,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3495,7 +3495,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3509,7 +3509,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3523,7 +3523,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3537,7 +3537,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3551,7 +3551,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3565,7 +3565,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3579,7 +3579,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3593,7 +3593,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3607,7 +3607,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3621,7 +3621,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3635,7 +3635,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3649,7 +3649,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3663,7 +3663,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3677,7 +3677,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3691,7 +3691,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3705,7 +3705,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3719,7 +3719,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3733,7 +3733,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3747,7 +3747,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3761,7 +3761,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3775,7 +3775,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3789,7 +3789,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3803,7 +3803,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3817,7 +3817,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3831,7 +3831,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3845,7 +3845,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3859,7 +3859,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3873,7 +3873,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3887,7 +3887,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3901,7 +3901,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3915,7 +3915,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3929,7 +3929,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3943,7 +3943,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3957,7 +3957,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3971,7 +3971,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3985,7 +3985,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3999,7 +3999,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4013,7 +4013,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4027,7 +4027,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4041,7 +4041,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4055,7 +4055,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4069,7 +4069,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4083,7 +4083,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4097,7 +4097,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4111,7 +4111,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4125,7 +4125,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4139,7 +4139,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4153,7 +4153,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4167,7 +4167,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4181,7 +4181,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4195,7 +4195,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4209,7 +4209,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4223,7 +4223,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4237,7 +4237,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4251,7 +4251,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4265,7 +4265,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4279,7 +4279,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4293,7 +4293,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4307,7 +4307,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4321,7 +4321,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4335,7 +4335,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4349,7 +4349,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4363,7 +4363,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4377,7 +4377,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4391,7 +4391,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4405,7 +4405,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4419,7 +4419,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4433,7 +4433,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4447,7 +4447,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4461,7 +4461,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4475,7 +4475,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4489,7 +4489,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4503,7 +4503,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4517,7 +4517,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4531,7 +4531,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4545,7 +4545,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4559,7 +4559,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4573,7 +4573,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4587,7 +4587,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4601,7 +4601,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4615,7 +4615,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4629,7 +4629,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4643,7 +4643,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4657,7 +4657,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4671,7 +4671,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4685,7 +4685,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4699,7 +4699,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4713,7 +4713,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4727,7 +4727,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4741,7 +4741,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4755,7 +4755,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4769,7 +4769,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4783,7 +4783,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4797,7 +4797,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4811,7 +4811,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4825,7 +4825,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4839,7 +4839,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4853,7 +4853,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4867,7 +4867,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4881,7 +4881,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4895,7 +4895,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4909,7 +4909,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4923,7 +4923,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4937,7 +4937,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4951,7 +4951,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4965,7 +4965,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4979,7 +4979,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4993,7 +4993,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5007,7 +5007,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5021,7 +5021,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5035,7 +5035,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5049,7 +5049,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5063,7 +5063,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5077,7 +5077,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5091,7 +5091,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5105,7 +5105,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5119,7 +5119,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5133,7 +5133,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5147,7 +5147,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5161,7 +5161,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5175,7 +5175,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5189,7 +5189,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5203,7 +5203,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5217,7 +5217,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5231,7 +5231,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5245,7 +5245,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5259,7 +5259,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5273,7 +5273,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5287,7 +5287,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5301,7 +5301,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5315,7 +5315,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5329,7 +5329,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5343,7 +5343,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5357,7 +5357,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5371,7 +5371,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5385,7 +5385,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5399,7 +5399,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5413,7 +5413,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5427,7 +5427,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5441,7 +5441,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5455,7 +5455,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5469,7 +5469,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5483,7 +5483,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5497,7 +5497,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5511,7 +5511,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5525,7 +5525,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5539,7 +5539,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5553,7 +5553,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5567,7 +5567,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5581,7 +5581,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5595,7 +5595,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5609,7 +5609,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5623,7 +5623,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5637,7 +5637,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5651,7 +5651,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5665,7 +5665,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5679,7 +5679,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""

--- a/locales/tl-PH/tl-PH.json
+++ b/locales/tl-PH/tl-PH.json
@@ -9,7 +9,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -23,7 +23,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -37,7 +37,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -51,7 +51,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -65,7 +65,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -79,7 +79,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -93,7 +93,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -107,7 +107,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -121,7 +121,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -135,7 +135,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -149,7 +149,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -163,7 +163,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -177,7 +177,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -191,7 +191,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -205,7 +205,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -219,7 +219,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -233,7 +233,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -247,7 +247,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -261,7 +261,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -275,7 +275,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -289,7 +289,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -303,7 +303,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -317,7 +317,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -331,7 +331,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -345,7 +345,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -359,7 +359,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -373,7 +373,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -387,7 +387,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -401,7 +401,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -415,7 +415,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -429,7 +429,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -443,7 +443,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -457,7 +457,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -471,7 +471,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -485,7 +485,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -499,7 +499,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -513,7 +513,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -527,7 +527,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -541,7 +541,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -555,7 +555,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -569,7 +569,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -583,7 +583,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -597,7 +597,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -611,7 +611,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -625,7 +625,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -639,7 +639,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -653,7 +653,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -667,7 +667,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -681,7 +681,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -695,7 +695,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -709,7 +709,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -723,7 +723,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -737,7 +737,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -751,7 +751,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -765,7 +765,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -779,7 +779,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -793,7 +793,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -807,7 +807,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -821,7 +821,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -835,7 +835,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -849,7 +849,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -863,7 +863,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -877,7 +877,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -891,7 +891,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -905,7 +905,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -919,7 +919,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -933,7 +933,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -947,7 +947,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -961,7 +961,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -975,7 +975,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -989,7 +989,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1003,7 +1003,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1017,7 +1017,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1031,7 +1031,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1045,7 +1045,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1059,7 +1059,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1073,7 +1073,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1087,7 +1087,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1101,7 +1101,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1115,7 +1115,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1129,7 +1129,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1143,7 +1143,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1157,7 +1157,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1171,7 +1171,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1185,7 +1185,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1199,7 +1199,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1213,7 +1213,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1227,7 +1227,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1241,7 +1241,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1255,7 +1255,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1269,7 +1269,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1283,7 +1283,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1297,7 +1297,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1311,7 +1311,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1325,7 +1325,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1339,7 +1339,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1353,7 +1353,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1367,7 +1367,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1381,7 +1381,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1395,7 +1395,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1409,7 +1409,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1423,7 +1423,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1437,7 +1437,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1451,7 +1451,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1465,7 +1465,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1479,7 +1479,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1493,7 +1493,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1507,7 +1507,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1521,7 +1521,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1535,7 +1535,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1549,7 +1549,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1563,7 +1563,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1577,7 +1577,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1591,7 +1591,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1605,7 +1605,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1619,7 +1619,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1633,7 +1633,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1647,7 +1647,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1661,7 +1661,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1675,7 +1675,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1689,7 +1689,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1703,7 +1703,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1717,7 +1717,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1731,7 +1731,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1745,7 +1745,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1759,7 +1759,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1773,7 +1773,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1787,7 +1787,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1801,7 +1801,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1815,7 +1815,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1829,7 +1829,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1843,7 +1843,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1857,7 +1857,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1871,7 +1871,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1885,7 +1885,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1899,7 +1899,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1913,7 +1913,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1927,7 +1927,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1941,7 +1941,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1955,7 +1955,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1969,7 +1969,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1983,7 +1983,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1997,7 +1997,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2011,7 +2011,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2025,7 +2025,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2039,7 +2039,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2053,7 +2053,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2067,7 +2067,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2081,7 +2081,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2095,7 +2095,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2109,7 +2109,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2123,7 +2123,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2137,7 +2137,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2151,7 +2151,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2165,7 +2165,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2179,7 +2179,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2193,7 +2193,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2207,7 +2207,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2221,7 +2221,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2235,7 +2235,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2249,7 +2249,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2263,7 +2263,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2277,7 +2277,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2291,7 +2291,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2305,7 +2305,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2319,7 +2319,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2333,7 +2333,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2347,7 +2347,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2361,7 +2361,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2375,7 +2375,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2389,7 +2389,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2403,7 +2403,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2417,7 +2417,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2431,7 +2431,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2445,7 +2445,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2459,7 +2459,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2473,7 +2473,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2487,7 +2487,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2501,7 +2501,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2515,7 +2515,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2529,7 +2529,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2543,7 +2543,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2557,7 +2557,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2571,7 +2571,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2585,7 +2585,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2599,7 +2599,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2613,7 +2613,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2627,7 +2627,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2641,7 +2641,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2655,7 +2655,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2669,7 +2669,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2683,7 +2683,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2697,7 +2697,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2711,7 +2711,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2725,7 +2725,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2739,7 +2739,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2753,7 +2753,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2767,7 +2767,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2781,7 +2781,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2795,7 +2795,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2809,7 +2809,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2823,7 +2823,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2837,7 +2837,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2851,7 +2851,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2865,7 +2865,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2879,7 +2879,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2893,7 +2893,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2907,7 +2907,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2921,7 +2921,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2935,7 +2935,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2949,7 +2949,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2963,7 +2963,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2977,7 +2977,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2991,7 +2991,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3005,7 +3005,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3019,7 +3019,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3033,7 +3033,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3047,7 +3047,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3061,7 +3061,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3075,7 +3075,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3089,7 +3089,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3103,7 +3103,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3117,7 +3117,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3131,7 +3131,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3145,7 +3145,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3159,7 +3159,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3173,7 +3173,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3187,7 +3187,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3201,7 +3201,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3215,7 +3215,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3229,7 +3229,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3243,7 +3243,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3257,7 +3257,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3271,7 +3271,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3285,7 +3285,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3299,7 +3299,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3313,7 +3313,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3327,7 +3327,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3341,7 +3341,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3355,7 +3355,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3369,7 +3369,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3383,7 +3383,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3397,7 +3397,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3411,7 +3411,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3425,7 +3425,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3439,7 +3439,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3453,7 +3453,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3467,7 +3467,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3481,7 +3481,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3495,7 +3495,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3509,7 +3509,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3523,7 +3523,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3537,7 +3537,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3551,7 +3551,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3565,7 +3565,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3579,7 +3579,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3593,7 +3593,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3607,7 +3607,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3621,7 +3621,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3635,7 +3635,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3649,7 +3649,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3663,7 +3663,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3677,7 +3677,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3691,7 +3691,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3705,7 +3705,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3719,7 +3719,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3733,7 +3733,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3747,7 +3747,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3761,7 +3761,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3775,7 +3775,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3789,7 +3789,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3803,7 +3803,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3817,7 +3817,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3831,7 +3831,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3845,7 +3845,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3859,7 +3859,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3873,7 +3873,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3887,7 +3887,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3901,7 +3901,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3915,7 +3915,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3929,7 +3929,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3943,7 +3943,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3957,7 +3957,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3971,7 +3971,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3985,7 +3985,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3999,7 +3999,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4013,7 +4013,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4027,7 +4027,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4041,7 +4041,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4055,7 +4055,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4069,7 +4069,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4083,7 +4083,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4097,7 +4097,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4111,7 +4111,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4125,7 +4125,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4139,7 +4139,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4153,7 +4153,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4167,7 +4167,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4181,7 +4181,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4195,7 +4195,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4209,7 +4209,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4223,7 +4223,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4237,7 +4237,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4251,7 +4251,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4265,7 +4265,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4279,7 +4279,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4293,7 +4293,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4307,7 +4307,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4321,7 +4321,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4335,7 +4335,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4349,7 +4349,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4363,7 +4363,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4377,7 +4377,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4391,7 +4391,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4405,7 +4405,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4419,7 +4419,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4433,7 +4433,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4447,7 +4447,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4461,7 +4461,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4475,7 +4475,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4489,7 +4489,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4503,7 +4503,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4517,7 +4517,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4531,7 +4531,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4545,7 +4545,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4559,7 +4559,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4573,7 +4573,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4587,7 +4587,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4601,7 +4601,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4615,7 +4615,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4629,7 +4629,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4643,7 +4643,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4657,7 +4657,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4671,7 +4671,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4685,7 +4685,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4699,7 +4699,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4713,7 +4713,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4727,7 +4727,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4741,7 +4741,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4755,7 +4755,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4769,7 +4769,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4783,7 +4783,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4797,7 +4797,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4811,7 +4811,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4825,7 +4825,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4839,7 +4839,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4853,7 +4853,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4867,7 +4867,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4881,7 +4881,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4895,7 +4895,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4909,7 +4909,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4923,7 +4923,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4937,7 +4937,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4951,7 +4951,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4965,7 +4965,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4979,7 +4979,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4993,7 +4993,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5007,7 +5007,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5021,7 +5021,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5035,7 +5035,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5049,7 +5049,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5063,7 +5063,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5077,7 +5077,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5091,7 +5091,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5105,7 +5105,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5119,7 +5119,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5133,7 +5133,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5147,7 +5147,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5161,7 +5161,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5175,7 +5175,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5189,7 +5189,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5203,7 +5203,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5217,7 +5217,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5231,7 +5231,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5245,7 +5245,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5259,7 +5259,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5273,7 +5273,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5287,7 +5287,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5301,7 +5301,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5315,7 +5315,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5329,7 +5329,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5343,7 +5343,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5357,7 +5357,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5371,7 +5371,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5385,7 +5385,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5399,7 +5399,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5413,7 +5413,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5427,7 +5427,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5441,7 +5441,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5455,7 +5455,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5469,7 +5469,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5483,7 +5483,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5497,7 +5497,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5511,7 +5511,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5525,7 +5525,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5539,7 +5539,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5553,7 +5553,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5567,7 +5567,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5581,7 +5581,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5595,7 +5595,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5609,7 +5609,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5623,7 +5623,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5637,7 +5637,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5651,7 +5651,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5665,7 +5665,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5679,7 +5679,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""

--- a/locales/tr-TR/tr-TR.json
+++ b/locales/tr-TR/tr-TR.json
@@ -9,7 +9,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -23,7 +23,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -37,7 +37,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -51,7 +51,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -65,7 +65,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -79,7 +79,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -93,7 +93,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -107,7 +107,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -121,7 +121,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -135,7 +135,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -149,7 +149,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -163,7 +163,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -177,7 +177,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -191,7 +191,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -205,7 +205,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -219,7 +219,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -233,7 +233,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -247,7 +247,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -261,7 +261,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -275,7 +275,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -289,7 +289,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -303,7 +303,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -317,7 +317,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -331,7 +331,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -345,7 +345,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -359,7 +359,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -373,7 +373,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -387,7 +387,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -401,7 +401,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -415,7 +415,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -429,7 +429,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -443,7 +443,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -457,7 +457,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -471,7 +471,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -485,7 +485,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -499,7 +499,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -513,7 +513,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -527,7 +527,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -541,7 +541,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -555,7 +555,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -569,7 +569,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -583,7 +583,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -597,7 +597,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -611,7 +611,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -625,7 +625,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -639,7 +639,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -653,7 +653,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -667,7 +667,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -681,7 +681,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -695,7 +695,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -709,7 +709,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -723,7 +723,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -737,7 +737,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -751,7 +751,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -765,7 +765,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -779,7 +779,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -793,7 +793,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -807,7 +807,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -821,7 +821,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -835,7 +835,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -849,7 +849,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -863,7 +863,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -877,7 +877,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -891,7 +891,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -905,7 +905,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -919,7 +919,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -933,7 +933,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -947,7 +947,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -961,7 +961,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -975,7 +975,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -989,7 +989,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1003,7 +1003,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1017,7 +1017,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1031,7 +1031,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1045,7 +1045,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1059,7 +1059,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1073,7 +1073,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1087,7 +1087,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1101,7 +1101,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1115,7 +1115,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1129,7 +1129,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1143,7 +1143,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1157,7 +1157,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1171,7 +1171,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1185,7 +1185,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1199,7 +1199,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1213,7 +1213,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1227,7 +1227,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1241,7 +1241,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1255,7 +1255,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1269,7 +1269,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1283,7 +1283,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1297,7 +1297,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1311,7 +1311,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1325,7 +1325,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1339,7 +1339,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1353,7 +1353,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1367,7 +1367,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1381,7 +1381,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1395,7 +1395,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1409,7 +1409,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1423,7 +1423,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1437,7 +1437,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1451,7 +1451,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1465,7 +1465,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1479,7 +1479,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1493,7 +1493,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1507,7 +1507,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1521,7 +1521,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1535,7 +1535,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1549,7 +1549,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1563,7 +1563,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1577,7 +1577,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1591,7 +1591,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1605,7 +1605,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1619,7 +1619,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1633,7 +1633,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1647,7 +1647,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1661,7 +1661,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1675,7 +1675,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1689,7 +1689,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1703,7 +1703,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1717,7 +1717,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1731,7 +1731,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1745,7 +1745,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1759,7 +1759,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1773,7 +1773,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1787,7 +1787,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1801,7 +1801,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1815,7 +1815,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1829,7 +1829,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1843,7 +1843,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1857,7 +1857,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1871,7 +1871,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1885,7 +1885,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1899,7 +1899,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1913,7 +1913,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1927,7 +1927,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1941,7 +1941,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1955,7 +1955,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1969,7 +1969,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1983,7 +1983,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1997,7 +1997,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2011,7 +2011,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2025,7 +2025,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2039,7 +2039,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2053,7 +2053,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2067,7 +2067,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2081,7 +2081,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2095,7 +2095,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2109,7 +2109,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2123,7 +2123,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2137,7 +2137,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2151,7 +2151,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2165,7 +2165,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2179,7 +2179,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2193,7 +2193,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2207,7 +2207,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2221,7 +2221,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2235,7 +2235,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2249,7 +2249,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2263,7 +2263,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2277,7 +2277,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2291,7 +2291,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2305,7 +2305,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2319,7 +2319,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2333,7 +2333,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2347,7 +2347,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2361,7 +2361,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2375,7 +2375,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2389,7 +2389,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2403,7 +2403,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2417,7 +2417,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2431,7 +2431,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2445,7 +2445,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2459,7 +2459,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2473,7 +2473,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2487,7 +2487,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2501,7 +2501,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2515,7 +2515,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2529,7 +2529,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2543,7 +2543,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2557,7 +2557,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2571,7 +2571,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2585,7 +2585,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2599,7 +2599,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2613,7 +2613,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2627,7 +2627,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2641,7 +2641,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2655,7 +2655,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2669,7 +2669,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2683,7 +2683,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2697,7 +2697,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2711,7 +2711,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2725,7 +2725,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2739,7 +2739,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2753,7 +2753,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2767,7 +2767,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2781,7 +2781,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2795,7 +2795,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2809,7 +2809,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2823,7 +2823,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2837,7 +2837,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2851,7 +2851,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2865,7 +2865,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2879,7 +2879,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2893,7 +2893,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2907,7 +2907,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2921,7 +2921,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2935,7 +2935,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2949,7 +2949,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2963,7 +2963,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2977,7 +2977,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2991,7 +2991,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3005,7 +3005,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3019,7 +3019,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3033,7 +3033,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3047,7 +3047,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3061,7 +3061,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3075,7 +3075,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3089,7 +3089,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3103,7 +3103,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3117,7 +3117,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3131,7 +3131,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3145,7 +3145,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3159,7 +3159,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3173,7 +3173,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3187,7 +3187,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3201,7 +3201,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3215,7 +3215,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3229,7 +3229,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3243,7 +3243,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3257,7 +3257,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3271,7 +3271,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3285,7 +3285,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3299,7 +3299,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3313,7 +3313,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3327,7 +3327,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3341,7 +3341,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3355,7 +3355,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3369,7 +3369,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3383,7 +3383,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3397,7 +3397,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3411,7 +3411,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3425,7 +3425,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3439,7 +3439,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3453,7 +3453,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3467,7 +3467,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3481,7 +3481,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3495,7 +3495,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3509,7 +3509,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3523,7 +3523,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3537,7 +3537,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3551,7 +3551,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3565,7 +3565,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3579,7 +3579,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3593,7 +3593,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3607,7 +3607,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3621,7 +3621,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3635,7 +3635,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3649,7 +3649,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3663,7 +3663,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3677,7 +3677,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3691,7 +3691,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3705,7 +3705,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3719,7 +3719,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3733,7 +3733,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3747,7 +3747,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3761,7 +3761,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3775,7 +3775,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3789,7 +3789,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3803,7 +3803,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3817,7 +3817,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3831,7 +3831,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3845,7 +3845,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3859,7 +3859,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3873,7 +3873,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3887,7 +3887,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3901,7 +3901,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3915,7 +3915,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3929,7 +3929,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3943,7 +3943,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3957,7 +3957,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3971,7 +3971,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3985,7 +3985,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3999,7 +3999,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4013,7 +4013,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4027,7 +4027,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4041,7 +4041,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4055,7 +4055,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4069,7 +4069,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4083,7 +4083,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4097,7 +4097,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4111,7 +4111,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4125,7 +4125,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4139,7 +4139,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4153,7 +4153,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4167,7 +4167,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4181,7 +4181,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4195,7 +4195,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4209,7 +4209,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4223,7 +4223,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4237,7 +4237,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4251,7 +4251,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4265,7 +4265,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4279,7 +4279,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4293,7 +4293,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4307,7 +4307,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4321,7 +4321,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4335,7 +4335,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4349,7 +4349,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4363,7 +4363,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4377,7 +4377,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4391,7 +4391,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4405,7 +4405,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4419,7 +4419,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4433,7 +4433,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4447,7 +4447,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4461,7 +4461,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4475,7 +4475,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4489,7 +4489,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4503,7 +4503,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4517,7 +4517,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4531,7 +4531,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4545,7 +4545,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4559,7 +4559,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4573,7 +4573,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4587,7 +4587,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4601,7 +4601,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4615,7 +4615,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4629,7 +4629,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4643,7 +4643,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4657,7 +4657,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4671,7 +4671,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4685,7 +4685,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4699,7 +4699,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4713,7 +4713,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4727,7 +4727,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4741,7 +4741,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4755,7 +4755,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4769,7 +4769,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4783,7 +4783,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4797,7 +4797,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4811,7 +4811,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4825,7 +4825,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4839,7 +4839,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4853,7 +4853,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4867,7 +4867,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4881,7 +4881,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4895,7 +4895,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4909,7 +4909,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4923,7 +4923,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4937,7 +4937,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4951,7 +4951,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4965,7 +4965,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4979,7 +4979,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4993,7 +4993,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5007,7 +5007,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5021,7 +5021,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5035,7 +5035,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5049,7 +5049,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5063,7 +5063,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5077,7 +5077,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5091,7 +5091,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5105,7 +5105,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5119,7 +5119,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5133,7 +5133,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5147,7 +5147,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5161,7 +5161,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5175,7 +5175,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5189,7 +5189,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5203,7 +5203,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5217,7 +5217,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5231,7 +5231,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5245,7 +5245,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5259,7 +5259,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5273,7 +5273,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5287,7 +5287,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5301,7 +5301,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5315,7 +5315,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5329,7 +5329,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5343,7 +5343,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5357,7 +5357,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5371,7 +5371,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5385,7 +5385,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5399,7 +5399,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5413,7 +5413,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5427,7 +5427,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5441,7 +5441,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5455,7 +5455,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5469,7 +5469,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5483,7 +5483,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5497,7 +5497,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5511,7 +5511,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5525,7 +5525,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5539,7 +5539,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5553,7 +5553,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5567,7 +5567,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5581,7 +5581,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5595,7 +5595,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5609,7 +5609,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5623,7 +5623,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5637,7 +5637,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5651,7 +5651,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5665,7 +5665,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5679,7 +5679,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""

--- a/locales/uk-UA/uk-UA.json
+++ b/locales/uk-UA/uk-UA.json
@@ -9,7 +9,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -23,7 +23,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -37,7 +37,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -51,7 +51,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -65,7 +65,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -79,7 +79,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/51-percent-attack",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/51-percent-attack",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -93,7 +93,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -107,7 +107,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/absolute-advantage",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/absolute-advantage",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -121,7 +121,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -135,7 +135,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -149,7 +149,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/active-management",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/active-management",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -163,7 +163,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/actively-validated-services-avs",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/actively-validated-services-avs",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -177,7 +177,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/ad-hoc",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/ad-hoc",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -191,7 +191,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/address",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/address",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -205,7 +205,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -219,7 +219,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -233,7 +233,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -247,7 +247,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/airdrop",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/airdrop",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -261,7 +261,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -275,7 +275,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -289,7 +289,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/algorithm",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/algorithm",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -303,7 +303,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/all-or-none-order",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/all-or-none-order",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -317,7 +317,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/all-time-high",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/all-time-high",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -331,7 +331,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/allocation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/allocation",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -345,7 +345,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/alpha",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/alpha",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -359,7 +359,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/altcoin",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/altcoin",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -373,7 +373,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -387,7 +387,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/angel-investor",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/angel-investor",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -401,7 +401,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/anti-money-laundering",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/anti-money-laundering",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -415,7 +415,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -429,7 +429,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -443,7 +443,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -457,7 +457,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/application-programming-interface",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/application-programming-interface",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -471,7 +471,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/application-specific-integrated-circuit",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/application-specific-integrated-circuit",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -485,7 +485,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/arbitrage",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/arbitrage",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -499,7 +499,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -513,7 +513,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/arc-20",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/arc-20",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -527,7 +527,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/artificial-intelligence-ai",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/artificial-intelligence-ai",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -541,7 +541,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -555,7 +555,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/asic-resistant",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/asic-resistant",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -569,7 +569,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/asking-price",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/asking-price",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -583,7 +583,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/asset-management",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/asset-management",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -597,7 +597,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -611,7 +611,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/assets-under-management-aum",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/assets-under-management-aum",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -625,7 +625,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/asynchronous",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/asynchronous",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -639,7 +639,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/atomic-swap",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/atomic-swap",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -653,7 +653,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/attack-surface",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/attack-surface",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -667,7 +667,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -681,7 +681,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/auction",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/auction",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -695,7 +695,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -709,7 +709,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/automated-market-maker-amm",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/automated-market-maker-amm",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -723,7 +723,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -737,7 +737,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -751,7 +751,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -765,7 +765,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/b-tokens",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/b-tokens",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -779,7 +779,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/bags",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/bags",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -793,7 +793,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -807,7 +807,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/beacon-chain",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/beacon-chain",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -821,7 +821,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/bear-market",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/bear-market",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -835,7 +835,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/benchmark",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/benchmark",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -849,7 +849,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/bep-1155",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/bep-1155",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -863,7 +863,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/bep-20",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/bep-20",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -877,7 +877,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/bep-721",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/bep-721",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -891,7 +891,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/bep-95",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/bep-95",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -905,7 +905,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -919,7 +919,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/beta-coefficient",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/beta-coefficient",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -933,7 +933,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/beta-release",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/beta-release",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -947,7 +947,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/bid-ask-spread",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/bid-ask-spread",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -961,7 +961,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/bid-price",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/bid-price",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -975,7 +975,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -989,7 +989,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/binance-blockchain-charity-foundation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/binance-blockchain-charity-foundation",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1003,7 +1003,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/binance-ecosystem-fund",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/binance-ecosystem-fund",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1017,7 +1017,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/binancian",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/binancian",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1031,7 +1031,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/bitcoin",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/bitcoin",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1045,7 +1045,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/bitcoin-core",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/bitcoin-core",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1059,7 +1059,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/bitcoin-dominance",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/bitcoin-dominance",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1073,7 +1073,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/bitcoin-maximalists",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/bitcoin-maximalists",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1087,7 +1087,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/bitcoin-pizza",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/bitcoin-pizza",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1101,7 +1101,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/black-swan-event",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/black-swan-event",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1115,7 +1115,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/block",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/block",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1129,7 +1129,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/block-explorer",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/block-explorer",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1143,7 +1143,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/block-header",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/block-header",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1157,7 +1157,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/block-height",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/block-height",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1171,7 +1171,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/block-reward",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/block-reward",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1185,7 +1185,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1199,7 +1199,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1213,7 +1213,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/blockchain",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/blockchain",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1227,7 +1227,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1241,7 +1241,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1255,7 +1255,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/bloom-filter",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/bloom-filter",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1269,7 +1269,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/blue-chip-token",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/blue-chip-token",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1283,7 +1283,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/bnb",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/bnb",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1297,7 +1297,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1311,7 +1311,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/bnsol",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/bnsol",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1325,7 +1325,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/bollinger-bands",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/bollinger-bands",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1339,7 +1339,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/bond",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/bond",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1353,7 +1353,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/bounty",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/bounty",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1367,7 +1367,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1381,7 +1381,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1395,7 +1395,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/brc-20-tokens",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/brc-20-tokens",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1409,7 +1409,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/break-even-point",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/break-even-point",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1423,7 +1423,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/breakeven-multiple",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/breakeven-multiple",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1437,7 +1437,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/breakout",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/breakout",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1451,7 +1451,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1465,7 +1465,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/bscscan",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/bscscan",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1479,7 +1479,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1493,7 +1493,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/btc-wallet-address",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/btc-wallet-address",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1507,7 +1507,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/buidl",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/buidl",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1521,7 +1521,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/bull-market",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/bull-market",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1535,7 +1535,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/burner-wallet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/burner-wallet",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1549,7 +1549,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/buy-wall",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/buy-wall",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1563,7 +1563,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1577,7 +1577,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1591,7 +1591,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1605,7 +1605,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/candidate-block",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/candidate-block",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1619,7 +1619,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/candlestick",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/candlestick",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1633,7 +1633,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/capitulation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/capitulation",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1647,7 +1647,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1661,7 +1661,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/censorship-resistance",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/censorship-resistance",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1675,7 +1675,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/central-bank",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/central-bank",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1689,7 +1689,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/central-bank-digital-currency-cbdc",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/central-bank-digital-currency-cbdc",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1703,7 +1703,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/central-processing-unit",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/central-processing-unit",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1717,7 +1717,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/centralized",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/centralized",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1731,7 +1731,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/centralized-exchange",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/centralized-exchange",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1745,7 +1745,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1759,7 +1759,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1773,7 +1773,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/chatgpt",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/chatgpt",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1787,7 +1787,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1801,7 +1801,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/cipher",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/cipher",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1815,7 +1815,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/circulating-supply",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/circulating-supply",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1829,7 +1829,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1843,7 +1843,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/cloud",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/cloud",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1857,7 +1857,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1871,7 +1871,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/coin",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/coin",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1885,7 +1885,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1899,7 +1899,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1913,7 +1913,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/cold-storage",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/cold-storage",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1927,7 +1927,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1941,7 +1941,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/collateral",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/collateral",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1955,7 +1955,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/colocation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/colocation",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1969,7 +1969,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/commodity-futures-trading-commission",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/commodity-futures-trading-commission",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1983,7 +1983,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1997,7 +1997,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2011,7 +2011,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/compound-interest",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/compound-interest",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2025,7 +2025,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2039,7 +2039,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/confirmation-time",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/confirmation-time",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2053,7 +2053,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/confluence",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/confluence",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2067,7 +2067,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2081,7 +2081,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/consensus-algorithm",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/consensus-algorithm",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2095,7 +2095,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2109,7 +2109,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2123,7 +2123,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2137,7 +2137,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2151,7 +2151,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2165,7 +2165,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/consumer-price-index-(cpi)",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/consumer-price-index-(cpi)",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2179,7 +2179,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/contango-and-backwardation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/contango-and-backwardation",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2193,7 +2193,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2207,7 +2207,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2221,7 +2221,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2235,7 +2235,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/copy-trading",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/copy-trading",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2249,7 +2249,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/counterparty-risk",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/counterparty-risk",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2263,7 +2263,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/credentials",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/credentials",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2277,7 +2277,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/cross-chain-bridges",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/cross-chain-bridges",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2291,7 +2291,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2305,7 +2305,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2319,7 +2319,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2333,7 +2333,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2347,7 +2347,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/crypto-etfs",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/crypto-etfs",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2361,7 +2361,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/crypto-fear-and-greed-index",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/crypto-fear-and-greed-index",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2375,7 +2375,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2389,7 +2389,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/crypto-protocol",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/crypto-protocol",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2403,7 +2403,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2417,7 +2417,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/crypto-winter",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/crypto-winter",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2431,7 +2431,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2445,7 +2445,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/cryptocurrency",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/cryptocurrency",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2459,7 +2459,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2473,7 +2473,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/cryptography",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/cryptography",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2487,7 +2487,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2501,7 +2501,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/custody",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/custody",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2515,7 +2515,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2529,7 +2529,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/daemon",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/daemon",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2543,7 +2543,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2557,7 +2557,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/danksharding",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/danksharding",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2571,7 +2571,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2585,7 +2585,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2599,7 +2599,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2613,7 +2613,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/dead-cat-bounce",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/dead-cat-bounce",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2627,7 +2627,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/death-cross",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/death-cross",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2641,7 +2641,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2655,7 +2655,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/decentralized-application",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/decentralized-application",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2669,7 +2669,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/decentralized-autonomous-cooperative",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/decentralized-autonomous-cooperative",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2683,7 +2683,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/decentralized-autonomous-organization",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/decentralized-autonomous-organization",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2697,7 +2697,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/decentralized-exchange",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/decentralized-exchange",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2711,7 +2711,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2725,7 +2725,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/decentralized-indexes",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/decentralized-indexes",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2739,7 +2739,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2753,7 +2753,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/decryption",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/decryption",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2767,7 +2767,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/deep-web",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/deep-web",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2781,7 +2781,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2795,7 +2795,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2809,7 +2809,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/delisting",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/delisting",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2823,7 +2823,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2837,7 +2837,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/depeg",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/depeg",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2851,7 +2851,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2865,7 +2865,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/depression",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/depression",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2879,7 +2879,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2893,7 +2893,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/design-flaw-attack",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/design-flaw-attack",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2907,7 +2907,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2921,7 +2921,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2935,7 +2935,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2949,7 +2949,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2963,7 +2963,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/diamond-hands",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/diamond-hands",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2977,7 +2977,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/difficulty",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/difficulty",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2991,7 +2991,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/difficulty-bomb",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/difficulty-bomb",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3005,7 +3005,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3019,7 +3019,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3033,7 +3033,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/digital-signature",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/digital-signature",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3047,7 +3047,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3061,7 +3061,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/direct-market-access-dma",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/direct-market-access-dma",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3075,7 +3075,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3089,7 +3089,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/divergence",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/divergence",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3103,7 +3103,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/diversification",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/diversification",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3117,7 +3117,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3131,7 +3131,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/do-your-own-research",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/do-your-own-research",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3145,7 +3145,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/dollar-cost-averaging",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/dollar-cost-averaging",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3159,7 +3159,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/dot-plot",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/dot-plot",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3173,7 +3173,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3187,7 +3187,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/double-spending",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/double-spending",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3201,7 +3201,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/eclipse-attack",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/eclipse-attack",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3215,7 +3215,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3229,7 +3229,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3243,7 +3243,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/efficient-market-hypothesis-emh",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/efficient-market-hypothesis-emh",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3257,7 +3257,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/eigenlayer",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/eigenlayer",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3271,7 +3271,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/eip",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/eip",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3285,7 +3285,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3299,7 +3299,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/eip-3074",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/eip-3074",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3313,7 +3313,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/eip-4844",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/eip-4844",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3327,7 +3327,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/eip-7251",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/eip-7251",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3341,7 +3341,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/eip-7702",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/eip-7702",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3355,7 +3355,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/elasticity",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/elasticity",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3369,7 +3369,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3383,7 +3383,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/encryption",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/encryption",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3397,7 +3397,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/endogenous-variable",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/endogenous-variable",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3411,7 +3411,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3425,7 +3425,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3439,7 +3439,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3453,7 +3453,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3467,7 +3467,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/erc-1155",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/erc-1155",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3481,7 +3481,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/erc-20",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/erc-20",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3495,7 +3495,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/erc-404",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/erc-404",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3509,7 +3509,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/erc-721",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/erc-721",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3523,7 +3523,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/etf",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/etf",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3537,7 +3537,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3551,7 +3551,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3565,7 +3565,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3579,7 +3579,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3593,7 +3593,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/ethereum-classic",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/ethereum-classic",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3607,7 +3607,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/ethereum-foundation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/ethereum-foundation",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3621,7 +3621,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3635,7 +3635,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3649,7 +3649,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3663,7 +3663,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3677,7 +3677,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/ethereum-virtual-machine-evm",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/ethereum-virtual-machine-evm",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3691,7 +3691,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3705,7 +3705,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3719,7 +3719,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3733,7 +3733,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/exchange",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/exchange",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3747,7 +3747,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3761,7 +3761,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3775,7 +3775,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/exogenous-variable",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/exogenous-variable",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3789,7 +3789,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/exponential-moving-average-ema",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/exponential-moving-average-ema",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3803,7 +3803,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/externally-owned-account-eoa",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/externally-owned-account-eoa",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3817,7 +3817,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/fakeout",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/fakeout",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3831,7 +3831,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/falling-knife",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/falling-knife",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3845,7 +3845,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/fan-tokens",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/fan-tokens",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3859,7 +3859,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3873,7 +3873,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3887,7 +3887,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3901,7 +3901,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/fear-of-missing-out",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/fear-of-missing-out",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3915,7 +3915,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/fear-uncertainty-and-doubt",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/fear-uncertainty-and-doubt",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3929,7 +3929,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/fiat",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/fiat",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3943,7 +3943,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3957,7 +3957,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/fibonacci-retracement",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/fibonacci-retracement",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3971,7 +3971,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/fill-or-kill-order",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/fill-or-kill-order",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3985,7 +3985,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/finality",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/finality",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3999,7 +3999,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4013,7 +4013,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4027,7 +4027,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4041,7 +4041,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4055,7 +4055,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4069,7 +4069,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4083,7 +4083,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/first-mover-advantage",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/first-mover-advantage",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4097,7 +4097,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/fiscal-policy",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/fiscal-policy",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4111,7 +4111,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/flappening",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/flappening",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4125,7 +4125,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/flashbots",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/flashbots",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4139,7 +4139,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/flippening",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/flippening",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4153,7 +4153,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/flow-variable",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/flow-variable",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4167,7 +4167,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/forced-liquidation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/forced-liquidation",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4181,7 +4181,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/forex-fx",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/forex-fx",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4195,7 +4195,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/fork",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/fork",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4209,7 +4209,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/formal-verification",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/formal-verification",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4223,7 +4223,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4237,7 +4237,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/fraud-proof",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/fraud-proof",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4251,7 +4251,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/fren",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/fren",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4265,7 +4265,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4279,7 +4279,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/full-node",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/full-node",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4293,7 +4293,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/fully-diluted-valuation-fdv",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/fully-diluted-valuation-fdv",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4307,7 +4307,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/fundamental-analysis",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/fundamental-analysis",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4321,7 +4321,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/funding-fees",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/funding-fees",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4335,7 +4335,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/fungibility",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/fungibility",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4349,7 +4349,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/futures-contract",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/futures-contract",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4363,7 +4363,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/gamefi",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/gamefi",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4377,7 +4377,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4391,7 +4391,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/gas",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/gas",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4405,7 +4405,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4419,7 +4419,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/gas-limit",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/gas-limit",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4433,7 +4433,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4447,7 +4447,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4461,7 +4461,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4475,7 +4475,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/gdp-deflator",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/gdp-deflator",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4489,7 +4489,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/general-public-license",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/general-public-license",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4503,7 +4503,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/genesis-block",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/genesis-block",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4517,7 +4517,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4531,7 +4531,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/github",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/github",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4545,7 +4545,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/gm-good-morning",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/gm-good-morning",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4559,7 +4559,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4573,7 +4573,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/golden-cross",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/golden-cross",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4587,7 +4587,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/golden-ratio",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/golden-ratio",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4601,7 +4601,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/goldilocks",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/goldilocks",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4615,7 +4615,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/gossip-protocol",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/gossip-protocol",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4629,7 +4629,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4643,7 +4643,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/gross-domestic-product-gdp",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/gross-domestic-product-gdp",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4657,7 +4657,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4671,7 +4671,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/gwei",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/gwei",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4685,7 +4685,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/hackathon",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/hackathon",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4699,7 +4699,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/hacker",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/hacker",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4713,7 +4713,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/haha-money-printer-go-brrrrr",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/haha-money-printer-go-brrrrr",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4727,7 +4727,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/halving",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/halving",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4741,7 +4741,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/hard-cap",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/hard-cap",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4755,7 +4755,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4769,7 +4769,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/hard-landing",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/hard-landing",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4783,7 +4783,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4797,7 +4797,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4811,7 +4811,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/hash",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/hash",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4825,7 +4825,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/hash-rate",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/hash-rate",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4839,7 +4839,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/hashed-timelock-contract",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/hashed-timelock-contract",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4853,7 +4853,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4867,7 +4867,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/herd-instinct",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/herd-instinct",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4881,7 +4881,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4895,7 +4895,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/high-frequency-trading-hft",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/high-frequency-trading-hft",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4909,7 +4909,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/hodl",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/hodl",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4923,7 +4923,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/honeypot",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/honeypot",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4937,7 +4937,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4951,7 +4951,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4965,7 +4965,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4979,7 +4979,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4993,7 +4993,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5007,7 +5007,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/iceberg-order",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/iceberg-order",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5021,7 +5021,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5035,7 +5035,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5049,7 +5049,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/immutability",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/immutability",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5063,7 +5063,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/index-funds",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/index-funds",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5077,7 +5077,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5091,7 +5091,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/initial-coin-offering",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/initial-coin-offering",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5105,7 +5105,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/initial-dex-offering-ido",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/initial-dex-offering-ido",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5119,7 +5119,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/initial-exchange-offering",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/initial-exchange-offering",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5133,7 +5133,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/initial-public-offering",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/initial-public-offering",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5147,7 +5147,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/inscription",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/inscription",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5161,7 +5161,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5175,7 +5175,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/integrated-circuit",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/integrated-circuit",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5189,7 +5189,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/interest-rates",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/interest-rates",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5203,7 +5203,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5217,7 +5217,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/interoperability",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/interoperability",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5231,7 +5231,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5245,7 +5245,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/interplanetary-file-system-ipfs",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/interplanetary-file-system-ipfs",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5259,7 +5259,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/iou",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/iou",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5273,7 +5273,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5287,7 +5287,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5301,7 +5301,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5315,7 +5315,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/isolated-margin",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/isolated-margin",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5329,7 +5329,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/issuance",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/issuance",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5343,7 +5343,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5357,7 +5357,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5371,7 +5371,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/keccak",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/keccak",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5385,7 +5385,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5399,7 +5399,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/know-your-customer",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/know-your-customer",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5413,7 +5413,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5427,7 +5427,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5441,7 +5441,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5455,7 +5455,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5469,7 +5469,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/laspeyres-index",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/laspeyres-index",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5483,7 +5483,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/latency",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/latency",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5497,7 +5497,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5511,7 +5511,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5525,7 +5525,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/law-of-demand",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/law-of-demand",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5539,7 +5539,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5553,7 +5553,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/layer-2",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/layer-2",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5567,7 +5567,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/ledger",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/ledger",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5581,7 +5581,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5595,7 +5595,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5609,7 +5609,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/leveraged-tokens",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/leveraged-tokens",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5623,7 +5623,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/library",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/library",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5637,7 +5637,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5651,7 +5651,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5665,7 +5665,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/lightning-network",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/lightning-network",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5679,7 +5679,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/limit-order",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/limit-order",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5693,7 +5693,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5707,7 +5707,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/linux",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/linux",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5721,7 +5721,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/liquid-staking",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/liquid-staking",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5735,7 +5735,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/liquid-staking-token-lst",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/liquid-staking-token-lst",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5749,7 +5749,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5763,7 +5763,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/liquidity",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/liquidity",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5777,7 +5777,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/liquidity-crisis",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/liquidity-crisis",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5791,7 +5791,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5805,7 +5805,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/liquidity-provider",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/liquidity-provider",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5819,7 +5819,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/liquidity-ratios",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/liquidity-ratios",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5833,7 +5833,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5847,7 +5847,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/listing",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/listing",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5861,7 +5861,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/mainnet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/mainnet",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5875,7 +5875,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/mainnet-swap",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/mainnet-swap",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5889,7 +5889,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/maker",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/maker",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5903,7 +5903,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5917,7 +5917,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/malware",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/malware",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5931,7 +5931,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/margin-trading",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/margin-trading",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5945,7 +5945,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5959,7 +5959,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/market-capitalization",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/market-capitalization",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5973,7 +5973,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/market-momentum",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/market-momentum",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5987,7 +5987,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/market-order",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/market-order",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6001,7 +6001,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/masternode",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/masternode",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6015,7 +6015,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/matching-engine",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/matching-engine",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6029,7 +6029,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6043,7 +6043,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/maximum-supply",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/maximum-supply",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6057,7 +6057,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6071,7 +6071,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/mempool",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/mempool",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6085,7 +6085,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6099,7 +6099,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6113,7 +6113,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/merged-mining",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/merged-mining",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6127,7 +6127,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6141,7 +6141,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/merkle-tree",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/merkle-tree",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6155,7 +6155,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6169,7 +6169,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/metadata",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/metadata",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6183,7 +6183,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6197,7 +6197,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6211,7 +6211,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6225,7 +6225,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6239,7 +6239,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6253,7 +6253,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/metaverse",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/metaverse",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6267,7 +6267,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6281,7 +6281,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6295,7 +6295,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/microtransactions",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/microtransactions",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6309,7 +6309,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6323,7 +6323,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6337,7 +6337,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/mining",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/mining",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6351,7 +6351,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/mining-farm",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/mining-farm",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6365,7 +6365,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/mint",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/mint",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6379,7 +6379,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6393,7 +6393,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6407,7 +6407,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6421,7 +6421,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/monetary-policy",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/monetary-policy",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6435,7 +6435,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/money-markets",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/money-markets",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6449,7 +6449,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/monitoring-tag",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/monitoring-tag",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6463,7 +6463,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/moon",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/moon",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6477,7 +6477,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6491,7 +6491,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/moving-average-envelopes",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/moving-average-envelopes",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6505,7 +6505,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/moving-average-ribbon",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/moving-average-ribbon",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6519,7 +6519,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/mt-gox",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/mt-gox",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6533,7 +6533,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6547,7 +6547,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6561,7 +6561,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/multisignature",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/multisignature",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6575,7 +6575,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/nakamoto-consensus",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/nakamoto-consensus",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6589,7 +6589,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6603,7 +6603,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/net-asset-value-nav",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/net-asset-value-nav",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6617,7 +6617,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6631,7 +6631,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6645,7 +6645,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6659,7 +6659,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6673,7 +6673,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6687,7 +6687,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6701,7 +6701,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/nft-floor-prices",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/nft-floor-prices",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6715,7 +6715,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/nft-mystery-boxes",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/nft-mystery-boxes",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6729,7 +6729,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/ngmi",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/ngmi",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6743,7 +6743,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6757,7 +6757,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/node",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/node",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6771,7 +6771,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6785,7 +6785,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/non-fungible-token-nft",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/non-fungible-token-nft",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6799,7 +6799,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/nonce",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/nonce",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6813,7 +6813,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/oco-order",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/oco-order",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6827,7 +6827,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/off-chain",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/off-chain",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6841,7 +6841,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6855,7 +6855,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/offline-signing-orchestrator-oso",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/offline-signing-orchestrator-oso",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6869,7 +6869,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/offshore-account",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/offshore-account",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6883,7 +6883,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6897,7 +6897,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/on-chain",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/on-chain",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6911,7 +6911,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6925,7 +6925,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6939,7 +6939,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/opbnb",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/opbnb",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6953,7 +6953,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/open-source-software-oss",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/open-source-software-oss",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6967,7 +6967,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6981,7 +6981,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6995,7 +6995,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/opportunity-cost",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/opportunity-cost",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7009,7 +7009,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7023,7 +7023,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7037,7 +7037,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/oracle",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/oracle",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7051,7 +7051,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/orc-20-tokens",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/orc-20-tokens",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7065,7 +7065,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/order-book",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/order-book",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7079,7 +7079,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/ordinals",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/ordinals",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7093,7 +7093,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/orphan-block",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/orphan-block",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7107,7 +7107,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7121,7 +7121,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7135,7 +7135,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/pancakeswap",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/pancakeswap",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7149,7 +7149,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/paper-wallet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/paper-wallet",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7163,7 +7163,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/parallelization",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/parallelization",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7177,7 +7177,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7191,7 +7191,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7205,7 +7205,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/passive-management",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/passive-management",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7219,7 +7219,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7233,7 +7233,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7247,7 +7247,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7261,7 +7261,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7275,7 +7275,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/peer-to-peer",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/peer-to-peer",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7289,7 +7289,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/pegged-currency",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/pegged-currency",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7303,7 +7303,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7317,7 +7317,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/permissionless-blockchain",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/permissionless-blockchain",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7331,7 +7331,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/phishing",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/phishing",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7345,7 +7345,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7359,7 +7359,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/plasma",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/plasma",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7373,7 +7373,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7387,7 +7387,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/polkadot-crowdloan",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/polkadot-crowdloan",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7401,7 +7401,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7415,7 +7415,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/ponzi-scheme",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/ponzi-scheme",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7429,7 +7429,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7443,7 +7443,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7457,7 +7457,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/premining",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/premining",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7471,7 +7471,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/price-action",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/price-action",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7485,7 +7485,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/prisoners-dilemma",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/prisoners-dilemma",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7499,7 +7499,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7513,7 +7513,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7527,7 +7527,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/private-key",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/private-key",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7541,7 +7541,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/private-sale",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/private-sale",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7555,7 +7555,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/progressive-web-application",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/progressive-web-application",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7569,7 +7569,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/proof-of-attendance-protocol-poap",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/proof-of-attendance-protocol-poap",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7583,7 +7583,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/proof-of-reserves-por",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/proof-of-reserves-por",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7597,7 +7597,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/proof-of-stake",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/proof-of-stake",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7611,7 +7611,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/proof-of-staked-authority-posa",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/proof-of-staked-authority-posa",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7625,7 +7625,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/proof-of-work",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/proof-of-work",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7639,7 +7639,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/proposer-builder-separation-pbs",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/proposer-builder-separation-pbs",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7653,7 +7653,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/proto-danksharding",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/proto-danksharding",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7667,7 +7667,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7681,7 +7681,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/pseudorandom",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/pseudorandom",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7695,7 +7695,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7709,7 +7709,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7723,7 +7723,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/public-key",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/public-key",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7737,7 +7737,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7751,7 +7751,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/pump-and-dump",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/pump-and-dump",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7765,7 +7765,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7779,7 +7779,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/quantitative-easing-qe",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/quantitative-easing-qe",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7793,7 +7793,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/quantitative-tightening-qt",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/quantitative-tightening-qt",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7807,7 +7807,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/quantum-computing",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/quantum-computing",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7821,7 +7821,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7835,7 +7835,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/race-attack",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/race-attack",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7849,7 +7849,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/ransomware",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/ransomware",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7863,7 +7863,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7877,7 +7877,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/real-world-assets-rwas",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/real-world-assets-rwas",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7891,7 +7891,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/recession",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/recession",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7905,7 +7905,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/recursive-inscription",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/recursive-inscription",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7919,7 +7919,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/rekt",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/rekt",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7933,7 +7933,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/relative-strength-index",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/relative-strength-index",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7947,7 +7947,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7961,7 +7961,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7975,7 +7975,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/resistance",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/resistance",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7989,7 +7989,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/return-on-investment",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/return-on-investment",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8003,7 +8003,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/revenge-trading",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/revenge-trading",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8017,7 +8017,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8031,7 +8031,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/risk-premium",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/risk-premium",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8045,7 +8045,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/roadmap",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/roadmap",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8059,7 +8059,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8073,7 +8073,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8087,7 +8087,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8101,7 +8101,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/routing-attack",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/routing-attack",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8115,7 +8115,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8129,7 +8129,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/rug-pull",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/rug-pull",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8143,7 +8143,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8157,7 +8157,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/sahm-rule",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/sahm-rule",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8171,7 +8171,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8185,7 +8185,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8199,7 +8199,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/sandwich-trading",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/sandwich-trading",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8213,7 +8213,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8227,7 +8227,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/satoshi",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/satoshi",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8241,7 +8241,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/satoshi-nakamoto",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/satoshi-nakamoto",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8255,7 +8255,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8269,7 +8269,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8283,7 +8283,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8297,7 +8297,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8311,7 +8311,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8325,7 +8325,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8339,7 +8339,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8353,7 +8353,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/secure-asset-fund-for-users",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/secure-asset-fund-for-users",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8367,7 +8367,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/securities-and-exchange-commission",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/securities-and-exchange-commission",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8381,7 +8381,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/security-audit",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/security-audit",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8395,7 +8395,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8409,7 +8409,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8423,7 +8423,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/security-token-offering-sto",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/security-token-offering-sto",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8437,7 +8437,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/seed-phrase",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/seed-phrase",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8451,7 +8451,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/seed-tag",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/seed-tag",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8465,7 +8465,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/segregated-witness",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/segregated-witness",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8479,7 +8479,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8493,7 +8493,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8507,7 +8507,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/selfish-mining",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/selfish-mining",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8521,7 +8521,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/sell-wall",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/sell-wall",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8535,7 +8535,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/sentiment",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/sentiment",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8549,7 +8549,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8563,7 +8563,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8577,7 +8577,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8591,7 +8591,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8605,7 +8605,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/sharding",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/sharding",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8619,7 +8619,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/sharpe-ratio",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/sharpe-ratio",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8633,7 +8633,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8647,7 +8647,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8661,7 +8661,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/sidechains",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/sidechains",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8675,7 +8675,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/simple-moving-average-sma",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/simple-moving-average-sma",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8689,7 +8689,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/slashing",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/slashing",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8703,7 +8703,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8717,7 +8717,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/slippage",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/slippage",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8731,7 +8731,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8745,7 +8745,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/smart-contract",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/smart-contract",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8759,7 +8759,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/smart-contract-wallet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/smart-contract-wallet",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8773,7 +8773,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/snapshot",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/snapshot",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8787,7 +8787,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/social-recovery-wallet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/social-recovery-wallet",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8801,7 +8801,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/social-trading",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/social-trading",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8815,7 +8815,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/socialfi",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/socialfi",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8829,7 +8829,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8843,7 +8843,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/soft-landing",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/soft-landing",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8857,7 +8857,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/solidity",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/solidity",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8871,7 +8871,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/source-code",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/source-code",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8885,7 +8885,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/spl",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/spl",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8899,7 +8899,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/src-20-tokens",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/src-20-tokens",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8913,7 +8913,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/stablecoin",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/stablecoin",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8927,7 +8927,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/stagflation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/stagflation",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8941,7 +8941,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8955,7 +8955,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8969,7 +8969,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/staking-pool",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/staking-pool",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8983,7 +8983,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8997,7 +8997,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/state-channel",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/state-channel",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9011,7 +9011,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9025,7 +9025,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/steth",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/steth",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9039,7 +9039,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9053,7 +9053,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/stock-variable",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/stock-variable",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9067,7 +9067,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/store-of-value",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/store-of-value",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9081,7 +9081,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9095,7 +9095,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/supercomputer",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/supercomputer",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9109,7 +9109,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/supply-chain",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/supply-chain",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9123,7 +9123,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/support",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/support",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9137,7 +9137,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9151,7 +9151,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/sybil-attack",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/sybil-attack",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9165,7 +9165,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9179,7 +9179,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/taker",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/taker",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9193,7 +9193,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/tank",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/tank",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9207,7 +9207,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9221,7 +9221,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9235,7 +9235,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/testnet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/testnet",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9249,7 +9249,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9263,7 +9263,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9277,7 +9277,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9291,7 +9291,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/ticker",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/ticker",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9305,7 +9305,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/ticker-symbol",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/ticker-symbol",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9319,7 +9319,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/token",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/token",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9333,7 +9333,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/token-generation-event-tge",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/token-generation-event-tge",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9347,7 +9347,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/token-lockup",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/token-lockup",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9361,7 +9361,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/token-merge",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/token-merge",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9375,7 +9375,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/token-sale",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/token-sale",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9389,7 +9389,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9403,7 +9403,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/token-standards",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/token-standards",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9417,7 +9417,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/tokenization",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/tokenization",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9431,7 +9431,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/tokenomics",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/tokenomics",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9445,7 +9445,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/total-supply",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/total-supply",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9459,7 +9459,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/total-value-locked-tvl",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/total-value-locked-tvl",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9473,7 +9473,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/tradfi",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/tradfi",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9487,7 +9487,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9501,7 +9501,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9515,7 +9515,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9529,7 +9529,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/transaction-id",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/transaction-id",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9543,7 +9543,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9557,7 +9557,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/transactions-per-second-tps",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/transactions-per-second-tps",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9571,7 +9571,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9585,7 +9585,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/treasury-bills-t-bills",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/treasury-bills-t-bills",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9599,7 +9599,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9613,7 +9613,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/trueusd-tusd",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/trueusd-tusd",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9627,7 +9627,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9641,7 +9641,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/trustless",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/trustless",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9655,7 +9655,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/turing-complete",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/turing-complete",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9669,7 +9669,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9683,7 +9683,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9697,7 +9697,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9711,7 +9711,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/understanding-cz-s-number-4",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/understanding-cz-s-number-4",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9725,7 +9725,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9739,7 +9739,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9753,7 +9753,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/unit-of-account",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/unit-of-account",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9767,7 +9767,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9781,7 +9781,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/unspent-transaction-output-utxo",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/unspent-transaction-output-utxo",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9795,7 +9795,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9809,7 +9809,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9823,7 +9823,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9837,7 +9837,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9851,7 +9851,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/user-interface",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/user-interface",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9865,7 +9865,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/utility-token",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/utility-token",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9879,7 +9879,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9893,7 +9893,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9907,7 +9907,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9921,7 +9921,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/verification-code",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/verification-code",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9935,7 +9935,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9949,7 +9949,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9963,7 +9963,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/virtual-machine",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/virtual-machine",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9977,7 +9977,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/vladimir-club",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/vladimir-club",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9991,7 +9991,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/volatility",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/volatility",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10005,7 +10005,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/volume",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/volume",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10019,7 +10019,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/wagmi",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/wagmi",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10033,7 +10033,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/wallet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/wallet",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10047,7 +10047,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10061,7 +10061,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10075,7 +10075,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/wash-trading",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/wash-trading",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10089,7 +10089,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/weak-hands",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/weak-hands",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10103,7 +10103,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/weak-subjectivity",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/weak-subjectivity",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10117,7 +10117,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/web-1",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/web-1",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10131,7 +10131,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10145,7 +10145,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10159,7 +10159,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10173,7 +10173,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10187,7 +10187,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10201,7 +10201,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/wei",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/wei",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10215,7 +10215,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/weighted-moving-average-wma",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/weighted-moving-average-wma",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10229,7 +10229,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/whale",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/whale",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10243,7 +10243,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/whiskers",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/whiskers",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10257,7 +10257,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/whitelist",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/whitelist",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10271,7 +10271,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10285,7 +10285,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/wick",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/wick",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10299,7 +10299,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/win-rate",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/win-rate",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10313,7 +10313,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/wrapped-ether",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/wrapped-ether",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10327,7 +10327,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10341,7 +10341,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/wyckoff",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/wyckoff",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10355,7 +10355,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10369,7 +10369,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10383,7 +10383,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10397,7 +10397,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10411,7 +10411,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/yield-farming",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/yield-farming",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10425,7 +10425,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10439,7 +10439,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10453,7 +10453,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/zero-knowledge-proofs",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/zero-knowledge-proofs",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10467,7 +10467,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10481,7 +10481,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/zk-rollup",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/zk-rollup",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10495,7 +10495,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/zk-snarks",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/zk-snarks",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10509,7 +10509,7 @@
       "definitionSource": "https://academy.binance.com/uk/glossary/zk-starks",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/uk/glossary/zk-starks",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""

--- a/locales/uk-UA/uk-UA.json
+++ b/locales/uk-UA/uk-UA.json
@@ -9576,7 +9576,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "treasury-bills-t-bills": {
+    "treasury-bills": {
       "term": "Казначейські векселі (T-Bills)",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/vi-VN/vi-VN.json
+++ b/locales/vi-VN/vi-VN.json
@@ -9576,7 +9576,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "treasury-bills-t-bills": {
+    "treasury-bills": {
       "term": "Trái phiếu kho bạc (T-Bill)",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/vi-VN/vi-VN.json
+++ b/locales/vi-VN/vi-VN.json
@@ -9,7 +9,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -23,7 +23,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -37,7 +37,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -51,7 +51,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -65,7 +65,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -79,7 +79,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/51-percent-attack",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/51-percent-attack",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -93,7 +93,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -107,7 +107,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/absolute-advantage",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/absolute-advantage",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -121,7 +121,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -135,7 +135,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -149,7 +149,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/active-management",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/active-management",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -163,7 +163,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/actively-validated-services-avs",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/actively-validated-services-avs",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -177,7 +177,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/ad-hoc",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/ad-hoc",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -191,7 +191,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/address",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/address",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -205,7 +205,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -219,7 +219,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -233,7 +233,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -247,7 +247,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/airdrop",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/airdrop",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -261,7 +261,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -275,7 +275,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -289,7 +289,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/algorithm",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/algorithm",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -303,7 +303,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/all-or-none-order",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/all-or-none-order",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -317,7 +317,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/all-time-high",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/all-time-high",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -331,7 +331,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/allocation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/allocation",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -345,7 +345,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/alpha",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/alpha",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -359,7 +359,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/altcoin",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/altcoin",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -373,7 +373,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -387,7 +387,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/angel-investor",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/angel-investor",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -401,7 +401,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/anti-money-laundering",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/anti-money-laundering",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -415,7 +415,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -429,7 +429,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -443,7 +443,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -457,7 +457,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/application-programming-interface",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/application-programming-interface",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -471,7 +471,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/application-specific-integrated-circuit",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/application-specific-integrated-circuit",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -485,7 +485,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/arbitrage",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/arbitrage",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -499,7 +499,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -513,7 +513,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/arc-20",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/arc-20",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -527,7 +527,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/artificial-intelligence-ai",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/artificial-intelligence-ai",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -541,7 +541,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -555,7 +555,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/asic-resistant",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/asic-resistant",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -569,7 +569,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/asking-price",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/asking-price",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -583,7 +583,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/asset-management",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/asset-management",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -597,7 +597,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -611,7 +611,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/assets-under-management-aum",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/assets-under-management-aum",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -625,7 +625,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/asynchronous",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/asynchronous",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -639,7 +639,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/atomic-swap",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/atomic-swap",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -653,7 +653,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/attack-surface",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/attack-surface",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -667,7 +667,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -681,7 +681,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/auction",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/auction",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -695,7 +695,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -709,7 +709,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/automated-market-maker-amm",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/automated-market-maker-amm",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -723,7 +723,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -737,7 +737,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -751,7 +751,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -765,7 +765,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/b-tokens",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/b-tokens",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -779,7 +779,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/bags",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/bags",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -793,7 +793,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -807,7 +807,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/beacon-chain",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/beacon-chain",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -821,7 +821,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/bear-market",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/bear-market",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -835,7 +835,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/benchmark",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/benchmark",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -849,7 +849,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/bep-1155",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/bep-1155",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -863,7 +863,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/bep-20",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/bep-20",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -877,7 +877,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/bep-721",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/bep-721",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -891,7 +891,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/bep-95",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/bep-95",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -905,7 +905,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -919,7 +919,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/beta-coefficient",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/beta-coefficient",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -933,7 +933,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/beta-release",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/beta-release",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -947,7 +947,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/bid-ask-spread",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/bid-ask-spread",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -961,7 +961,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/bid-price",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/bid-price",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -975,7 +975,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -989,7 +989,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/binance-blockchain-charity-foundation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/binance-blockchain-charity-foundation",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1003,7 +1003,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/binance-ecosystem-fund",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/binance-ecosystem-fund",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1017,7 +1017,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/binancian",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/binancian",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1031,7 +1031,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/bitcoin",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/bitcoin",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1045,7 +1045,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/bitcoin-core",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/bitcoin-core",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1059,7 +1059,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/bitcoin-dominance",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/bitcoin-dominance",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1073,7 +1073,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/bitcoin-maximalists",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/bitcoin-maximalists",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1087,7 +1087,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/bitcoin-pizza",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/bitcoin-pizza",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1101,7 +1101,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/black-swan-event",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/black-swan-event",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1115,7 +1115,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/block",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/block",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1129,7 +1129,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/block-explorer",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/block-explorer",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1143,7 +1143,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/block-header",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/block-header",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1157,7 +1157,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/block-height",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/block-height",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1171,7 +1171,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/block-reward",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/block-reward",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1185,7 +1185,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1199,7 +1199,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1213,7 +1213,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/blockchain",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/blockchain",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1227,7 +1227,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1241,7 +1241,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1255,7 +1255,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/bloom-filter",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/bloom-filter",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1269,7 +1269,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/blue-chip-token",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/blue-chip-token",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1283,7 +1283,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/bnb",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/bnb",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1297,7 +1297,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1311,7 +1311,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/bnsol",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/bnsol",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1325,7 +1325,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/bollinger-bands",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/bollinger-bands",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1339,7 +1339,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/bond",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/bond",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1353,7 +1353,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/bounty",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/bounty",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1367,7 +1367,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1381,7 +1381,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1395,7 +1395,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/brc-20-tokens",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/brc-20-tokens",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1409,7 +1409,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/break-even-point",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/break-even-point",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1423,7 +1423,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/breakeven-multiple",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/breakeven-multiple",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1437,7 +1437,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/breakout",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/breakout",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1451,7 +1451,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1465,7 +1465,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/bscscan",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/bscscan",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1479,7 +1479,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1493,7 +1493,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/btc-wallet-address",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/btc-wallet-address",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1507,7 +1507,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/buidl",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/buidl",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1521,7 +1521,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/bull-market",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/bull-market",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1535,7 +1535,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/burner-wallet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/burner-wallet",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1549,7 +1549,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/buy-wall",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/buy-wall",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1563,7 +1563,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1577,7 +1577,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1591,7 +1591,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1605,7 +1605,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/candidate-block",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/candidate-block",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1619,7 +1619,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/candlestick",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/candlestick",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1633,7 +1633,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/capitulation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/capitulation",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1647,7 +1647,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1661,7 +1661,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/censorship-resistance",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/censorship-resistance",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1675,7 +1675,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/central-bank",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/central-bank",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1689,7 +1689,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/central-bank-digital-currency-cbdc",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/central-bank-digital-currency-cbdc",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1703,7 +1703,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/central-processing-unit",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/central-processing-unit",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1717,7 +1717,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/centralized",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/centralized",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1731,7 +1731,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/centralized-exchange",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/centralized-exchange",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1745,7 +1745,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1759,7 +1759,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1773,7 +1773,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/chatgpt",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/chatgpt",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1787,7 +1787,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1801,7 +1801,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/cipher",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/cipher",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1815,7 +1815,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/circulating-supply",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/circulating-supply",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1829,7 +1829,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1843,7 +1843,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/cloud",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/cloud",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1857,7 +1857,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1871,7 +1871,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/coin",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/coin",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1885,7 +1885,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1899,7 +1899,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1913,7 +1913,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/cold-storage",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/cold-storage",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1927,7 +1927,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1941,7 +1941,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/collateral",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/collateral",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1955,7 +1955,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/colocation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/colocation",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1969,7 +1969,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/commodity-futures-trading-commission",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/commodity-futures-trading-commission",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1983,7 +1983,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1997,7 +1997,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2011,7 +2011,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/compound-interest",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/compound-interest",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2025,7 +2025,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2039,7 +2039,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/confirmation-time",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/confirmation-time",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2053,7 +2053,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/confluence",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/confluence",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2067,7 +2067,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2081,7 +2081,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/consensus-algorithm",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/consensus-algorithm",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2095,7 +2095,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2109,7 +2109,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2123,7 +2123,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2137,7 +2137,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2151,7 +2151,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2165,7 +2165,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/consumer-price-index-(cpi)",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/consumer-price-index-(cpi)",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2179,7 +2179,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/contango-and-backwardation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/contango-and-backwardation",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2193,7 +2193,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2207,7 +2207,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2221,7 +2221,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2235,7 +2235,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/copy-trading",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/copy-trading",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2249,7 +2249,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/counterparty-risk",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/counterparty-risk",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2263,7 +2263,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/credentials",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/credentials",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2277,7 +2277,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/cross-chain-bridges",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/cross-chain-bridges",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2291,7 +2291,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2305,7 +2305,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2319,7 +2319,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2333,7 +2333,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2347,7 +2347,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/crypto-etfs",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/crypto-etfs",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2361,7 +2361,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/crypto-fear-and-greed-index",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/crypto-fear-and-greed-index",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2375,7 +2375,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2389,7 +2389,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/crypto-protocol",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/crypto-protocol",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2403,7 +2403,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2417,7 +2417,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/crypto-winter",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/crypto-winter",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2431,7 +2431,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2445,7 +2445,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/cryptocurrency",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/cryptocurrency",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2459,7 +2459,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2473,7 +2473,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/cryptography",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/cryptography",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2487,7 +2487,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2501,7 +2501,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/custody",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/custody",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2515,7 +2515,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2529,7 +2529,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/daemon",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/daemon",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2543,7 +2543,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2557,7 +2557,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/danksharding",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/danksharding",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2571,7 +2571,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2585,7 +2585,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2599,7 +2599,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2613,7 +2613,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/dead-cat-bounce",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/dead-cat-bounce",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2627,7 +2627,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/death-cross",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/death-cross",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2641,7 +2641,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2655,7 +2655,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/decentralized-application",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/decentralized-application",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2669,7 +2669,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/decentralized-autonomous-cooperative",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/decentralized-autonomous-cooperative",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2683,7 +2683,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/decentralized-autonomous-organization",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/decentralized-autonomous-organization",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2697,7 +2697,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/decentralized-exchange",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/decentralized-exchange",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2711,7 +2711,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2725,7 +2725,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/decentralized-indexes",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/decentralized-indexes",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2739,7 +2739,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2753,7 +2753,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/decryption",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/decryption",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2767,7 +2767,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/deep-web",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/deep-web",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2781,7 +2781,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2795,7 +2795,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2809,7 +2809,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/delisting",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/delisting",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2823,7 +2823,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2837,7 +2837,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/depeg",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/depeg",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2851,7 +2851,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2865,7 +2865,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/depression",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/depression",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2879,7 +2879,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2893,7 +2893,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/design-flaw-attack",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/design-flaw-attack",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2907,7 +2907,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2921,7 +2921,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2935,7 +2935,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2949,7 +2949,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2963,7 +2963,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/diamond-hands",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/diamond-hands",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2977,7 +2977,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/difficulty",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/difficulty",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2991,7 +2991,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/difficulty-bomb",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/difficulty-bomb",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3005,7 +3005,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3019,7 +3019,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3033,7 +3033,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/digital-signature",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/digital-signature",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3047,7 +3047,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3061,7 +3061,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/direct-market-access-dma",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/direct-market-access-dma",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3075,7 +3075,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3089,7 +3089,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/divergence",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/divergence",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3103,7 +3103,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/diversification",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/diversification",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3117,7 +3117,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3131,7 +3131,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/do-your-own-research",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/do-your-own-research",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3145,7 +3145,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/dollar-cost-averaging",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/dollar-cost-averaging",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3159,7 +3159,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/dot-plot",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/dot-plot",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3173,7 +3173,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3187,7 +3187,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/double-spending",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/double-spending",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3201,7 +3201,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/eclipse-attack",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/eclipse-attack",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3215,7 +3215,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3229,7 +3229,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3243,7 +3243,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/efficient-market-hypothesis-emh",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/efficient-market-hypothesis-emh",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3257,7 +3257,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/eigenlayer",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/eigenlayer",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3271,7 +3271,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/eip",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/eip",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3285,7 +3285,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3299,7 +3299,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/eip-3074",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/eip-3074",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3313,7 +3313,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/eip-4844",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/eip-4844",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3327,7 +3327,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/eip-7251",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/eip-7251",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3341,7 +3341,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/eip-7702",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/eip-7702",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3355,7 +3355,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/elasticity",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/elasticity",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3369,7 +3369,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3383,7 +3383,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/encryption",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/encryption",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3397,7 +3397,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/endogenous-variable",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/endogenous-variable",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3411,7 +3411,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3425,7 +3425,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3439,7 +3439,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3453,7 +3453,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3467,7 +3467,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/erc-1155",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/erc-1155",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3481,7 +3481,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/erc-20",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/erc-20",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3495,7 +3495,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/erc-404",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/erc-404",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3509,7 +3509,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/erc-721",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/erc-721",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3523,7 +3523,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/etf",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/etf",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3537,7 +3537,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3551,7 +3551,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3565,7 +3565,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3579,7 +3579,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3593,7 +3593,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/ethereum-classic",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/ethereum-classic",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3607,7 +3607,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/ethereum-foundation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/ethereum-foundation",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3621,7 +3621,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3635,7 +3635,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3649,7 +3649,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3663,7 +3663,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3677,7 +3677,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/ethereum-virtual-machine-evm",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/ethereum-virtual-machine-evm",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3691,7 +3691,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3705,7 +3705,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3719,7 +3719,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3733,7 +3733,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/exchange",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/exchange",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3747,7 +3747,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3761,7 +3761,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3775,7 +3775,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/exogenous-variable",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/exogenous-variable",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3789,7 +3789,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/exponential-moving-average-ema",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/exponential-moving-average-ema",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3803,7 +3803,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/externally-owned-account-eoa",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/externally-owned-account-eoa",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3817,7 +3817,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/fakeout",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/fakeout",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3831,7 +3831,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/falling-knife",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/falling-knife",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3845,7 +3845,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/fan-tokens",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/fan-tokens",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3859,7 +3859,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3873,7 +3873,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3887,7 +3887,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3901,7 +3901,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/fear-of-missing-out",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/fear-of-missing-out",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3915,7 +3915,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/fear-uncertainty-and-doubt",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/fear-uncertainty-and-doubt",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3929,7 +3929,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/fiat",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/fiat",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3943,7 +3943,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3957,7 +3957,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/fibonacci-retracement",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/fibonacci-retracement",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3971,7 +3971,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/fill-or-kill-order",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/fill-or-kill-order",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3985,7 +3985,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/finality",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/finality",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3999,7 +3999,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4013,7 +4013,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4027,7 +4027,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4041,7 +4041,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4055,7 +4055,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4069,7 +4069,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4083,7 +4083,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/first-mover-advantage",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/first-mover-advantage",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4097,7 +4097,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/fiscal-policy",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/fiscal-policy",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4111,7 +4111,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/flappening",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/flappening",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4125,7 +4125,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/flashbots",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/flashbots",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4139,7 +4139,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/flippening",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/flippening",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4153,7 +4153,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/flow-variable",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/flow-variable",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4167,7 +4167,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/forced-liquidation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/forced-liquidation",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4181,7 +4181,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/forex-fx",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/forex-fx",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4195,7 +4195,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/fork",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/fork",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4209,7 +4209,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/formal-verification",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/formal-verification",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4223,7 +4223,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4237,7 +4237,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/fraud-proof",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/fraud-proof",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4251,7 +4251,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/fren",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/fren",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4265,7 +4265,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4279,7 +4279,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/full-node",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/full-node",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4293,7 +4293,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/fully-diluted-valuation-fdv",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/fully-diluted-valuation-fdv",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4307,7 +4307,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/fundamental-analysis",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/fundamental-analysis",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4321,7 +4321,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/funding-fees",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/funding-fees",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4335,7 +4335,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/fungibility",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/fungibility",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4349,7 +4349,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/futures-contract",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/futures-contract",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4363,7 +4363,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/gamefi",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/gamefi",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4377,7 +4377,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4391,7 +4391,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/gas",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/gas",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4405,7 +4405,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4419,7 +4419,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/gas-limit",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/gas-limit",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4433,7 +4433,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4447,7 +4447,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4461,7 +4461,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4475,7 +4475,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/gdp-deflator",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/gdp-deflator",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4489,7 +4489,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/general-public-license",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/general-public-license",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4503,7 +4503,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/genesis-block",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/genesis-block",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4517,7 +4517,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4531,7 +4531,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/github",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/github",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4545,7 +4545,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/gm-good-morning",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/gm-good-morning",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4559,7 +4559,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4573,7 +4573,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/golden-cross",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/golden-cross",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4587,7 +4587,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/golden-ratio",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/golden-ratio",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4601,7 +4601,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/goldilocks",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/goldilocks",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4615,7 +4615,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/gossip-protocol",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/gossip-protocol",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4629,7 +4629,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4643,7 +4643,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/gross-domestic-product-gdp",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/gross-domestic-product-gdp",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4657,7 +4657,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4671,7 +4671,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/gwei",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/gwei",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4685,7 +4685,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/hackathon",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/hackathon",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4699,7 +4699,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/hacker",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/hacker",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4713,7 +4713,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/haha-money-printer-go-brrrrr",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/haha-money-printer-go-brrrrr",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4727,7 +4727,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/halving",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/halving",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4741,7 +4741,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/hard-cap",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/hard-cap",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4755,7 +4755,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4769,7 +4769,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/hard-landing",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/hard-landing",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4783,7 +4783,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4797,7 +4797,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4811,7 +4811,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/hash",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/hash",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4825,7 +4825,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/hash-rate",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/hash-rate",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4839,7 +4839,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/hashed-timelock-contract",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/hashed-timelock-contract",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4853,7 +4853,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4867,7 +4867,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/herd-instinct",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/herd-instinct",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4881,7 +4881,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4895,7 +4895,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/high-frequency-trading-hft",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/high-frequency-trading-hft",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4909,7 +4909,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/hodl",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/hodl",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4923,7 +4923,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/honeypot",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/honeypot",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4937,7 +4937,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4951,7 +4951,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4965,7 +4965,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4979,7 +4979,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4993,7 +4993,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5007,7 +5007,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/iceberg-order",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/iceberg-order",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5021,7 +5021,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5035,7 +5035,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5049,7 +5049,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/immutability",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/immutability",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5063,7 +5063,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/index-funds",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/index-funds",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5077,7 +5077,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5091,7 +5091,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/initial-coin-offering",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/initial-coin-offering",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5105,7 +5105,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/initial-dex-offering-ido",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/initial-dex-offering-ido",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5119,7 +5119,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/initial-exchange-offering",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/initial-exchange-offering",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5133,7 +5133,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/initial-public-offering",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/initial-public-offering",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5147,7 +5147,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/inscription",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/inscription",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5161,7 +5161,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5175,7 +5175,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/integrated-circuit",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/integrated-circuit",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5189,7 +5189,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/interest-rates",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/interest-rates",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5203,7 +5203,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5217,7 +5217,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/interoperability",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/interoperability",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5231,7 +5231,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5245,7 +5245,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/interplanetary-file-system-ipfs",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/interplanetary-file-system-ipfs",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5259,7 +5259,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/iou",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/iou",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5273,7 +5273,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5287,7 +5287,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5301,7 +5301,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5315,7 +5315,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/isolated-margin",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/isolated-margin",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5329,7 +5329,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/issuance",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/issuance",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5343,7 +5343,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5357,7 +5357,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5371,7 +5371,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/keccak",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/keccak",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5385,7 +5385,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5399,7 +5399,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/know-your-customer",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/know-your-customer",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5413,7 +5413,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5427,7 +5427,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5441,7 +5441,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5455,7 +5455,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5469,7 +5469,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/laspeyres-index",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/laspeyres-index",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5483,7 +5483,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/latency",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/latency",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5497,7 +5497,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5511,7 +5511,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5525,7 +5525,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/law-of-demand",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/law-of-demand",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5539,7 +5539,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5553,7 +5553,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/layer-2",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/layer-2",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5567,7 +5567,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/ledger",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/ledger",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5581,7 +5581,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5595,7 +5595,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5609,7 +5609,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/leveraged-tokens",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/leveraged-tokens",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5623,7 +5623,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/library",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/library",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5637,7 +5637,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5651,7 +5651,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5665,7 +5665,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/lightning-network",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/lightning-network",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5679,7 +5679,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/limit-order",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/limit-order",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5693,7 +5693,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5707,7 +5707,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/linux",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/linux",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5721,7 +5721,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/liquid-staking",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/liquid-staking",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5735,7 +5735,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/liquid-staking-token-lst",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/liquid-staking-token-lst",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5749,7 +5749,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5763,7 +5763,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/liquidity",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/liquidity",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5777,7 +5777,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/liquidity-crisis",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/liquidity-crisis",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5791,7 +5791,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5805,7 +5805,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/liquidity-provider",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/liquidity-provider",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5819,7 +5819,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/liquidity-ratios",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/liquidity-ratios",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5833,7 +5833,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5847,7 +5847,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/listing",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/listing",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5861,7 +5861,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/mainnet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/mainnet",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5875,7 +5875,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/mainnet-swap",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/mainnet-swap",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5889,7 +5889,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/maker",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/maker",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5903,7 +5903,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5917,7 +5917,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/malware",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/malware",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5931,7 +5931,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/margin-trading",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/margin-trading",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5945,7 +5945,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5959,7 +5959,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/market-capitalization",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/market-capitalization",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5973,7 +5973,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/market-momentum",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/market-momentum",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5987,7 +5987,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/market-order",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/market-order",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6001,7 +6001,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/masternode",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/masternode",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6015,7 +6015,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/matching-engine",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/matching-engine",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6029,7 +6029,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6043,7 +6043,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/maximum-supply",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/maximum-supply",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6057,7 +6057,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6071,7 +6071,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/mempool",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/mempool",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6085,7 +6085,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6099,7 +6099,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6113,7 +6113,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/merged-mining",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/merged-mining",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6127,7 +6127,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6141,7 +6141,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/merkle-tree",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/merkle-tree",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6155,7 +6155,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6169,7 +6169,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/metadata",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/metadata",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6183,7 +6183,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6197,7 +6197,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6211,7 +6211,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6225,7 +6225,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6239,7 +6239,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6253,7 +6253,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/metaverse",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/metaverse",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6267,7 +6267,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6281,7 +6281,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6295,7 +6295,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/microtransactions",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/microtransactions",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6309,7 +6309,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6323,7 +6323,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6337,7 +6337,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/mining",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/mining",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6351,7 +6351,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/mining-farm",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/mining-farm",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6365,7 +6365,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/mint",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/mint",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6379,7 +6379,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6393,7 +6393,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6407,7 +6407,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6421,7 +6421,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/monetary-policy",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/monetary-policy",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6435,7 +6435,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/money-markets",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/money-markets",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6449,7 +6449,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/monitoring-tag",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/monitoring-tag",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6463,7 +6463,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/moon",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/moon",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6477,7 +6477,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6491,7 +6491,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/moving-average-envelopes",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/moving-average-envelopes",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6505,7 +6505,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/moving-average-ribbon",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/moving-average-ribbon",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6519,7 +6519,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/mt-gox",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/mt-gox",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6533,7 +6533,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6547,7 +6547,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6561,7 +6561,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/multisignature",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/multisignature",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6575,7 +6575,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/nakamoto-consensus",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/nakamoto-consensus",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6589,7 +6589,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6603,7 +6603,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/net-asset-value-nav",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/net-asset-value-nav",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6617,7 +6617,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6631,7 +6631,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6645,7 +6645,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6659,7 +6659,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6673,7 +6673,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6687,7 +6687,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6701,7 +6701,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/nft-floor-prices",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/nft-floor-prices",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6715,7 +6715,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/nft-mystery-boxes",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/nft-mystery-boxes",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6729,7 +6729,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/ngmi",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/ngmi",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6743,7 +6743,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6757,7 +6757,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/node",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/node",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6771,7 +6771,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6785,7 +6785,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/non-fungible-token-nft",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/non-fungible-token-nft",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6799,7 +6799,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/nonce",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/nonce",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6813,7 +6813,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/oco-order",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/oco-order",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6827,7 +6827,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/off-chain",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/off-chain",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6841,7 +6841,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6855,7 +6855,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/offline-signing-orchestrator-oso",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/offline-signing-orchestrator-oso",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6869,7 +6869,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/offshore-account",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/offshore-account",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6883,7 +6883,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6897,7 +6897,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/on-chain",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/on-chain",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6911,7 +6911,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6925,7 +6925,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6939,7 +6939,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/opbnb",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/opbnb",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6953,7 +6953,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/open-source-software-oss",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/open-source-software-oss",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6967,7 +6967,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6981,7 +6981,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6995,7 +6995,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/opportunity-cost",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/opportunity-cost",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7009,7 +7009,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7023,7 +7023,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7037,7 +7037,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/oracle",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/oracle",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7051,7 +7051,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/orc-20-tokens",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/orc-20-tokens",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7065,7 +7065,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/order-book",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/order-book",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7079,7 +7079,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/ordinals",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/ordinals",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7093,7 +7093,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/orphan-block",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/orphan-block",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7107,7 +7107,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7121,7 +7121,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7135,7 +7135,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/pancakeswap",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/pancakeswap",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7149,7 +7149,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/paper-wallet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/paper-wallet",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7163,7 +7163,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/parallelization",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/parallelization",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7177,7 +7177,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7191,7 +7191,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7205,7 +7205,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/passive-management",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/passive-management",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7219,7 +7219,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7233,7 +7233,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7247,7 +7247,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7261,7 +7261,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7275,7 +7275,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/peer-to-peer",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/peer-to-peer",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7289,7 +7289,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/pegged-currency",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/pegged-currency",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7303,7 +7303,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7317,7 +7317,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/permissionless-blockchain",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/permissionless-blockchain",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7331,7 +7331,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/phishing",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/phishing",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7345,7 +7345,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7359,7 +7359,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/plasma",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/plasma",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7373,7 +7373,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7387,7 +7387,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/polkadot-crowdloan",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/polkadot-crowdloan",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7401,7 +7401,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7415,7 +7415,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/ponzi-scheme",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/ponzi-scheme",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7429,7 +7429,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7443,7 +7443,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7457,7 +7457,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/premining",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/premining",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7471,7 +7471,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/price-action",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/price-action",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7485,7 +7485,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/prisoners-dilemma",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/prisoners-dilemma",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7499,7 +7499,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7513,7 +7513,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7527,7 +7527,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/private-key",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/private-key",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7541,7 +7541,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/private-sale",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/private-sale",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7555,7 +7555,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/progressive-web-application",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/progressive-web-application",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7569,7 +7569,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/proof-of-attendance-protocol-poap",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/proof-of-attendance-protocol-poap",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7583,7 +7583,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/proof-of-reserves-por",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/proof-of-reserves-por",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7597,7 +7597,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/proof-of-stake",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/proof-of-stake",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7611,7 +7611,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/proof-of-staked-authority-posa",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/proof-of-staked-authority-posa",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7625,7 +7625,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/proof-of-work",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/proof-of-work",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7639,7 +7639,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/proposer-builder-separation-pbs",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/proposer-builder-separation-pbs",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7653,7 +7653,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/proto-danksharding",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/proto-danksharding",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7667,7 +7667,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7681,7 +7681,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/pseudorandom",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/pseudorandom",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7695,7 +7695,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7709,7 +7709,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7723,7 +7723,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/public-key",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/public-key",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7737,7 +7737,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7751,7 +7751,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/pump-and-dump",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/pump-and-dump",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7765,7 +7765,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7779,7 +7779,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/quantitative-easing-qe",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/quantitative-easing-qe",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7793,7 +7793,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/quantitative-tightening-qt",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/quantitative-tightening-qt",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7807,7 +7807,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/quantum-computing",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/quantum-computing",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7821,7 +7821,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7835,7 +7835,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/race-attack",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/race-attack",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7849,7 +7849,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/ransomware",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/ransomware",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7863,7 +7863,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7877,7 +7877,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/real-world-assets-rwas",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/real-world-assets-rwas",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7891,7 +7891,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/recession",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/recession",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7905,7 +7905,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/recursive-inscription",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/recursive-inscription",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7919,7 +7919,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/rekt",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/rekt",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7933,7 +7933,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/relative-strength-index",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/relative-strength-index",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7947,7 +7947,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7961,7 +7961,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7975,7 +7975,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/resistance",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/resistance",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7989,7 +7989,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/return-on-investment",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/return-on-investment",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8003,7 +8003,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/revenge-trading",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/revenge-trading",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8017,7 +8017,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8031,7 +8031,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/risk-premium",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/risk-premium",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8045,7 +8045,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/roadmap",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/roadmap",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8059,7 +8059,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8073,7 +8073,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8087,7 +8087,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8101,7 +8101,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/routing-attack",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/routing-attack",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8115,7 +8115,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8129,7 +8129,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/rug-pull",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/rug-pull",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8143,7 +8143,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8157,7 +8157,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/sahm-rule",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/sahm-rule",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8171,7 +8171,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8185,7 +8185,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8199,7 +8199,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/sandwich-trading",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/sandwich-trading",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8213,7 +8213,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8227,7 +8227,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/satoshi",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/satoshi",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8241,7 +8241,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/satoshi-nakamoto",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/satoshi-nakamoto",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8255,7 +8255,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8269,7 +8269,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8283,7 +8283,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8297,7 +8297,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8311,7 +8311,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8325,7 +8325,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8339,7 +8339,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8353,7 +8353,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/secure-asset-fund-for-users",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/secure-asset-fund-for-users",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8367,7 +8367,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/securities-and-exchange-commission",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/securities-and-exchange-commission",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8381,7 +8381,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/security-audit",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/security-audit",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8395,7 +8395,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8409,7 +8409,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8423,7 +8423,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/security-token-offering-sto",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/security-token-offering-sto",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8437,7 +8437,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/seed-phrase",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/seed-phrase",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8451,7 +8451,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/seed-tag",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/seed-tag",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8465,7 +8465,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/segregated-witness",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/segregated-witness",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8479,7 +8479,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8493,7 +8493,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8507,7 +8507,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/selfish-mining",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/selfish-mining",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8521,7 +8521,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/sell-wall",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/sell-wall",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8535,7 +8535,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/sentiment",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/sentiment",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8549,7 +8549,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8563,7 +8563,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8577,7 +8577,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8591,7 +8591,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8605,7 +8605,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/sharding",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/sharding",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8619,7 +8619,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/sharpe-ratio",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/sharpe-ratio",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8633,7 +8633,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8647,7 +8647,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8661,7 +8661,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/sidechains",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/sidechains",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8675,7 +8675,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/simple-moving-average-sma",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/simple-moving-average-sma",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8689,7 +8689,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/slashing",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/slashing",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8703,7 +8703,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8717,7 +8717,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/slippage",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/slippage",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8731,7 +8731,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8745,7 +8745,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/smart-contract",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/smart-contract",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8759,7 +8759,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/smart-contract-wallet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/smart-contract-wallet",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8773,7 +8773,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/snapshot",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/snapshot",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8787,7 +8787,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/social-recovery-wallet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/social-recovery-wallet",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8801,7 +8801,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/social-trading",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/social-trading",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8815,7 +8815,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/socialfi",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/socialfi",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8829,7 +8829,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8843,7 +8843,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/soft-landing",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/soft-landing",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8857,7 +8857,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/solidity",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/solidity",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8871,7 +8871,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/source-code",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/source-code",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8885,7 +8885,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/spl",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/spl",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8899,7 +8899,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/src-20-tokens",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/src-20-tokens",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8913,7 +8913,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/stablecoin",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/stablecoin",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8927,7 +8927,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/stagflation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/stagflation",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8941,7 +8941,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8955,7 +8955,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8969,7 +8969,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/staking-pool",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/staking-pool",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8983,7 +8983,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8997,7 +8997,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/state-channel",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/state-channel",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9011,7 +9011,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9025,7 +9025,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/steth",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/steth",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9039,7 +9039,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9053,7 +9053,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/stock-variable",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/stock-variable",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9067,7 +9067,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/store-of-value",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/store-of-value",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9081,7 +9081,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9095,7 +9095,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/supercomputer",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/supercomputer",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9109,7 +9109,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/supply-chain",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/supply-chain",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9123,7 +9123,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/support",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/support",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9137,7 +9137,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9151,7 +9151,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/sybil-attack",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/sybil-attack",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9165,7 +9165,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9179,7 +9179,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/taker",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/taker",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9193,7 +9193,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/tank",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/tank",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9207,7 +9207,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9221,7 +9221,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9235,7 +9235,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/testnet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/testnet",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9249,7 +9249,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9263,7 +9263,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9277,7 +9277,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9291,7 +9291,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/ticker",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/ticker",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9305,7 +9305,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/ticker-symbol",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/ticker-symbol",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9319,7 +9319,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/token",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/token",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9333,7 +9333,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/token-generation-event-tge",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/token-generation-event-tge",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9347,7 +9347,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/token-lockup",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/token-lockup",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9361,7 +9361,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/token-merge",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/token-merge",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9375,7 +9375,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/token-sale",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/token-sale",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9389,7 +9389,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9403,7 +9403,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/token-standards",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/token-standards",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9417,7 +9417,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/tokenization",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/tokenization",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9431,7 +9431,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/tokenomics",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/tokenomics",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9445,7 +9445,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/total-supply",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/total-supply",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9459,7 +9459,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/total-value-locked-tvl",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/total-value-locked-tvl",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9473,7 +9473,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/tradfi",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/tradfi",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9487,7 +9487,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9501,7 +9501,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9515,7 +9515,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9529,7 +9529,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/transaction-id",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/transaction-id",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9543,7 +9543,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9557,7 +9557,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/transactions-per-second-tps",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/transactions-per-second-tps",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9571,7 +9571,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9585,7 +9585,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/treasury-bills-t-bills",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/treasury-bills-t-bills",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9599,7 +9599,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9613,7 +9613,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/trueusd-tusd",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/trueusd-tusd",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9627,7 +9627,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9641,7 +9641,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/trustless",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/trustless",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9655,7 +9655,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/turing-complete",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/turing-complete",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9669,7 +9669,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9683,7 +9683,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9697,7 +9697,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9711,7 +9711,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/understanding-cz-s-number-4",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/understanding-cz-s-number-4",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9725,7 +9725,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9739,7 +9739,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9753,7 +9753,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/unit-of-account",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/unit-of-account",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9767,7 +9767,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9781,7 +9781,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/unspent-transaction-output-utxo",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/unspent-transaction-output-utxo",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9795,7 +9795,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9809,7 +9809,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9823,7 +9823,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9837,7 +9837,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9851,7 +9851,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/user-interface",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/user-interface",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9865,7 +9865,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/utility-token",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/utility-token",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9879,7 +9879,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9893,7 +9893,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9907,7 +9907,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9921,7 +9921,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/verification-code",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/verification-code",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9935,7 +9935,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9949,7 +9949,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9963,7 +9963,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/virtual-machine",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/virtual-machine",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9977,7 +9977,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/vladimir-club",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/vladimir-club",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9991,7 +9991,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/volatility",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/volatility",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10005,7 +10005,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/volume",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/volume",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10019,7 +10019,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/wagmi",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/wagmi",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10033,7 +10033,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/wallet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/wallet",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10047,7 +10047,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10061,7 +10061,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10075,7 +10075,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/wash-trading",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/wash-trading",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10089,7 +10089,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/weak-hands",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/weak-hands",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10103,7 +10103,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/weak-subjectivity",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/weak-subjectivity",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10117,7 +10117,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/web-1",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/web-1",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10131,7 +10131,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10145,7 +10145,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10159,7 +10159,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10173,7 +10173,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10187,7 +10187,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10201,7 +10201,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/wei",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/wei",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10215,7 +10215,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/weighted-moving-average-wma",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/weighted-moving-average-wma",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10229,7 +10229,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/whale",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/whale",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10243,7 +10243,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/whiskers",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/whiskers",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10257,7 +10257,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/whitelist",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/whitelist",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10271,7 +10271,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10285,7 +10285,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/wick",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/wick",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10299,7 +10299,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/win-rate",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/win-rate",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10313,7 +10313,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/wrapped-ether",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/wrapped-ether",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10327,7 +10327,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10341,7 +10341,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/wyckoff",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/wyckoff",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10355,7 +10355,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10369,7 +10369,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10383,7 +10383,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10397,7 +10397,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10411,7 +10411,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/yield-farming",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/yield-farming",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10425,7 +10425,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10439,7 +10439,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10453,7 +10453,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/zero-knowledge-proofs",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/zero-knowledge-proofs",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10467,7 +10467,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10481,7 +10481,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/zk-rollup",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/zk-rollup",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10495,7 +10495,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/zk-snarks",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/zk-snarks",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10509,7 +10509,7 @@
       "definitionSource": "https://academy.binance.com/vi/glossary/zk-starks",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/vi/glossary/zk-starks",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""

--- a/locales/zh-CN/zh-CN.json
+++ b/locales/zh-CN/zh-CN.json
@@ -9576,7 +9576,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "treasury-bills-t-bills": {
+    "treasury-bills": {
       "term": "国库券 (T-bill)",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/zh-CN/zh-CN.json
+++ b/locales/zh-CN/zh-CN.json
@@ -9,7 +9,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -23,7 +23,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -37,7 +37,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -51,7 +51,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -65,7 +65,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -79,7 +79,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/51-percent-attack",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/51-percent-attack",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -93,7 +93,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -107,7 +107,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/absolute-advantage",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/absolute-advantage",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -121,7 +121,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -135,7 +135,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -149,7 +149,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/active-management",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/active-management",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -163,7 +163,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/actively-validated-services-avs",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/actively-validated-services-avs",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -177,7 +177,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/ad-hoc",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/ad-hoc",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -191,7 +191,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/address",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/address",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -205,7 +205,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -219,7 +219,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -233,7 +233,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -247,7 +247,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/airdrop",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/airdrop",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -261,7 +261,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -275,7 +275,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -289,7 +289,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/algorithm",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/algorithm",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -303,7 +303,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/all-or-none-order",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/all-or-none-order",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -317,7 +317,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/all-time-high",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/all-time-high",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -331,7 +331,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/allocation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/allocation",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -345,7 +345,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/alpha",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/alpha",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -359,7 +359,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/altcoin",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/altcoin",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -373,7 +373,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -387,7 +387,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/angel-investor",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/angel-investor",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -401,7 +401,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/anti-money-laundering",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/anti-money-laundering",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -415,7 +415,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -429,7 +429,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -443,7 +443,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -457,7 +457,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/application-programming-interface",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/application-programming-interface",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -471,7 +471,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/application-specific-integrated-circuit",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/application-specific-integrated-circuit",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -485,7 +485,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/arbitrage",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/arbitrage",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -499,7 +499,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -513,7 +513,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/arc-20",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/arc-20",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -527,7 +527,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/artificial-intelligence-ai",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/artificial-intelligence-ai",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -541,7 +541,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -555,7 +555,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/asic-resistant",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/asic-resistant",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -569,7 +569,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/asking-price",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/asking-price",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -583,7 +583,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/asset-management",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/asset-management",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -597,7 +597,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -611,7 +611,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/assets-under-management-aum",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/assets-under-management-aum",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -625,7 +625,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/asynchronous",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/asynchronous",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -639,7 +639,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/atomic-swap",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/atomic-swap",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -653,7 +653,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/attack-surface",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/attack-surface",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -667,7 +667,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -681,7 +681,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/auction",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/auction",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -695,7 +695,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -709,7 +709,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/automated-market-maker-amm",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/automated-market-maker-amm",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -723,7 +723,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -737,7 +737,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -751,7 +751,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -765,7 +765,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/b-tokens",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/b-tokens",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -779,7 +779,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/bags",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/bags",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -793,7 +793,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -807,7 +807,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/beacon-chain",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/beacon-chain",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -821,7 +821,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/bear-market",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/bear-market",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -835,7 +835,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/benchmark",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/benchmark",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -849,7 +849,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/bep-1155",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/bep-1155",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -863,7 +863,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/bep-20",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/bep-20",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -877,7 +877,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/bep-721",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/bep-721",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -891,7 +891,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/bep-95",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/bep-95",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -905,7 +905,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -919,7 +919,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/beta-coefficient",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/beta-coefficient",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -933,7 +933,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/beta-release",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/beta-release",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -947,7 +947,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/bid-ask-spread",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/bid-ask-spread",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -961,7 +961,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/bid-price",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/bid-price",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -975,7 +975,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -989,7 +989,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/binance-blockchain-charity-foundation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/binance-blockchain-charity-foundation",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1003,7 +1003,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/binance-ecosystem-fund",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/binance-ecosystem-fund",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1017,7 +1017,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/binancian",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/binancian",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1031,7 +1031,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/bitcoin",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/bitcoin",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1045,7 +1045,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/bitcoin-core",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/bitcoin-core",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1059,7 +1059,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/bitcoin-dominance",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/bitcoin-dominance",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1073,7 +1073,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/bitcoin-maximalists",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/bitcoin-maximalists",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1087,7 +1087,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/bitcoin-pizza",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/bitcoin-pizza",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1101,7 +1101,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/black-swan-event",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/black-swan-event",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1115,7 +1115,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/block",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/block",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1129,7 +1129,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/block-explorer",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/block-explorer",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1143,7 +1143,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/block-header",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/block-header",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1157,7 +1157,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/block-height",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/block-height",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1171,7 +1171,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/block-reward",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/block-reward",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1185,7 +1185,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1199,7 +1199,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1213,7 +1213,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/blockchain",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/blockchain",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1227,7 +1227,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1241,7 +1241,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1255,7 +1255,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/bloom-filter",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/bloom-filter",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1269,7 +1269,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/blue-chip-token",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/blue-chip-token",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1283,7 +1283,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/bnb",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/bnb",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1297,7 +1297,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1311,7 +1311,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/bnsol",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/bnsol",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1325,7 +1325,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/bollinger-bands",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/bollinger-bands",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1339,7 +1339,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/bond",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/bond",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1353,7 +1353,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/bounty",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/bounty",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1367,7 +1367,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1381,7 +1381,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1395,7 +1395,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/brc-20-tokens",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/brc-20-tokens",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1409,7 +1409,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/break-even-point",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/break-even-point",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1423,7 +1423,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/breakeven-multiple",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/breakeven-multiple",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1437,7 +1437,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/breakout",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/breakout",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1451,7 +1451,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1465,7 +1465,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/bscscan",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/bscscan",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1479,7 +1479,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1493,7 +1493,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/btc-wallet-address",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/btc-wallet-address",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1507,7 +1507,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/buidl",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/buidl",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1521,7 +1521,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/bull-market",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/bull-market",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1535,7 +1535,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/burner-wallet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/burner-wallet",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1549,7 +1549,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/buy-wall",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/buy-wall",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1563,7 +1563,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1577,7 +1577,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1591,7 +1591,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1605,7 +1605,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/candidate-block",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/candidate-block",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1619,7 +1619,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/candlestick",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/candlestick",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1633,7 +1633,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/capitulation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/capitulation",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1647,7 +1647,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1661,7 +1661,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/censorship-resistance",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/censorship-resistance",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1675,7 +1675,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/central-bank",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/central-bank",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1689,7 +1689,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/central-bank-digital-currency-cbdc",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/central-bank-digital-currency-cbdc",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1703,7 +1703,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/central-processing-unit",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/central-processing-unit",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1717,7 +1717,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/centralized",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/centralized",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1731,7 +1731,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/centralized-exchange",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/centralized-exchange",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1745,7 +1745,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1759,7 +1759,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1773,7 +1773,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/chatgpt",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/chatgpt",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1787,7 +1787,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1801,7 +1801,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/cipher",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/cipher",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1815,7 +1815,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/circulating-supply",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/circulating-supply",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1829,7 +1829,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1843,7 +1843,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/cloud",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/cloud",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1857,7 +1857,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1871,7 +1871,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/coin",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/coin",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1885,7 +1885,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1899,7 +1899,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1913,7 +1913,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/cold-storage",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/cold-storage",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1927,7 +1927,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1941,7 +1941,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/collateral",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/collateral",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1955,7 +1955,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/colocation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/colocation",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1969,7 +1969,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/commodity-futures-trading-commission",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/commodity-futures-trading-commission",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1983,7 +1983,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1997,7 +1997,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2011,7 +2011,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/compound-interest",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/compound-interest",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2025,7 +2025,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2039,7 +2039,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/confirmation-time",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/confirmation-time",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2053,7 +2053,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/confluence",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/confluence",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2067,7 +2067,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2081,7 +2081,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/consensus-algorithm",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/consensus-algorithm",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2095,7 +2095,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2109,7 +2109,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2123,7 +2123,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2137,7 +2137,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2151,7 +2151,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2165,7 +2165,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/consumer-price-index-(cpi)",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/consumer-price-index-(cpi)",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2179,7 +2179,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/contango-and-backwardation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/contango-and-backwardation",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2193,7 +2193,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2207,7 +2207,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2221,7 +2221,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2235,7 +2235,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/copy-trading",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/copy-trading",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2249,7 +2249,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/counterparty-risk",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/counterparty-risk",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2263,7 +2263,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/credentials",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/credentials",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2277,7 +2277,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/cross-chain-bridges",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/cross-chain-bridges",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2291,7 +2291,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2305,7 +2305,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2319,7 +2319,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2333,7 +2333,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2347,7 +2347,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/crypto-etfs",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/crypto-etfs",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2361,7 +2361,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/crypto-fear-and-greed-index",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/crypto-fear-and-greed-index",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2375,7 +2375,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2389,7 +2389,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/crypto-protocol",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/crypto-protocol",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2403,7 +2403,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2417,7 +2417,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/crypto-winter",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/crypto-winter",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2431,7 +2431,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2445,7 +2445,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/cryptocurrency",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/cryptocurrency",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2459,7 +2459,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2473,7 +2473,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/cryptography",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/cryptography",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2487,7 +2487,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2501,7 +2501,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/custody",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/custody",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2515,7 +2515,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2529,7 +2529,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/daemon",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/daemon",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2543,7 +2543,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2557,7 +2557,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/danksharding",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/danksharding",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2571,7 +2571,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2585,7 +2585,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2599,7 +2599,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2613,7 +2613,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/dead-cat-bounce",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/dead-cat-bounce",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2627,7 +2627,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/death-cross",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/death-cross",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2641,7 +2641,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2655,7 +2655,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/decentralized-application",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/decentralized-application",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2669,7 +2669,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/decentralized-autonomous-cooperative",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/decentralized-autonomous-cooperative",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2683,7 +2683,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/decentralized-autonomous-organization",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/decentralized-autonomous-organization",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2697,7 +2697,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/decentralized-exchange",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/decentralized-exchange",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2711,7 +2711,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2725,7 +2725,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/decentralized-indexes",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/decentralized-indexes",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2739,7 +2739,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2753,7 +2753,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/decryption",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/decryption",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2767,7 +2767,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/deep-web",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/deep-web",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2781,7 +2781,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2795,7 +2795,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2809,7 +2809,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/delisting",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/delisting",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2823,7 +2823,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2837,7 +2837,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/depeg",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/depeg",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2851,7 +2851,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2865,7 +2865,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/depression",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/depression",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2879,7 +2879,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2893,7 +2893,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/design-flaw-attack",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/design-flaw-attack",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2907,7 +2907,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2921,7 +2921,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2935,7 +2935,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2949,7 +2949,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2963,7 +2963,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/diamond-hands",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/diamond-hands",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2977,7 +2977,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/difficulty",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/difficulty",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2991,7 +2991,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/difficulty-bomb",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/difficulty-bomb",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3005,7 +3005,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3019,7 +3019,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3033,7 +3033,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/digital-signature",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/digital-signature",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3047,7 +3047,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3061,7 +3061,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/direct-market-access-dma",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/direct-market-access-dma",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3075,7 +3075,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3089,7 +3089,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/divergence",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/divergence",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3103,7 +3103,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/diversification",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/diversification",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3117,7 +3117,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3131,7 +3131,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/do-your-own-research",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/do-your-own-research",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3145,7 +3145,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/dollar-cost-averaging",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/dollar-cost-averaging",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3159,7 +3159,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/dot-plot",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/dot-plot",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3173,7 +3173,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3187,7 +3187,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/double-spending",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/double-spending",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3201,7 +3201,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/eclipse-attack",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/eclipse-attack",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3215,7 +3215,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3229,7 +3229,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3243,7 +3243,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/efficient-market-hypothesis-emh",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/efficient-market-hypothesis-emh",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3257,7 +3257,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/eigenlayer",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/eigenlayer",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3271,7 +3271,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/eip",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/eip",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3285,7 +3285,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3299,7 +3299,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/eip-3074",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/eip-3074",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3313,7 +3313,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/eip-4844",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/eip-4844",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3327,7 +3327,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/eip-7251",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/eip-7251",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3341,7 +3341,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/eip-7702",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/eip-7702",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3355,7 +3355,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/elasticity",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/elasticity",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3369,7 +3369,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3383,7 +3383,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/encryption",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/encryption",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3397,7 +3397,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/endogenous-variable",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/endogenous-variable",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3411,7 +3411,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3425,7 +3425,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3439,7 +3439,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3453,7 +3453,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3467,7 +3467,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/erc-1155",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/erc-1155",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3481,7 +3481,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/erc-20",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/erc-20",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3495,7 +3495,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/erc-404",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/erc-404",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3509,7 +3509,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/erc-721",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/erc-721",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3523,7 +3523,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/etf",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/etf",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3537,7 +3537,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3551,7 +3551,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3565,7 +3565,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3579,7 +3579,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3593,7 +3593,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/ethereum-classic",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/ethereum-classic",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3607,7 +3607,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/ethereum-foundation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/ethereum-foundation",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3621,7 +3621,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3635,7 +3635,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3649,7 +3649,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3663,7 +3663,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3677,7 +3677,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/ethereum-virtual-machine-evm",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/ethereum-virtual-machine-evm",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3691,7 +3691,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3705,7 +3705,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3719,7 +3719,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3733,7 +3733,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/exchange",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/exchange",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3747,7 +3747,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3761,7 +3761,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3775,7 +3775,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/exogenous-variable",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/exogenous-variable",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3789,7 +3789,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/exponential-moving-average-ema",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/exponential-moving-average-ema",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3803,7 +3803,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/externally-owned-account-eoa",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/externally-owned-account-eoa",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3817,7 +3817,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/fakeout",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/fakeout",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3831,7 +3831,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/falling-knife",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/falling-knife",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3845,7 +3845,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/fan-tokens",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/fan-tokens",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3859,7 +3859,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3873,7 +3873,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3887,7 +3887,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3901,7 +3901,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/fear-of-missing-out",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/fear-of-missing-out",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3915,7 +3915,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/fear-uncertainty-and-doubt",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/fear-uncertainty-and-doubt",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3929,7 +3929,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/fiat",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/fiat",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3943,7 +3943,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3957,7 +3957,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/fibonacci-retracement",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/fibonacci-retracement",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3971,7 +3971,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/fill-or-kill-order",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/fill-or-kill-order",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3985,7 +3985,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/finality",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/finality",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3999,7 +3999,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4013,7 +4013,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4027,7 +4027,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4041,7 +4041,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4055,7 +4055,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4069,7 +4069,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4083,7 +4083,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/first-mover-advantage",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/first-mover-advantage",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4097,7 +4097,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/fiscal-policy",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/fiscal-policy",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4111,7 +4111,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/flappening",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/flappening",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4125,7 +4125,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/flashbots",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/flashbots",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4139,7 +4139,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/flippening",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/flippening",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4153,7 +4153,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/flow-variable",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/flow-variable",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4167,7 +4167,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/forced-liquidation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/forced-liquidation",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4181,7 +4181,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/forex-fx",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/forex-fx",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4195,7 +4195,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/fork",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/fork",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4209,7 +4209,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/formal-verification",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/formal-verification",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4223,7 +4223,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4237,7 +4237,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/fraud-proof",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/fraud-proof",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4251,7 +4251,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/fren",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/fren",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4265,7 +4265,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4279,7 +4279,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/full-node",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/full-node",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4293,7 +4293,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/fully-diluted-valuation-fdv",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/fully-diluted-valuation-fdv",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4307,7 +4307,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/fundamental-analysis",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/fundamental-analysis",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4321,7 +4321,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/funding-fees",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/funding-fees",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4335,7 +4335,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/fungibility",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/fungibility",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4349,7 +4349,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/futures-contract",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/futures-contract",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4363,7 +4363,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/gamefi",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/gamefi",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4377,7 +4377,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4391,7 +4391,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/gas",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/gas",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4405,7 +4405,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4419,7 +4419,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/gas-limit",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/gas-limit",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4433,7 +4433,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4447,7 +4447,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4461,7 +4461,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4475,7 +4475,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/gdp-deflator",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/gdp-deflator",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4489,7 +4489,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/general-public-license",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/general-public-license",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4503,7 +4503,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/genesis-block",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/genesis-block",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4517,7 +4517,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4531,7 +4531,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/github",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/github",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4545,7 +4545,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/gm-good-morning",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/gm-good-morning",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4559,7 +4559,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4573,7 +4573,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/golden-cross",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/golden-cross",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4587,7 +4587,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/golden-ratio",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/golden-ratio",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4601,7 +4601,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/goldilocks",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/goldilocks",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4615,7 +4615,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/gossip-protocol",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/gossip-protocol",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4629,7 +4629,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4643,7 +4643,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/gross-domestic-product-gdp",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/gross-domestic-product-gdp",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4657,7 +4657,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4671,7 +4671,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/gwei",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/gwei",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4685,7 +4685,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/hackathon",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/hackathon",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4699,7 +4699,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/hacker",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/hacker",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4713,7 +4713,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/haha-money-printer-go-brrrrr",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/haha-money-printer-go-brrrrr",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4727,7 +4727,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/halving",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/halving",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4741,7 +4741,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/hard-cap",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/hard-cap",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4755,7 +4755,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4769,7 +4769,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/hard-landing",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/hard-landing",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4783,7 +4783,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4797,7 +4797,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4811,7 +4811,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/hash",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/hash",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4825,7 +4825,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/hash-rate",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/hash-rate",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4839,7 +4839,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/hashed-timelock-contract",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/hashed-timelock-contract",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4853,7 +4853,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4867,7 +4867,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/herd-instinct",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/herd-instinct",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4881,7 +4881,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4895,7 +4895,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/high-frequency-trading-hft",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/high-frequency-trading-hft",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4909,7 +4909,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/hodl",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/hodl",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4923,7 +4923,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/honeypot",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/honeypot",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4937,7 +4937,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4951,7 +4951,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4965,7 +4965,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4979,7 +4979,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4993,7 +4993,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5007,7 +5007,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/iceberg-order",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/iceberg-order",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5021,7 +5021,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5035,7 +5035,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5049,7 +5049,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/immutability",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/immutability",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5063,7 +5063,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/index-funds",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/index-funds",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5077,7 +5077,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5091,7 +5091,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/initial-coin-offering",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/initial-coin-offering",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5105,7 +5105,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/initial-dex-offering-ido",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/initial-dex-offering-ido",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5119,7 +5119,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/initial-exchange-offering",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/initial-exchange-offering",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5133,7 +5133,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/initial-public-offering",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/initial-public-offering",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5147,7 +5147,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/inscription",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/inscription",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5161,7 +5161,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5175,7 +5175,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/integrated-circuit",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/integrated-circuit",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5189,7 +5189,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/interest-rates",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/interest-rates",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5203,7 +5203,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5217,7 +5217,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/interoperability",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/interoperability",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5231,7 +5231,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5245,7 +5245,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/interplanetary-file-system-ipfs",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/interplanetary-file-system-ipfs",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5259,7 +5259,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/iou",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/iou",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5273,7 +5273,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5287,7 +5287,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5301,7 +5301,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5315,7 +5315,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/isolated-margin",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/isolated-margin",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5329,7 +5329,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/issuance",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/issuance",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5343,7 +5343,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5357,7 +5357,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5371,7 +5371,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/keccak",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/keccak",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5385,7 +5385,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5399,7 +5399,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/know-your-customer",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/know-your-customer",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5413,7 +5413,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5427,7 +5427,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5441,7 +5441,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5455,7 +5455,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5469,7 +5469,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/laspeyres-index",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/laspeyres-index",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5483,7 +5483,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/latency",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/latency",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5497,7 +5497,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5511,7 +5511,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5525,7 +5525,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/law-of-demand",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/law-of-demand",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5539,7 +5539,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5553,7 +5553,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/layer-2",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/layer-2",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5567,7 +5567,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/ledger",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/ledger",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5581,7 +5581,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5595,7 +5595,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5609,7 +5609,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/leveraged-tokens",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/leveraged-tokens",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5623,7 +5623,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/library",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/library",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5637,7 +5637,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5651,7 +5651,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5665,7 +5665,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/lightning-network",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/lightning-network",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5679,7 +5679,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/limit-order",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/limit-order",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5693,7 +5693,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5707,7 +5707,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/linux",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/linux",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5721,7 +5721,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/liquid-staking",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/liquid-staking",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5735,7 +5735,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/liquid-staking-token-lst",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/liquid-staking-token-lst",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5749,7 +5749,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5763,7 +5763,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/liquidity",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/liquidity",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5777,7 +5777,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/liquidity-crisis",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/liquidity-crisis",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5791,7 +5791,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5805,7 +5805,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/liquidity-provider",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/liquidity-provider",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5819,7 +5819,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/liquidity-ratios",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/liquidity-ratios",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5833,7 +5833,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5847,7 +5847,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/listing",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/listing",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5861,7 +5861,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/mainnet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/mainnet",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5875,7 +5875,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/mainnet-swap",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/mainnet-swap",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5889,7 +5889,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/maker",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/maker",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5903,7 +5903,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5917,7 +5917,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/malware",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/malware",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5931,7 +5931,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/margin-trading",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/margin-trading",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5945,7 +5945,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5959,7 +5959,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/market-capitalization",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/market-capitalization",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5973,7 +5973,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/market-momentum",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/market-momentum",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5987,7 +5987,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/market-order",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/market-order",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6001,7 +6001,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/masternode",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/masternode",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6015,7 +6015,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/matching-engine",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/matching-engine",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6029,7 +6029,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6043,7 +6043,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/maximum-supply",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/maximum-supply",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6057,7 +6057,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6071,7 +6071,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/mempool",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/mempool",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6085,7 +6085,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6099,7 +6099,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6113,7 +6113,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/merged-mining",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/merged-mining",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6127,7 +6127,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6141,7 +6141,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/merkle-tree",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/merkle-tree",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6155,7 +6155,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6169,7 +6169,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/metadata",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/metadata",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6183,7 +6183,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6197,7 +6197,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6211,7 +6211,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6225,7 +6225,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6239,7 +6239,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6253,7 +6253,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/metaverse",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/metaverse",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6267,7 +6267,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6281,7 +6281,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6295,7 +6295,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/microtransactions",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/microtransactions",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6309,7 +6309,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6323,7 +6323,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6337,7 +6337,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/mining",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/mining",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6351,7 +6351,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/mining-farm",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/mining-farm",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6365,7 +6365,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/mint",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/mint",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6379,7 +6379,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6393,7 +6393,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6407,7 +6407,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6421,7 +6421,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/monetary-policy",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/monetary-policy",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6435,7 +6435,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/money-markets",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/money-markets",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6449,7 +6449,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/monitoring-tag",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/monitoring-tag",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6463,7 +6463,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/moon",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/moon",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6477,7 +6477,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6491,7 +6491,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/moving-average-envelopes",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/moving-average-envelopes",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6505,7 +6505,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/moving-average-ribbon",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/moving-average-ribbon",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6519,7 +6519,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/mt-gox",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/mt-gox",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6533,7 +6533,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6547,7 +6547,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6561,7 +6561,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/multisignature",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/multisignature",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6575,7 +6575,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/nakamoto-consensus",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/nakamoto-consensus",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6589,7 +6589,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6603,7 +6603,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/net-asset-value-nav",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/net-asset-value-nav",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6617,7 +6617,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6631,7 +6631,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6645,7 +6645,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6659,7 +6659,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6673,7 +6673,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6687,7 +6687,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6701,7 +6701,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/nft-floor-prices",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/nft-floor-prices",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6715,7 +6715,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/nft-mystery-boxes",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/nft-mystery-boxes",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6729,7 +6729,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/ngmi",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/ngmi",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6743,7 +6743,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6757,7 +6757,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/node",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/node",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6771,7 +6771,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6785,7 +6785,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/non-fungible-token-nft",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/non-fungible-token-nft",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6799,7 +6799,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/nonce",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/nonce",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6813,7 +6813,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/oco-order",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/oco-order",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6827,7 +6827,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/off-chain",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/off-chain",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6841,7 +6841,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6855,7 +6855,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/offline-signing-orchestrator-oso",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/offline-signing-orchestrator-oso",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6869,7 +6869,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/offshore-account",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/offshore-account",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6883,7 +6883,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6897,7 +6897,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/on-chain",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/on-chain",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6911,7 +6911,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6925,7 +6925,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6939,7 +6939,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/opbnb",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/opbnb",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6953,7 +6953,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/open-source-software-oss",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/open-source-software-oss",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6967,7 +6967,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6981,7 +6981,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6995,7 +6995,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/opportunity-cost",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/opportunity-cost",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7009,7 +7009,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7023,7 +7023,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7037,7 +7037,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/oracle",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/oracle",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7051,7 +7051,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/orc-20-tokens",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/orc-20-tokens",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7065,7 +7065,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/order-book",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/order-book",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7079,7 +7079,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/ordinals",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/ordinals",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7093,7 +7093,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/orphan-block",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/orphan-block",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7107,7 +7107,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7121,7 +7121,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7135,7 +7135,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/pancakeswap",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/pancakeswap",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7149,7 +7149,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/paper-wallet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/paper-wallet",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7163,7 +7163,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/parallelization",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/parallelization",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7177,7 +7177,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7191,7 +7191,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7205,7 +7205,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/passive-management",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/passive-management",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7219,7 +7219,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7233,7 +7233,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7247,7 +7247,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7261,7 +7261,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7275,7 +7275,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/peer-to-peer",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/peer-to-peer",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7289,7 +7289,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/pegged-currency",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/pegged-currency",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7303,7 +7303,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7317,7 +7317,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/permissionless-blockchain",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/permissionless-blockchain",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7331,7 +7331,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/phishing",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/phishing",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7345,7 +7345,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7359,7 +7359,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/plasma",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/plasma",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7373,7 +7373,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7387,7 +7387,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/polkadot-crowdloan",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/polkadot-crowdloan",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7401,7 +7401,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7415,7 +7415,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/ponzi-scheme",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/ponzi-scheme",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7429,7 +7429,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7443,7 +7443,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7457,7 +7457,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/premining",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/premining",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7471,7 +7471,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/price-action",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/price-action",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7485,7 +7485,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/prisoners-dilemma",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/prisoners-dilemma",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7499,7 +7499,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7513,7 +7513,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7527,7 +7527,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/private-key",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/private-key",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7541,7 +7541,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/private-sale",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/private-sale",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7555,7 +7555,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/progressive-web-application",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/progressive-web-application",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7569,7 +7569,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/proof-of-attendance-protocol-poap",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/proof-of-attendance-protocol-poap",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7583,7 +7583,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/proof-of-reserves-por",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/proof-of-reserves-por",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7597,7 +7597,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/proof-of-stake",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/proof-of-stake",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7611,7 +7611,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/proof-of-staked-authority-posa",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/proof-of-staked-authority-posa",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7625,7 +7625,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/proof-of-work",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/proof-of-work",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7639,7 +7639,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/proposer-builder-separation-pbs",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/proposer-builder-separation-pbs",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7653,7 +7653,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/proto-danksharding",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/proto-danksharding",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7667,7 +7667,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7681,7 +7681,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/pseudorandom",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/pseudorandom",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7695,7 +7695,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7709,7 +7709,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7723,7 +7723,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/public-key",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/public-key",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7737,7 +7737,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7751,7 +7751,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/pump-and-dump",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/pump-and-dump",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7765,7 +7765,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7779,7 +7779,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/quantitative-easing-qe",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/quantitative-easing-qe",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7793,7 +7793,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/quantitative-tightening-qt",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/quantitative-tightening-qt",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7807,7 +7807,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/quantum-computing",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/quantum-computing",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7821,7 +7821,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7835,7 +7835,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/race-attack",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/race-attack",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7849,7 +7849,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/ransomware",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/ransomware",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7863,7 +7863,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7877,7 +7877,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/real-world-assets-rwas",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/real-world-assets-rwas",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7891,7 +7891,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/recession",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/recession",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7905,7 +7905,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/recursive-inscription",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/recursive-inscription",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7919,7 +7919,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/rekt",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/rekt",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7933,7 +7933,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/relative-strength-index",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/relative-strength-index",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7947,7 +7947,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7961,7 +7961,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7975,7 +7975,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/resistance",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/resistance",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7989,7 +7989,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/return-on-investment",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/return-on-investment",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8003,7 +8003,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/revenge-trading",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/revenge-trading",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8017,7 +8017,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8031,7 +8031,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/risk-premium",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/risk-premium",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8045,7 +8045,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/roadmap",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/roadmap",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8059,7 +8059,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8073,7 +8073,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8087,7 +8087,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8101,7 +8101,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/routing-attack",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/routing-attack",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8115,7 +8115,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8129,7 +8129,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/rug-pull",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/rug-pull",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8143,7 +8143,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8157,7 +8157,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/sahm-rule",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/sahm-rule",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8171,7 +8171,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8185,7 +8185,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8199,7 +8199,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/sandwich-trading",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/sandwich-trading",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8213,7 +8213,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8227,7 +8227,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/satoshi",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/satoshi",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8241,7 +8241,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/satoshi-nakamoto",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/satoshi-nakamoto",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8255,7 +8255,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8269,7 +8269,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8283,7 +8283,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8297,7 +8297,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8311,7 +8311,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8325,7 +8325,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8339,7 +8339,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8353,7 +8353,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/secure-asset-fund-for-users",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/secure-asset-fund-for-users",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8367,7 +8367,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/securities-and-exchange-commission",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/securities-and-exchange-commission",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8381,7 +8381,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/security-audit",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/security-audit",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8395,7 +8395,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8409,7 +8409,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8423,7 +8423,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/security-token-offering-sto",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/security-token-offering-sto",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8437,7 +8437,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/seed-phrase",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/seed-phrase",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8451,7 +8451,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/seed-tag",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/seed-tag",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8465,7 +8465,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/segregated-witness",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/segregated-witness",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8479,7 +8479,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8493,7 +8493,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8507,7 +8507,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/selfish-mining",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/selfish-mining",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8521,7 +8521,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/sell-wall",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/sell-wall",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8535,7 +8535,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/sentiment",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/sentiment",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8549,7 +8549,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8563,7 +8563,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8577,7 +8577,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8591,7 +8591,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8605,7 +8605,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/sharding",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/sharding",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8619,7 +8619,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/sharpe-ratio",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/sharpe-ratio",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8633,7 +8633,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8647,7 +8647,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8661,7 +8661,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/sidechains",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/sidechains",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8675,7 +8675,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/simple-moving-average-sma",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/simple-moving-average-sma",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8689,7 +8689,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/slashing",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/slashing",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8703,7 +8703,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8717,7 +8717,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/slippage",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/slippage",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8731,7 +8731,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8745,7 +8745,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/smart-contract",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/smart-contract",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8759,7 +8759,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/smart-contract-wallet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/smart-contract-wallet",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8773,7 +8773,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/snapshot",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/snapshot",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8787,7 +8787,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/social-recovery-wallet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/social-recovery-wallet",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8801,7 +8801,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/social-trading",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/social-trading",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8815,7 +8815,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/socialfi",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/socialfi",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8829,7 +8829,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8843,7 +8843,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/soft-landing",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/soft-landing",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8857,7 +8857,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/solidity",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/solidity",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8871,7 +8871,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/source-code",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/source-code",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8885,7 +8885,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/spl",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/spl",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8899,7 +8899,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/src-20-tokens",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/src-20-tokens",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8913,7 +8913,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/stablecoin",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/stablecoin",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8927,7 +8927,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/stagflation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/stagflation",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8941,7 +8941,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8955,7 +8955,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8969,7 +8969,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/staking-pool",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/staking-pool",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8983,7 +8983,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8997,7 +8997,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/state-channel",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/state-channel",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9011,7 +9011,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9025,7 +9025,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/steth",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/steth",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9039,7 +9039,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9053,7 +9053,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/stock-variable",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/stock-variable",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9067,7 +9067,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/store-of-value",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/store-of-value",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9081,7 +9081,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9095,7 +9095,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/supercomputer",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/supercomputer",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9109,7 +9109,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/supply-chain",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/supply-chain",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9123,7 +9123,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/support",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/support",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9137,7 +9137,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9151,7 +9151,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/sybil-attack",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/sybil-attack",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9165,7 +9165,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9179,7 +9179,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/taker",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/taker",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9193,7 +9193,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/tank",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/tank",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9207,7 +9207,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9221,7 +9221,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9235,7 +9235,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/testnet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/testnet",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9249,7 +9249,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9263,7 +9263,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9277,7 +9277,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9291,7 +9291,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/ticker",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/ticker",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9305,7 +9305,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/ticker-symbol",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/ticker-symbol",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9319,7 +9319,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/token",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/token",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9333,7 +9333,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/token-generation-event-tge",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/token-generation-event-tge",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9347,7 +9347,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/token-lockup",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/token-lockup",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9361,7 +9361,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/token-merge",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/token-merge",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9375,7 +9375,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/token-sale",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/token-sale",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9389,7 +9389,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9403,7 +9403,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/token-standards",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/token-standards",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9417,7 +9417,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/tokenization",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/tokenization",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9431,7 +9431,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/tokenomics",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/tokenomics",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9445,7 +9445,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/total-supply",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/total-supply",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9459,7 +9459,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/total-value-locked-tvl",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/total-value-locked-tvl",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9473,7 +9473,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/tradfi",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/tradfi",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9487,7 +9487,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9501,7 +9501,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9515,7 +9515,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9529,7 +9529,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/transaction-id",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/transaction-id",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9543,7 +9543,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9557,7 +9557,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/transactions-per-second-tps",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/transactions-per-second-tps",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9571,7 +9571,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9585,7 +9585,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/treasury-bills-t-bills",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/treasury-bills-t-bills",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9599,7 +9599,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9613,7 +9613,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/trueusd-tusd",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/trueusd-tusd",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9627,7 +9627,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9641,7 +9641,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/trustless",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/trustless",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9655,7 +9655,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/turing-complete",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/turing-complete",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9669,7 +9669,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9683,7 +9683,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9697,7 +9697,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9711,7 +9711,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/understanding-cz-s-number-4",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/understanding-cz-s-number-4",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9725,7 +9725,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9739,7 +9739,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9753,7 +9753,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/unit-of-account",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/unit-of-account",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9767,7 +9767,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9781,7 +9781,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/unspent-transaction-output-utxo",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/unspent-transaction-output-utxo",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9795,7 +9795,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9809,7 +9809,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9823,7 +9823,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9837,7 +9837,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9851,7 +9851,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/user-interface",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/user-interface",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9865,7 +9865,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/utility-token",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/utility-token",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9879,7 +9879,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9893,7 +9893,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9907,7 +9907,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9921,7 +9921,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/verification-code",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/verification-code",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9935,7 +9935,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9949,7 +9949,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9963,7 +9963,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/virtual-machine",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/virtual-machine",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9977,7 +9977,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/vladimir-club",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/vladimir-club",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9991,7 +9991,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/volatility",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/volatility",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10005,7 +10005,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/volume",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/volume",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10019,7 +10019,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/wagmi",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/wagmi",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10033,7 +10033,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/wallet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/wallet",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10047,7 +10047,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10061,7 +10061,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10075,7 +10075,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/wash-trading",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/wash-trading",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10089,7 +10089,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/weak-hands",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/weak-hands",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10103,7 +10103,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/weak-subjectivity",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/weak-subjectivity",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10117,7 +10117,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/web-1",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/web-1",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10131,7 +10131,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10145,7 +10145,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10159,7 +10159,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10173,7 +10173,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10187,7 +10187,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10201,7 +10201,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/wei",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/wei",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10215,7 +10215,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/weighted-moving-average-wma",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/weighted-moving-average-wma",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10229,7 +10229,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/whale",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/whale",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10243,7 +10243,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/whiskers",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/whiskers",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10257,7 +10257,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/whitelist",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/whitelist",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10271,7 +10271,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10285,7 +10285,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/wick",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/wick",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10299,7 +10299,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/win-rate",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/win-rate",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10313,7 +10313,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/wrapped-ether",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/wrapped-ether",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10327,7 +10327,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10341,7 +10341,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/wyckoff",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/wyckoff",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10355,7 +10355,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10369,7 +10369,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10383,7 +10383,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10397,7 +10397,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10411,7 +10411,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/yield-farming",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/yield-farming",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10425,7 +10425,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10439,7 +10439,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10453,7 +10453,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/zero-knowledge-proofs",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/zero-knowledge-proofs",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10467,7 +10467,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10481,7 +10481,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/zk-rollup",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/zk-rollup",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10495,7 +10495,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/zk-snarks",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/zk-snarks",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10509,7 +10509,7 @@
       "definitionSource": "https://academy.binance.com/zh-CN/glossary/zk-starks",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-CN/glossary/zk-starks",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""

--- a/locales/zh-TW/zh-TW.json
+++ b/locales/zh-TW/zh-TW.json
@@ -9576,7 +9576,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "treasury-bills-t-bills": {
+    "treasury-bills": {
       "term": "國庫券 (T-bills)",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/zh-TW/zh-TW.json
+++ b/locales/zh-TW/zh-TW.json
@@ -9,7 +9,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -23,7 +23,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -37,7 +37,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -51,7 +51,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -65,7 +65,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -79,7 +79,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/51-percent-attack",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/51-percent-attack",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -93,7 +93,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -107,7 +107,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/absolute-advantage",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/absolute-advantage",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -121,7 +121,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -135,7 +135,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -149,7 +149,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/active-management",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/active-management",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -163,7 +163,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/actively-validated-services-avs",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/actively-validated-services-avs",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -177,7 +177,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/ad-hoc",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/ad-hoc",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -191,7 +191,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/address",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/address",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -205,7 +205,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -219,7 +219,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -233,7 +233,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -247,7 +247,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/airdrop",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/airdrop",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -261,7 +261,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -275,7 +275,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -289,7 +289,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/algorithm",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/algorithm",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -303,7 +303,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/all-or-none-order",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/all-or-none-order",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -317,7 +317,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/all-time-high",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/all-time-high",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -331,7 +331,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/allocation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/allocation",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -345,7 +345,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/alpha",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/alpha",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -359,7 +359,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/altcoin",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/altcoin",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -373,7 +373,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -387,7 +387,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/angel-investor",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/angel-investor",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -401,7 +401,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/anti-money-laundering",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/anti-money-laundering",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -415,7 +415,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -429,7 +429,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -443,7 +443,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -457,7 +457,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/application-programming-interface",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/application-programming-interface",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -471,7 +471,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/application-specific-integrated-circuit",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/application-specific-integrated-circuit",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -485,7 +485,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/arbitrage",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/arbitrage",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -499,7 +499,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -513,7 +513,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/arc-20",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/arc-20",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -527,7 +527,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/artificial-intelligence-ai",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/artificial-intelligence-ai",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -541,7 +541,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -555,7 +555,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/asic-resistant",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/asic-resistant",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -569,7 +569,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/asking-price",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/asking-price",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -583,7 +583,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/asset-management",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/asset-management",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -597,7 +597,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -611,7 +611,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/assets-under-management-aum",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/assets-under-management-aum",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -625,7 +625,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/asynchronous",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/asynchronous",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -639,7 +639,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/atomic-swap",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/atomic-swap",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -653,7 +653,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/attack-surface",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/attack-surface",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -667,7 +667,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -681,7 +681,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/auction",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/auction",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -695,7 +695,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -709,7 +709,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/automated-market-maker-amm",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/automated-market-maker-amm",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -723,7 +723,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -737,7 +737,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -751,7 +751,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -765,7 +765,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/b-tokens",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/b-tokens",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -779,7 +779,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/bags",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/bags",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -793,7 +793,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -807,7 +807,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/beacon-chain",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/beacon-chain",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -821,7 +821,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/bear-market",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/bear-market",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -835,7 +835,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/benchmark",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/benchmark",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -849,7 +849,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/bep-1155",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/bep-1155",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -863,7 +863,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/bep-20",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/bep-20",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -877,7 +877,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/bep-721",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/bep-721",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -891,7 +891,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/bep-95",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/bep-95",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -905,7 +905,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -919,7 +919,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/beta-coefficient",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/beta-coefficient",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -933,7 +933,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/beta-release",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/beta-release",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -947,7 +947,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/bid-ask-spread",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/bid-ask-spread",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -961,7 +961,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/bid-price",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/bid-price",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -975,7 +975,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -989,7 +989,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/binance-blockchain-charity-foundation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/binance-blockchain-charity-foundation",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1003,7 +1003,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/binance-ecosystem-fund",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/binance-ecosystem-fund",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1017,7 +1017,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/binancian",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/binancian",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1031,7 +1031,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/bitcoin",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/bitcoin",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1045,7 +1045,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/bitcoin-core",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/bitcoin-core",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1059,7 +1059,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/bitcoin-dominance",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/bitcoin-dominance",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1073,7 +1073,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/bitcoin-maximalists",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/bitcoin-maximalists",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1087,7 +1087,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/bitcoin-pizza",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/bitcoin-pizza",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1101,7 +1101,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/black-swan-event",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/black-swan-event",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1115,7 +1115,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/block",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/block",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1129,7 +1129,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/block-explorer",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/block-explorer",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1143,7 +1143,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/block-header",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/block-header",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1157,7 +1157,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/block-height",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/block-height",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1171,7 +1171,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/block-reward",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/block-reward",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1185,7 +1185,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1199,7 +1199,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1213,7 +1213,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/blockchain",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/blockchain",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1227,7 +1227,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1241,7 +1241,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1255,7 +1255,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/bloom-filter",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/bloom-filter",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1269,7 +1269,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/blue-chip-token",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/blue-chip-token",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1283,7 +1283,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/bnb",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/bnb",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1297,7 +1297,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1311,7 +1311,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/bnsol",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/bnsol",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1325,7 +1325,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/bollinger-bands",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/bollinger-bands",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1339,7 +1339,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/bond",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/bond",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1353,7 +1353,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/bounty",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/bounty",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1367,7 +1367,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1381,7 +1381,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1395,7 +1395,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/brc-20-tokens",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/brc-20-tokens",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1409,7 +1409,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/break-even-point",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/break-even-point",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1423,7 +1423,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/breakeven-multiple",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/breakeven-multiple",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1437,7 +1437,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/breakout",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/breakout",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1451,7 +1451,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1465,7 +1465,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/bscscan",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/bscscan",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1479,7 +1479,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1493,7 +1493,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/btc-wallet-address",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/btc-wallet-address",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1507,7 +1507,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/buidl",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/buidl",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1521,7 +1521,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/bull-market",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/bull-market",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1535,7 +1535,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/burner-wallet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/burner-wallet",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1549,7 +1549,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/buy-wall",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/buy-wall",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1563,7 +1563,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1577,7 +1577,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1591,7 +1591,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1605,7 +1605,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/candidate-block",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/candidate-block",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1619,7 +1619,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/candlestick",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/candlestick",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1633,7 +1633,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/capitulation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/capitulation",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1647,7 +1647,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1661,7 +1661,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/censorship-resistance",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/censorship-resistance",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1675,7 +1675,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/central-bank",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/central-bank",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1689,7 +1689,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/central-bank-digital-currency-cbdc",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/central-bank-digital-currency-cbdc",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1703,7 +1703,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/central-processing-unit",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/central-processing-unit",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1717,7 +1717,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/centralized",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/centralized",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1731,7 +1731,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/centralized-exchange",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/centralized-exchange",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1745,7 +1745,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1759,7 +1759,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1773,7 +1773,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/chatgpt",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/chatgpt",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1787,7 +1787,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1801,7 +1801,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/cipher",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/cipher",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1815,7 +1815,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/circulating-supply",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/circulating-supply",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1829,7 +1829,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1843,7 +1843,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/cloud",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/cloud",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1857,7 +1857,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1871,7 +1871,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/coin",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/coin",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1885,7 +1885,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1899,7 +1899,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1913,7 +1913,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/cold-storage",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/cold-storage",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1927,7 +1927,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1941,7 +1941,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/collateral",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/collateral",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1955,7 +1955,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/colocation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/colocation",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1969,7 +1969,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/commodity-futures-trading-commission",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/commodity-futures-trading-commission",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -1983,7 +1983,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -1997,7 +1997,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2011,7 +2011,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/compound-interest",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/compound-interest",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2025,7 +2025,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2039,7 +2039,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/confirmation-time",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/confirmation-time",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2053,7 +2053,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/confluence",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/confluence",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2067,7 +2067,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2081,7 +2081,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/consensus-algorithm",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/consensus-algorithm",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2095,7 +2095,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2109,7 +2109,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2123,7 +2123,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2137,7 +2137,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2151,7 +2151,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2165,7 +2165,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/consumer-price-index-(cpi)",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/consumer-price-index-(cpi)",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2179,7 +2179,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/contango-and-backwardation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/contango-and-backwardation",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2193,7 +2193,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2207,7 +2207,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2221,7 +2221,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2235,7 +2235,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/copy-trading",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/copy-trading",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2249,7 +2249,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/counterparty-risk",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/counterparty-risk",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2263,7 +2263,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/credentials",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/credentials",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2277,7 +2277,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/cross-chain-bridges",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/cross-chain-bridges",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2291,7 +2291,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2305,7 +2305,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2319,7 +2319,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2333,7 +2333,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2347,7 +2347,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/crypto-etfs",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/crypto-etfs",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2361,7 +2361,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/crypto-fear-and-greed-index",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/crypto-fear-and-greed-index",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2375,7 +2375,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2389,7 +2389,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/crypto-protocol",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/crypto-protocol",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2403,7 +2403,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2417,7 +2417,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/crypto-winter",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/crypto-winter",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2431,7 +2431,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2445,7 +2445,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/cryptocurrency",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/cryptocurrency",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2459,7 +2459,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2473,7 +2473,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/cryptography",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/cryptography",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2487,7 +2487,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2501,7 +2501,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/custody",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/custody",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2515,7 +2515,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2529,7 +2529,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/daemon",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/daemon",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2543,7 +2543,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2557,7 +2557,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/danksharding",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/danksharding",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2571,7 +2571,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2585,7 +2585,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2599,7 +2599,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2613,7 +2613,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/dead-cat-bounce",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/dead-cat-bounce",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2627,7 +2627,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/death-cross",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/death-cross",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2641,7 +2641,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2655,7 +2655,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/decentralized-application",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/decentralized-application",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2669,7 +2669,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/decentralized-autonomous-cooperative",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/decentralized-autonomous-cooperative",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2683,7 +2683,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/decentralized-autonomous-organization",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/decentralized-autonomous-organization",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2697,7 +2697,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/decentralized-exchange",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/decentralized-exchange",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2711,7 +2711,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2725,7 +2725,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/decentralized-indexes",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/decentralized-indexes",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2739,7 +2739,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2753,7 +2753,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/decryption",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/decryption",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2767,7 +2767,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/deep-web",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/deep-web",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2781,7 +2781,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2795,7 +2795,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2809,7 +2809,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/delisting",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/delisting",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2823,7 +2823,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2837,7 +2837,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/depeg",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/depeg",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2851,7 +2851,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2865,7 +2865,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/depression",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/depression",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2879,7 +2879,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2893,7 +2893,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/design-flaw-attack",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/design-flaw-attack",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2907,7 +2907,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2921,7 +2921,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2935,7 +2935,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2949,7 +2949,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -2963,7 +2963,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/diamond-hands",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/diamond-hands",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2977,7 +2977,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/difficulty",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/difficulty",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -2991,7 +2991,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/difficulty-bomb",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/difficulty-bomb",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3005,7 +3005,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3019,7 +3019,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3033,7 +3033,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/digital-signature",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/digital-signature",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3047,7 +3047,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3061,7 +3061,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/direct-market-access-dma",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/direct-market-access-dma",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3075,7 +3075,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3089,7 +3089,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/divergence",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/divergence",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3103,7 +3103,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/diversification",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/diversification",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3117,7 +3117,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3131,7 +3131,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/do-your-own-research",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/do-your-own-research",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3145,7 +3145,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/dollar-cost-averaging",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/dollar-cost-averaging",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3159,7 +3159,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/dot-plot",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/dot-plot",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3173,7 +3173,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3187,7 +3187,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/double-spending",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/double-spending",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3201,7 +3201,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/eclipse-attack",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/eclipse-attack",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3215,7 +3215,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3229,7 +3229,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3243,7 +3243,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/efficient-market-hypothesis-emh",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/efficient-market-hypothesis-emh",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3257,7 +3257,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/eigenlayer",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/eigenlayer",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3271,7 +3271,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/eip",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/eip",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3285,7 +3285,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3299,7 +3299,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/eip-3074",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/eip-3074",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3313,7 +3313,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/eip-4844",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/eip-4844",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3327,7 +3327,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/eip-7251",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/eip-7251",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3341,7 +3341,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/eip-7702",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/eip-7702",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3355,7 +3355,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/elasticity",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/elasticity",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3369,7 +3369,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3383,7 +3383,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/encryption",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/encryption",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3397,7 +3397,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/endogenous-variable",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/endogenous-variable",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3411,7 +3411,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3425,7 +3425,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3439,7 +3439,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3453,7 +3453,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3467,7 +3467,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/erc-1155",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/erc-1155",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3481,7 +3481,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/erc-20",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/erc-20",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3495,7 +3495,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/erc-404",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/erc-404",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3509,7 +3509,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/erc-721",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/erc-721",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3523,7 +3523,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/etf",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/etf",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3537,7 +3537,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3551,7 +3551,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3565,7 +3565,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3579,7 +3579,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3593,7 +3593,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/ethereum-classic",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/ethereum-classic",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3607,7 +3607,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/ethereum-foundation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/ethereum-foundation",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3621,7 +3621,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3635,7 +3635,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3649,7 +3649,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3663,7 +3663,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3677,7 +3677,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/ethereum-virtual-machine-evm",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/ethereum-virtual-machine-evm",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3691,7 +3691,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3705,7 +3705,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3719,7 +3719,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3733,7 +3733,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/exchange",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/exchange",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3747,7 +3747,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3761,7 +3761,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3775,7 +3775,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/exogenous-variable",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/exogenous-variable",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3789,7 +3789,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/exponential-moving-average-ema",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/exponential-moving-average-ema",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3803,7 +3803,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/externally-owned-account-eoa",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/externally-owned-account-eoa",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3817,7 +3817,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/fakeout",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/fakeout",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3831,7 +3831,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/falling-knife",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/falling-knife",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3845,7 +3845,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/fan-tokens",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/fan-tokens",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3859,7 +3859,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3873,7 +3873,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3887,7 +3887,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3901,7 +3901,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/fear-of-missing-out",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/fear-of-missing-out",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3915,7 +3915,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/fear-uncertainty-and-doubt",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/fear-uncertainty-and-doubt",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3929,7 +3929,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/fiat",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/fiat",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3943,7 +3943,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -3957,7 +3957,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/fibonacci-retracement",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/fibonacci-retracement",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3971,7 +3971,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/fill-or-kill-order",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/fill-or-kill-order",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3985,7 +3985,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/finality",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/finality",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -3999,7 +3999,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4013,7 +4013,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4027,7 +4027,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4041,7 +4041,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4055,7 +4055,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4069,7 +4069,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4083,7 +4083,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/first-mover-advantage",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/first-mover-advantage",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4097,7 +4097,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/fiscal-policy",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/fiscal-policy",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4111,7 +4111,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/flappening",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/flappening",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4125,7 +4125,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/flashbots",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/flashbots",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4139,7 +4139,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/flippening",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/flippening",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4153,7 +4153,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/flow-variable",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/flow-variable",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4167,7 +4167,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/forced-liquidation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/forced-liquidation",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4181,7 +4181,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/forex-fx",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/forex-fx",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4195,7 +4195,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/fork",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/fork",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4209,7 +4209,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/formal-verification",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/formal-verification",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4223,7 +4223,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4237,7 +4237,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/fraud-proof",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/fraud-proof",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4251,7 +4251,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/fren",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/fren",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4265,7 +4265,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4279,7 +4279,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/full-node",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/full-node",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4293,7 +4293,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/fully-diluted-valuation-fdv",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/fully-diluted-valuation-fdv",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4307,7 +4307,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/fundamental-analysis",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/fundamental-analysis",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4321,7 +4321,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/funding-fees",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/funding-fees",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4335,7 +4335,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/fungibility",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/fungibility",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4349,7 +4349,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/futures-contract",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/futures-contract",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4363,7 +4363,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/gamefi",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/gamefi",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4377,7 +4377,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4391,7 +4391,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/gas",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/gas",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4405,7 +4405,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4419,7 +4419,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/gas-limit",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/gas-limit",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4433,7 +4433,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4447,7 +4447,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4461,7 +4461,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4475,7 +4475,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/gdp-deflator",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/gdp-deflator",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4489,7 +4489,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/general-public-license",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/general-public-license",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4503,7 +4503,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/genesis-block",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/genesis-block",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4517,7 +4517,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4531,7 +4531,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/github",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/github",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4545,7 +4545,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/gm-good-morning",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/gm-good-morning",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4559,7 +4559,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4573,7 +4573,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/golden-cross",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/golden-cross",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4587,7 +4587,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/golden-ratio",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/golden-ratio",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4601,7 +4601,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/goldilocks",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/goldilocks",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4615,7 +4615,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/gossip-protocol",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/gossip-protocol",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4629,7 +4629,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4643,7 +4643,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/gross-domestic-product-gdp",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/gross-domestic-product-gdp",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4657,7 +4657,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4671,7 +4671,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/gwei",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/gwei",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4685,7 +4685,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/hackathon",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/hackathon",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4699,7 +4699,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/hacker",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/hacker",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4713,7 +4713,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/haha-money-printer-go-brrrrr",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/haha-money-printer-go-brrrrr",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4727,7 +4727,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/halving",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/halving",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4741,7 +4741,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/hard-cap",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/hard-cap",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4755,7 +4755,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4769,7 +4769,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/hard-landing",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/hard-landing",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4783,7 +4783,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4797,7 +4797,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4811,7 +4811,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/hash",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/hash",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4825,7 +4825,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/hash-rate",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/hash-rate",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4839,7 +4839,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/hashed-timelock-contract",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/hashed-timelock-contract",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4853,7 +4853,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4867,7 +4867,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/herd-instinct",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/herd-instinct",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4881,7 +4881,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4895,7 +4895,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/high-frequency-trading-hft",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/high-frequency-trading-hft",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4909,7 +4909,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/hodl",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/hodl",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4923,7 +4923,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/honeypot",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/honeypot",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -4937,7 +4937,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4951,7 +4951,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4965,7 +4965,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4979,7 +4979,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -4993,7 +4993,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5007,7 +5007,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/iceberg-order",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/iceberg-order",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5021,7 +5021,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5035,7 +5035,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5049,7 +5049,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/immutability",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/immutability",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5063,7 +5063,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/index-funds",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/index-funds",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5077,7 +5077,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5091,7 +5091,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/initial-coin-offering",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/initial-coin-offering",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5105,7 +5105,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/initial-dex-offering-ido",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/initial-dex-offering-ido",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5119,7 +5119,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/initial-exchange-offering",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/initial-exchange-offering",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5133,7 +5133,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/initial-public-offering",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/initial-public-offering",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5147,7 +5147,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/inscription",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/inscription",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5161,7 +5161,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5175,7 +5175,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/integrated-circuit",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/integrated-circuit",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5189,7 +5189,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/interest-rates",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/interest-rates",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5203,7 +5203,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5217,7 +5217,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/interoperability",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/interoperability",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5231,7 +5231,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5245,7 +5245,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/interplanetary-file-system-ipfs",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/interplanetary-file-system-ipfs",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5259,7 +5259,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/iou",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/iou",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5273,7 +5273,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5287,7 +5287,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5301,7 +5301,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5315,7 +5315,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/isolated-margin",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/isolated-margin",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5329,7 +5329,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/issuance",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/issuance",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5343,7 +5343,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5357,7 +5357,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5371,7 +5371,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/keccak",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/keccak",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5385,7 +5385,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5399,7 +5399,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/know-your-customer",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/know-your-customer",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5413,7 +5413,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5427,7 +5427,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5441,7 +5441,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5455,7 +5455,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5469,7 +5469,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/laspeyres-index",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/laspeyres-index",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5483,7 +5483,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/latency",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/latency",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5497,7 +5497,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5511,7 +5511,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5525,7 +5525,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/law-of-demand",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/law-of-demand",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5539,7 +5539,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5553,7 +5553,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/layer-2",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/layer-2",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5567,7 +5567,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/ledger",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/ledger",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5581,7 +5581,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5595,7 +5595,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5609,7 +5609,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/leveraged-tokens",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/leveraged-tokens",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5623,7 +5623,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/library",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/library",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5637,7 +5637,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5651,7 +5651,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5665,7 +5665,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/lightning-network",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/lightning-network",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5679,7 +5679,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/limit-order",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/limit-order",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5693,7 +5693,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5707,7 +5707,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/linux",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/linux",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5721,7 +5721,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/liquid-staking",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/liquid-staking",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5735,7 +5735,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/liquid-staking-token-lst",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/liquid-staking-token-lst",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5749,7 +5749,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5763,7 +5763,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/liquidity",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/liquidity",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5777,7 +5777,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/liquidity-crisis",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/liquidity-crisis",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5791,7 +5791,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5805,7 +5805,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/liquidity-provider",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/liquidity-provider",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5819,7 +5819,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/liquidity-ratios",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/liquidity-ratios",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5833,7 +5833,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5847,7 +5847,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/listing",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/listing",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5861,7 +5861,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/mainnet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/mainnet",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5875,7 +5875,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/mainnet-swap",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/mainnet-swap",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5889,7 +5889,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/maker",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/maker",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5903,7 +5903,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5917,7 +5917,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/malware",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/malware",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5931,7 +5931,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/margin-trading",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/margin-trading",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5945,7 +5945,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -5959,7 +5959,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/market-capitalization",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/market-capitalization",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5973,7 +5973,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/market-momentum",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/market-momentum",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -5987,7 +5987,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/market-order",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/market-order",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6001,7 +6001,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/masternode",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/masternode",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6015,7 +6015,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/matching-engine",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/matching-engine",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6029,7 +6029,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6043,7 +6043,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/maximum-supply",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/maximum-supply",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6057,7 +6057,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6071,7 +6071,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/mempool",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/mempool",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6085,7 +6085,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6099,7 +6099,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6113,7 +6113,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/merged-mining",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/merged-mining",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6127,7 +6127,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6141,7 +6141,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/merkle-tree",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/merkle-tree",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6155,7 +6155,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6169,7 +6169,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/metadata",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/metadata",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6183,7 +6183,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6197,7 +6197,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6211,7 +6211,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6225,7 +6225,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6239,7 +6239,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6253,7 +6253,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/metaverse",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/metaverse",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6267,7 +6267,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6281,7 +6281,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6295,7 +6295,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/microtransactions",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/microtransactions",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6309,7 +6309,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6323,7 +6323,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6337,7 +6337,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/mining",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/mining",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6351,7 +6351,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/mining-farm",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/mining-farm",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6365,7 +6365,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/mint",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/mint",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6379,7 +6379,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6393,7 +6393,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6407,7 +6407,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6421,7 +6421,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/monetary-policy",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/monetary-policy",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6435,7 +6435,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/money-markets",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/money-markets",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6449,7 +6449,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/monitoring-tag",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/monitoring-tag",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6463,7 +6463,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/moon",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/moon",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6477,7 +6477,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6491,7 +6491,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/moving-average-envelopes",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/moving-average-envelopes",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6505,7 +6505,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/moving-average-ribbon",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/moving-average-ribbon",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6519,7 +6519,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/mt-gox",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/mt-gox",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6533,7 +6533,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6547,7 +6547,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6561,7 +6561,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/multisignature",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/multisignature",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6575,7 +6575,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/nakamoto-consensus",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/nakamoto-consensus",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6589,7 +6589,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6603,7 +6603,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/net-asset-value-nav",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/net-asset-value-nav",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6617,7 +6617,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6631,7 +6631,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6645,7 +6645,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6659,7 +6659,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6673,7 +6673,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6687,7 +6687,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6701,7 +6701,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/nft-floor-prices",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/nft-floor-prices",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6715,7 +6715,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/nft-mystery-boxes",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/nft-mystery-boxes",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6729,7 +6729,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/ngmi",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/ngmi",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6743,7 +6743,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6757,7 +6757,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/node",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/node",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6771,7 +6771,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6785,7 +6785,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/non-fungible-token-nft",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/non-fungible-token-nft",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6799,7 +6799,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/nonce",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/nonce",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6813,7 +6813,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/oco-order",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/oco-order",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6827,7 +6827,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/off-chain",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/off-chain",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6841,7 +6841,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6855,7 +6855,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/offline-signing-orchestrator-oso",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/offline-signing-orchestrator-oso",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6869,7 +6869,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/offshore-account",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/offshore-account",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6883,7 +6883,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6897,7 +6897,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/on-chain",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/on-chain",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6911,7 +6911,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6925,7 +6925,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6939,7 +6939,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/opbnb",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/opbnb",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6953,7 +6953,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/open-source-software-oss",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/open-source-software-oss",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -6967,7 +6967,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6981,7 +6981,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -6995,7 +6995,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/opportunity-cost",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/opportunity-cost",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7009,7 +7009,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7023,7 +7023,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7037,7 +7037,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/oracle",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/oracle",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7051,7 +7051,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/orc-20-tokens",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/orc-20-tokens",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7065,7 +7065,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/order-book",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/order-book",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7079,7 +7079,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/ordinals",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/ordinals",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7093,7 +7093,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/orphan-block",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/orphan-block",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7107,7 +7107,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7121,7 +7121,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7135,7 +7135,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/pancakeswap",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/pancakeswap",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7149,7 +7149,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/paper-wallet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/paper-wallet",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7163,7 +7163,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/parallelization",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/parallelization",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7177,7 +7177,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7191,7 +7191,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7205,7 +7205,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/passive-management",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/passive-management",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7219,7 +7219,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7233,7 +7233,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7247,7 +7247,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7261,7 +7261,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7275,7 +7275,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/peer-to-peer",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/peer-to-peer",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7289,7 +7289,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/pegged-currency",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/pegged-currency",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7303,7 +7303,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7317,7 +7317,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/permissionless-blockchain",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/permissionless-blockchain",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7331,7 +7331,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/phishing",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/phishing",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7345,7 +7345,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7359,7 +7359,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/plasma",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/plasma",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7373,7 +7373,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7387,7 +7387,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/polkadot-crowdloan",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/polkadot-crowdloan",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7401,7 +7401,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7415,7 +7415,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/ponzi-scheme",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/ponzi-scheme",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7429,7 +7429,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7443,7 +7443,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7457,7 +7457,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/premining",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/premining",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7471,7 +7471,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/price-action",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/price-action",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7485,7 +7485,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/prisoners-dilemma",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/prisoners-dilemma",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7499,7 +7499,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7513,7 +7513,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7527,7 +7527,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/private-key",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/private-key",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7541,7 +7541,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/private-sale",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/private-sale",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7555,7 +7555,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/progressive-web-application",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/progressive-web-application",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7569,7 +7569,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/proof-of-attendance-protocol-poap",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/proof-of-attendance-protocol-poap",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7583,7 +7583,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/proof-of-reserves-por",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/proof-of-reserves-por",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7597,7 +7597,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/proof-of-stake",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/proof-of-stake",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7611,7 +7611,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/proof-of-staked-authority-posa",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/proof-of-staked-authority-posa",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7625,7 +7625,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/proof-of-work",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/proof-of-work",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7639,7 +7639,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/proposer-builder-separation-pbs",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/proposer-builder-separation-pbs",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7653,7 +7653,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/proto-danksharding",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/proto-danksharding",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7667,7 +7667,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7681,7 +7681,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/pseudorandom",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/pseudorandom",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7695,7 +7695,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7709,7 +7709,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7723,7 +7723,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/public-key",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/public-key",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7737,7 +7737,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7751,7 +7751,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/pump-and-dump",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/pump-and-dump",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7765,7 +7765,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7779,7 +7779,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/quantitative-easing-qe",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/quantitative-easing-qe",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7793,7 +7793,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/quantitative-tightening-qt",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/quantitative-tightening-qt",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7807,7 +7807,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/quantum-computing",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/quantum-computing",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7821,7 +7821,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7835,7 +7835,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/race-attack",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/race-attack",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7849,7 +7849,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/ransomware",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/ransomware",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7863,7 +7863,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7877,7 +7877,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/real-world-assets-rwas",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/real-world-assets-rwas",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7891,7 +7891,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/recession",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/recession",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7905,7 +7905,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/recursive-inscription",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/recursive-inscription",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7919,7 +7919,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/rekt",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/rekt",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7933,7 +7933,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/relative-strength-index",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/relative-strength-index",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7947,7 +7947,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7961,7 +7961,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -7975,7 +7975,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/resistance",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/resistance",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -7989,7 +7989,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/return-on-investment",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/return-on-investment",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8003,7 +8003,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/revenge-trading",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/revenge-trading",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8017,7 +8017,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8031,7 +8031,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/risk-premium",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/risk-premium",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8045,7 +8045,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/roadmap",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/roadmap",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8059,7 +8059,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8073,7 +8073,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8087,7 +8087,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8101,7 +8101,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/routing-attack",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/routing-attack",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8115,7 +8115,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8129,7 +8129,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/rug-pull",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/rug-pull",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8143,7 +8143,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8157,7 +8157,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/sahm-rule",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/sahm-rule",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8171,7 +8171,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8185,7 +8185,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8199,7 +8199,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/sandwich-trading",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/sandwich-trading",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8213,7 +8213,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8227,7 +8227,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/satoshi",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/satoshi",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8241,7 +8241,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/satoshi-nakamoto",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/satoshi-nakamoto",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8255,7 +8255,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8269,7 +8269,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8283,7 +8283,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8297,7 +8297,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8311,7 +8311,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8325,7 +8325,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8339,7 +8339,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8353,7 +8353,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/secure-asset-fund-for-users",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/secure-asset-fund-for-users",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8367,7 +8367,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/securities-and-exchange-commission",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/securities-and-exchange-commission",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8381,7 +8381,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/security-audit",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/security-audit",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8395,7 +8395,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8409,7 +8409,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8423,7 +8423,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/security-token-offering-sto",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/security-token-offering-sto",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8437,7 +8437,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/seed-phrase",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/seed-phrase",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8451,7 +8451,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/seed-tag",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/seed-tag",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8465,7 +8465,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/segregated-witness",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/segregated-witness",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8479,7 +8479,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8493,7 +8493,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8507,7 +8507,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/selfish-mining",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/selfish-mining",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8521,7 +8521,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/sell-wall",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/sell-wall",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8535,7 +8535,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/sentiment",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/sentiment",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8549,7 +8549,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8563,7 +8563,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8577,7 +8577,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8591,7 +8591,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8605,7 +8605,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/sharding",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/sharding",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8619,7 +8619,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/sharpe-ratio",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/sharpe-ratio",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8633,7 +8633,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8647,7 +8647,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8661,7 +8661,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/sidechains",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/sidechains",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8675,7 +8675,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/simple-moving-average-sma",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/simple-moving-average-sma",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8689,7 +8689,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/slashing",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/slashing",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8703,7 +8703,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8717,7 +8717,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/slippage",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/slippage",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8731,7 +8731,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8745,7 +8745,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/smart-contract",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/smart-contract",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8759,7 +8759,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/smart-contract-wallet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/smart-contract-wallet",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8773,7 +8773,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/snapshot",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/snapshot",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8787,7 +8787,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/social-recovery-wallet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/social-recovery-wallet",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8801,7 +8801,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/social-trading",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/social-trading",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8815,7 +8815,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/socialfi",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/socialfi",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8829,7 +8829,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8843,7 +8843,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/soft-landing",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/soft-landing",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8857,7 +8857,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/solidity",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/solidity",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8871,7 +8871,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/source-code",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/source-code",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8885,7 +8885,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/spl",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/spl",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8899,7 +8899,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/src-20-tokens",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/src-20-tokens",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8913,7 +8913,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/stablecoin",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/stablecoin",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8927,7 +8927,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/stagflation",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/stagflation",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8941,7 +8941,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8955,7 +8955,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8969,7 +8969,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/staking-pool",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/staking-pool",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -8983,7 +8983,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -8997,7 +8997,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/state-channel",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/state-channel",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9011,7 +9011,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9025,7 +9025,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/steth",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/steth",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9039,7 +9039,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9053,7 +9053,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/stock-variable",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/stock-variable",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9067,7 +9067,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/store-of-value",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/store-of-value",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9081,7 +9081,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9095,7 +9095,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/supercomputer",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/supercomputer",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9109,7 +9109,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/supply-chain",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/supply-chain",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9123,7 +9123,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/support",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/support",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9137,7 +9137,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9151,7 +9151,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/sybil-attack",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/sybil-attack",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9165,7 +9165,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9179,7 +9179,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/taker",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/taker",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9193,7 +9193,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/tank",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/tank",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9207,7 +9207,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9221,7 +9221,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9235,7 +9235,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/testnet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/testnet",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9249,7 +9249,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9263,7 +9263,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9277,7 +9277,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9291,7 +9291,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/ticker",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/ticker",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9305,7 +9305,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/ticker-symbol",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/ticker-symbol",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9319,7 +9319,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/token",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/token",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9333,7 +9333,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/token-generation-event-tge",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/token-generation-event-tge",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9347,7 +9347,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/token-lockup",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/token-lockup",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9361,7 +9361,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/token-merge",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/token-merge",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9375,7 +9375,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/token-sale",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/token-sale",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9389,7 +9389,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9403,7 +9403,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/token-standards",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/token-standards",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9417,7 +9417,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/tokenization",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/tokenization",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9431,7 +9431,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/tokenomics",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/tokenomics",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9445,7 +9445,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/total-supply",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/total-supply",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9459,7 +9459,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/total-value-locked-tvl",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/total-value-locked-tvl",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9473,7 +9473,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/tradfi",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/tradfi",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9487,7 +9487,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9501,7 +9501,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9515,7 +9515,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9529,7 +9529,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/transaction-id",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/transaction-id",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9543,7 +9543,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9557,7 +9557,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/transactions-per-second-tps",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/transactions-per-second-tps",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9571,7 +9571,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9585,7 +9585,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/treasury-bills-t-bills",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/treasury-bills-t-bills",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9599,7 +9599,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9613,7 +9613,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/trueusd-tusd",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/trueusd-tusd",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9627,7 +9627,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9641,7 +9641,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/trustless",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/trustless",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9655,7 +9655,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/turing-complete",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/turing-complete",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9669,7 +9669,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9683,7 +9683,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9697,7 +9697,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9711,7 +9711,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/understanding-cz-s-number-4",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/understanding-cz-s-number-4",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9725,7 +9725,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9739,7 +9739,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9753,7 +9753,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/unit-of-account",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/unit-of-account",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9767,7 +9767,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9781,7 +9781,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/unspent-transaction-output-utxo",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/unspent-transaction-output-utxo",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9795,7 +9795,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9809,7 +9809,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9823,7 +9823,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9837,7 +9837,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9851,7 +9851,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/user-interface",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/user-interface",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9865,7 +9865,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/utility-token",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/utility-token",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9879,7 +9879,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9893,7 +9893,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9907,7 +9907,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9921,7 +9921,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/verification-code",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/verification-code",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9935,7 +9935,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9949,7 +9949,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -9963,7 +9963,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/virtual-machine",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/virtual-machine",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9977,7 +9977,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/vladimir-club",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/vladimir-club",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -9991,7 +9991,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/volatility",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/volatility",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10005,7 +10005,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/volume",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/volume",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10019,7 +10019,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/wagmi",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/wagmi",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10033,7 +10033,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/wallet",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/wallet",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10047,7 +10047,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10061,7 +10061,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10075,7 +10075,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/wash-trading",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/wash-trading",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10089,7 +10089,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/weak-hands",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/weak-hands",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10103,7 +10103,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/weak-subjectivity",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/weak-subjectivity",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10117,7 +10117,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/web-1",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/web-1",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10131,7 +10131,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10145,7 +10145,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10159,7 +10159,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10173,7 +10173,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10187,7 +10187,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10201,7 +10201,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/wei",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/wei",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10215,7 +10215,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/weighted-moving-average-wma",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/weighted-moving-average-wma",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10229,7 +10229,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/whale",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/whale",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10243,7 +10243,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/whiskers",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/whiskers",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10257,7 +10257,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/whitelist",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/whitelist",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10271,7 +10271,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10285,7 +10285,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/wick",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/wick",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10299,7 +10299,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/win-rate",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/win-rate",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10313,7 +10313,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/wrapped-ether",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/wrapped-ether",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10327,7 +10327,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10341,7 +10341,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/wyckoff",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/wyckoff",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10355,7 +10355,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10369,7 +10369,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10383,7 +10383,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10397,7 +10397,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10411,7 +10411,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/yield-farming",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/yield-farming",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10425,7 +10425,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10439,7 +10439,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10453,7 +10453,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/zero-knowledge-proofs",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/zero-knowledge-proofs",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10467,7 +10467,7 @@
       "definitionSource": "",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "",
       "dateFirstRecorded": "",
       "commentary": ""
@@ -10481,7 +10481,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/zk-rollup",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/zk-rollup",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10495,7 +10495,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/zk-snarks",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/zk-snarks",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""
@@ -10509,7 +10509,7 @@
       "definitionSource": "https://academy.binance.com/zh-TW/glossary/zk-starks",
       "sampleSentence": "",
       "extended": "",
-      "alternate": [],
+      "additional": [],
       "termSource": "https://academy.binance.com/zh-TW/glossary/zk-starks",
       "dateFirstRecorded": "2025-02-01",
       "commentary": ""

--- a/public/assets/css/styles.css
+++ b/public/assets/css/styles.css
@@ -73,10 +73,10 @@ main {
 
 /* Card styling */
 .card {
-  background-color: #2c2934; /* Dark purple for card backgrounds */
+  background-color: #2a2a3b; 
   border: 1px solid #54547c; /* Subtle border for definition */
   border-radius: 8px;
-  color: #a49ceb; /* Light purple text for readability */
+  color: #ddd;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2); /* Slight shadow for depth */
 }
 

--- a/utils/additional-pages/resources.json
+++ b/utils/additional-pages/resources.json
@@ -73,6 +73,21 @@
             "text": "Ethereum Cat Herders",
             "url": "https://ethereumcatherders.com/",
             "description": "Community for Ethereum improvement proposals and governance."
+          },
+          {
+            "text": "Fellowship of Ethereum Magicians",
+            "url": "https://ethereum-magicians.org/",
+            "description": "If you really want alpha about what's going to happen at the protocol level of the Ethereum network... You'll read it here first. If you can understand it."
+          },
+          {
+            "text": "Ethereum Improvement Proposals",
+            "url": "https://eips.ethereum.org/",
+            "description": "The canonical source of truth regarding what's happened to the Ethereum network protocols. If you're confused about what this even means, see <a href='./english-us/ethereum-improvement-proposals.html'>here</a>."
+          },
+          {
+            "text": "Ethereum Rollup Improvement Proposals",
+            "url": "https://github.com/ethereum/RIPs",
+            "description": "Just when you thought you'd read all the EIPs and ERCs... RIP."
           }
         ]
       }

--- a/utils/build-pages.js
+++ b/utils/build-pages.js
@@ -91,13 +91,13 @@ export default async function buildPages() {
           termData.partOfSpeech || "Grammatical data not yet available";
         const definitionValue =
           termData.definition || "Definition not available.";
-        const alternateDefsArray =
-          Array.isArray(termData.alternate) && termData.additional.length
-            ? termData.alternate
+        const additionalDefsArray =
+          Array.isArray(termData.additional) && termData.additional.length
+            ? termData.additional
             : null;
 
-        const alternateDef = alternateDefsArray
-          ? alternateDefsArray
+        const additionalDef = additionalDefsArray
+          ? additionalDefsArray
               .map(
                 (alt) =>
                   `<p><strong>Additional definition:</strong> ${alt.definition} <em>(${alt.source})</em></p>`,
@@ -168,7 +168,7 @@ export default async function buildPages() {
           .replace(/{{definitionSource}}/g, definitionSource)
           .replace(/{{sampleSentence}}/g, sampleSentence)
           .replace(/{{extended}}/g, extended)
-          .replace(/{{alternateDef}}/g, alternateDef)
+          .replace(/{{additionalDef}}/g, additionalDef)
           .replace(/{{termSource}}/g, termSource)
           .replace(/{{dateFirstRecorded}}/g, date)
           .replace(/{{commentary}}/g, commentary);

--- a/utils/build-pages.js
+++ b/utils/build-pages.js
@@ -92,7 +92,7 @@ export default async function buildPages() {
         const definitionValue =
           termData.definition || "Definition not available.";
         const alternateDefsArray =
-          Array.isArray(termData.alternate) && termData.alternate.length
+          Array.isArray(termData.alternate) && termData.additional.length
             ? termData.alternate
             : null;
 
@@ -100,10 +100,10 @@ export default async function buildPages() {
           ? alternateDefsArray
               .map(
                 (alt) =>
-                  `<p><strong>Alternate:</strong> ${alt.definition} <em>(${alt.source})</em></p>`,
+                  `<p><strong>Additional definition:</strong> ${alt.definition} <em>(${alt.source})</em></p>`,
               )
               .join("")
-          : "<p>No alternate definitions found. Have another? Submit it!</p>";
+          : "<p>No additional definitions found. Have another? Submit it!</p>";
 
         const termCategoryValue = termData.termCategory || "To be determined";
         const definitionSource = termData.definitionSource || "N/A";

--- a/utils/build-pages.js
+++ b/utils/build-pages.js
@@ -109,8 +109,22 @@ export default async function buildPages() {
         const definitionSource = termData.definitionSource || "N/A";
         const sampleSentence = termData.sampleSentence || "N/A";
         const extended = termData.extended || "No extended definition. ...yet";
-        const termSource =
-          termData.termSource || "This word came from... the ether";
+        // Enhanced handling for termSource
+        const isValidUrl = (string) => {
+          try {
+            new URL(string);
+            return true;
+          } catch (_) {
+            return false;
+          }
+        };
+
+        const termSource = termData.termSource
+          ? isValidUrl(termData.termSource)
+            ? `<a href="${termData.termSource}" target="_blank" rel="noopener noreferrer">Term source</a>`
+            : `${termData.termSource}`
+          : "This word came from... the ether";
+
         const date = termData.dateFirstRecorded || "Unknown";
         const commentary =
           termData.commentary || "No commentary on this. ...yet";

--- a/utils/index-template.html
+++ b/utils/index-template.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="../assets/css/bootstrap/bootstrap.css" />
     <link rel="stylesheet" href="../assets/css/bootstrap/custom.css" />
     <link rel="stylesheet" href="../assets/css/styles.css" />
-    
+
     <!-- Social card / banner config starts here -->
     <meta
       property="og:title"
@@ -26,25 +26,27 @@
       name="twitter:title"
       content="wordsofweb3 - Your decentralized multilingual glossary"
     />
-    <your 
+    <your
       name="twitter:description"
       content="Explore crypto, web3, and tech terminology in multiple languages."
     />
-    <meta
-      name="twitter:image"
-      content="../assets/social-banner.png"
-    />
+    <meta name="twitter:image" content="../assets/social-banner.png" />
     <meta name="twitter:url" content="https://wordsofweb3.eth.limo" />
 
     <!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-R596NWWZKQ"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
+    <script
+      async
+      src="https://www.googletagmanager.com/gtag/js?id=G-R596NWWZKQ"
+    ></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() {
+        dataLayer.push(arguments);
+      }
+      gtag("js", new Date());
 
-  gtag('config', 'G-R596NWWZKQ');
-</script>
+      gtag("config", "G-R596NWWZKQ");
+    </script>
 
     <title>{{title}}</title>
     <script type="module" src="../js/index.js" defer></script>

--- a/utils/index-template.html
+++ b/utils/index-template.html
@@ -7,7 +7,8 @@
     <link rel="stylesheet" href="../assets/css/bootstrap/bootstrap.css" />
     <link rel="stylesheet" href="../assets/css/bootstrap/custom.css" />
     <link rel="stylesheet" href="../assets/css/styles.css" />
-
+    
+    <!-- Social card / banner config starts here -->
     <meta
       property="og:title"
       content="wordsofweb3 - Your decentralized multilingual glossary"
@@ -34,6 +35,16 @@
       content="../assets/social-banner.png"
     />
     <meta name="twitter:url" content="https://wordsofweb3.eth.limo" />
+
+    <!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R596NWWZKQ"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R596NWWZKQ');
+</script>
 
     <title>{{title}}</title>
     <script type="module" src="../js/index.js" defer></script>

--- a/utils/template.html
+++ b/utils/template.html
@@ -22,34 +22,6 @@
 
     <title>wordsofweb3 - {{title}}</title>
     <script type="module" src="../js/entry-page.js" defer></script>
-    <style>
-      body {
-        display: flex;
-        flex-direction: column;
-        min-height: 100vh;
-      }
-      main {
-        flex: 1;
-      }
-      footer {
-        margin-top: auto;
-        padding: 1rem;
-        background-color: #222;
-        color: #fff;
-      }
-      .card {
-        background-color: #2a2a3b;
-        color: #ddd;
-      }
-      .card-title,
-      h3,
-      h4 {
-        color: #ffcc00;
-      }
-      p {
-        color: #ccc;
-      }
-    </style>
   </head>
   <body>
     <header id="navbar-container" class="mb-5">

--- a/utils/template.html
+++ b/utils/template.html
@@ -108,8 +108,8 @@
         <div class="card-body">
           <h4 id="extended">Extended definition</h4>
           <p>{{extended}}</p>
-          <h4 id="alternatetitle">Additional definitions</h4>
-          <div id="alternate-definitions">{{alternateDef}}</div>
+          <h4 id="additionaltitle">Additional definitions</h4>
+          <div id="additional-definitions">{{additionalDef}}</div>
           <p id="termsource"><strong>Term source:</strong> {{termSource}}</p>
           <p id="date">
             <strong>Date first recorded:</strong> {{dateFirstRecorded}}

--- a/utils/template.html
+++ b/utils/template.html
@@ -8,17 +8,39 @@
     <link rel="stylesheet" href="../assets/css/bootstrap/custom.css" />
     <link rel="stylesheet" href="../assets/css/styles.css" />
 
+    <!-- Social card / banner configuration begins here -->
     <meta property="og:title" content="wordsofweb3 - {{term}}" />
     <meta property="og:description" content="{{definitionMetadata}}" />
     <meta property="og:image" content="../assets/social-banner.png" />
-    <meta property="og:url" content="https://wordsofweb3.eth.limo/{{locale}}/{{termSlug}}.html" />
+    <meta
+      property="og:url"
+      content="https://wordsofweb3.eth.limo/{{locale}}/{{termSlug}}.html"
+    />
     <meta property="og:type" content="article" />
-    
+
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:title" content="wordsofweb3 - {{term}}" />
     <meta name="twitter:description" content="{{definitionMetadata}}" />
     <meta name="twitter:image" content="../assets/social-banner.png" />
-    <meta name="twitter:url" content="https://wordsofweb3.eth.limo/{{locale}}/{{termSlug}}.html" />    
+    <meta
+      name="twitter:url"
+      content="https://wordsofweb3.eth.limo/{{locale}}/{{termSlug}}.html"
+    />
+
+    <!-- Google tag (gtag.js) -->
+    <script
+      async
+      src="https://www.googletagmanager.com/gtag/js?id=G-R596NWWZKQ"
+    ></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() {
+        dataLayer.push(arguments);
+      }
+      gtag("js", new Date());
+
+      gtag("config", "G-R596NWWZKQ");
+    </script>
 
     <title>wordsofweb3 - {{title}}</title>
     <script type="module" src="../js/entry-page.js" defer></script>
@@ -93,7 +115,7 @@
       <!-- Definition Card -->
       <div class="card mb-4" id="definition-card">
         <div class="card-body">
-          <h3 id="definitiontitle">Definition 1: </h3>
+          <h3 id="definitiontitle">Definition 1:</h3>
           <p id="definition">{{definition}}</p>
           <p id="defsource">
             <strong>Definition source:</strong> {{definitionSource}}

--- a/utils/template.html
+++ b/utils/template.html
@@ -132,7 +132,7 @@
           <p>{{extended}}</p>
           <h4 id="additionaltitle">Additional definitions</h4>
           <div id="additional-definitions">{{additionalDef}}</div>
-          <p id="termsource"><strong>Term source:</strong> {{termSource}}</p>
+          <p id="termsource">{{termSource}}</p>
           <p id="date">
             <strong>Date first recorded:</strong> {{dateFirstRecorded}}
           </p>

--- a/utils/template.html
+++ b/utils/template.html
@@ -93,7 +93,7 @@
       <!-- Definition Card -->
       <div class="card mb-4" id="definition-card">
         <div class="card-body">
-          <h3 id="definitiontitle">Definition</h3>
+          <h3 id="definitiontitle">Definition 1: </h3>
           <p id="definition">{{definition}}</p>
           <p id="defsource">
             <strong>Definition source:</strong> {{definitionSource}}
@@ -108,7 +108,7 @@
         <div class="card-body">
           <h4 id="extended">Extended definition</h4>
           <p>{{extended}}</p>
-          <h4 id="alternatetitle">Alternate definitions</h4>
+          <h4 id="alternatetitle">Additional definitions</h4>
           <div id="alternate-definitions">{{alternateDef}}</div>
           <p id="termsource"><strong>Term source:</strong> {{termSource}}</p>
           <p id="date">


### PR DESCRIPTION
Now that we're starting to cook with multiple definitions from multiple sources, we're leaning towards the classic dictionary approach of simply doing definitions in a numbered list. This indicates and implies preferential definitions, or 'strict denotative meanings' versus 'secondary, connotative meanings', etc. @mapachurro had originally called them "alternate definitions", on and this felt far too opinionated.

So, step one is to do this, note the hyperlink in the Additional Definitions box:

![image](https://github.com/user-attachments/assets/73ffbc92-0f72-4073-9d00-2f52cb46d3e8)

I'll do the same with the source for Definition 1, as well. Ideally additional definitions will be numbered, but we'll see.

Also, to contradict the heading here of "more credibly neutral", well, I'm adding a google analytics tracking tag in the header of all the pages. We'll see if we keep this long term but it would be nice to have some analytics visibility; now that we have metadata thanks to #45, SEO indexing might actually start, and start improving; it would be nice to have this tool in place to track that as it does, or does not, happen.

uhhh also I added a bunch of Ethereum-focused resources to the resources page