### PR TITLE
Removing parentheses from Binance term keys

### DIFF
--- a/locales/ar-001/ar-001.json
+++ b/locales/ar-001/ar-001.json
@@ -2156,7 +2156,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "consumer-price-index-(cpi)": {
+    "consumer-price-index": {
       "term": "Consumer Price Index (CPI)",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/ar-001/ar-001.json
+++ b/locales/ar-001/ar-001.json
@@ -3570,7 +3570,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "ethereum-2.0": {
+    "ethereum-2": {
       "term": "Ethereum 2.0",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/ar-001/ar-001.json
+++ b/locales/ar-001/ar-001.json
@@ -2786,7 +2786,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "delegated-proof-of-stake-(dpos)": {
+    "delegated-proof-of-stake": {
       "term": "DPoS",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/de-DE/de-DE.json
+++ b/locales/de-DE/de-DE.json
@@ -1414,7 +1414,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "delegated-proof-of-stake-(dpos)": {
+    "delegated-proof-of-stake": {
       "term": "DPoS",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/de-DE/de-DE.json
+++ b/locales/de-DE/de-DE.json
@@ -1862,7 +1862,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "ethereum-2.0": {
+    "ethereum-2": {
       "term": "Ethereum 2.0",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/el-GR/el-GR.json
+++ b/locales/el-GR/el-GR.json
@@ -1414,7 +1414,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "delegated-proof-of-stake-(dpos)": {
+    "delegated-proof-of-stake": {
       "term": "DPoS",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/el-GR/el-GR.json
+++ b/locales/el-GR/el-GR.json
@@ -1862,7 +1862,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "ethereum-2.0": {
+    "ethereum-2": {
       "term": "Ethereum 2.0",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/en-GB/en-GB.json
+++ b/locales/en-GB/en-GB.json
@@ -1414,7 +1414,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "delegated-proof-of-stake-(dpos)": {
+    "delegated-proof-of-stake": {
       "term": "Delegated proof of stake (DPoS)",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/en-GB/en-GB.json
+++ b/locales/en-GB/en-GB.json
@@ -1862,7 +1862,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "ethereum-2.0": {
+    "ethereum-2": {
       "term": "Ethereum 2.0",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/en-US/en-US.json
+++ b/locales/en-US/en-US.json
@@ -108,7 +108,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/absolute-advantage",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -155,7 +155,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/active-management",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -169,7 +169,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/actively-validated-services-avs",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -183,7 +183,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/ad-hoc",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -324,7 +324,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/all-or-none-order",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -338,7 +338,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/all-time-high",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -352,7 +352,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/allocation",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -366,7 +366,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/alpha",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -413,7 +413,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/angel-investor",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -427,7 +427,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/anti-money-laundering",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -483,7 +483,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/application-programming-interface",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -497,7 +497,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/application-specific-integrated-circuit",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -511,7 +511,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/arbitrage",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -539,7 +539,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/arc-20",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -553,7 +553,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/artificial-intelligence-ai",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -581,7 +581,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/asic-resistant",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -595,7 +595,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/asking-price",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -609,7 +609,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/asset-management",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -637,7 +637,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/assets-under-management-aum",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -651,7 +651,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/asynchronous",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -665,7 +665,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/atomic-swap",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -679,7 +679,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/attack-surface",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -707,7 +707,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/auction",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -735,7 +735,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/automated-market-maker-amm",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -791,7 +791,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/b-tokens",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -805,7 +805,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/bags",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -866,7 +866,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/bear-market",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -880,7 +880,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/benchmark",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -894,7 +894,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/bep-1155",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -908,7 +908,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/bep-20",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -922,7 +922,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/bep-721",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -936,7 +936,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/bep-95",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -964,7 +964,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/beta-coefficient",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -978,7 +978,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/beta-release",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -992,7 +992,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/bid-ask-spread",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -1006,7 +1006,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/bid-price",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -1034,7 +1034,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/binance-blockchain-charity-foundation",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -1048,7 +1048,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/binance-ecosystem-fund",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -1062,7 +1062,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/binancian",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -1095,7 +1095,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/bitcoin-core",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -1109,7 +1109,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/bitcoin-dominance",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -1123,7 +1123,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/bitcoin-maximalists",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -1137,7 +1137,7 @@
       "sampleSentence": "",
       "extended": "See also Pizza DAO: https://x.com/Pizza_DAO",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/bitcoin-pizza",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -1151,7 +1151,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/black-swan-event",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -1188,7 +1188,7 @@
       "sampleSentence": "",
       "extended": "See also blockchain explorer.",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/block-explorer",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -1202,7 +1202,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/block-header",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -1333,7 +1333,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/bloom-filter",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -1347,7 +1347,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/blue-chip-token",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -1361,7 +1361,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/bnb",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -1389,7 +1389,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/bnsol",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -1403,7 +1403,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/bollinger-bands",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -1417,7 +1417,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/bond",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -1478,7 +1478,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/brc-20-tokens",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -1492,7 +1492,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/break-even-point",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -1506,7 +1506,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/breakeven-multiple",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -1520,7 +1520,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/breakout",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -1548,7 +1548,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/bscscan",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -1576,7 +1576,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/btc-wallet-address",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -1609,7 +1609,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/bull-market",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -1623,7 +1623,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/burner-wallet",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -1637,7 +1637,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/buy-wall",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -1693,7 +1693,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/candidate-block",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -1707,7 +1707,7 @@
       "sampleSentence": "Did you see that green candlestick on $POO this morning? Someone bought big.",
       "extended": "Often shortened to simply 'candle'.",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/candlestick",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -1721,7 +1721,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/capitulation",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -1749,7 +1749,7 @@
       "sampleSentence": "",
       "extended": "While this is the noun phrase, you will often see a protocol or network described as 'censorship resistant'.",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/censorship-resistance",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -1763,7 +1763,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/central-bank",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -1777,7 +1777,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/central-bank-digital-currency-cbdc",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -1791,7 +1791,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/central-processing-unit",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -1805,7 +1805,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/centralized",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -1866,7 +1866,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/chatgpt",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -1894,7 +1894,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/cipher",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -1908,7 +1908,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/circulating-supply",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -1941,7 +1941,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/cloud",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -2049,7 +2049,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/collateral",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -2063,7 +2063,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/colocation",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": "Not to be confused with 'collocation', referring to common placement of phrases or words together."
     },
@@ -2077,7 +2077,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/commodity-futures-trading-commission",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -2119,7 +2119,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/compound-interest",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -2166,7 +2166,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/confluence",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": "Confluence is also the name of a workplace productivity tool, made by software company Atlassian."
     },
@@ -2194,7 +2194,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/consensus-algorithm",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -2292,7 +2292,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/contango-and-backwardation",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -2348,7 +2348,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/copy-trading",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -2362,7 +2362,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/counterparty-risk",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -2376,7 +2376,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/credentials",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -2390,7 +2390,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/cross-chain-bridges",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": "This phrasing, as used by Binance, is perhaps redundant. A bridge between blockchains is, by definition, cross-chain."
     },
@@ -2460,7 +2460,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/crypto-etfs",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -2474,7 +2474,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/crypto-fear-and-greed-index",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -2502,7 +2502,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/crypto-protocol",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": "This phrasing, as used by Binance, is perhaps implying a differentiation where one does not exist. A protocol is a protocol, regardless of whether it is employed in a crypto context or otherwise."
     },
@@ -2530,7 +2530,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/crypto-winter",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -2657,7 +2657,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/daemon",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -2685,7 +2685,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/danksharding",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -2741,7 +2741,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/dead-cat-bounce",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -2755,7 +2755,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/death-cross",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -2802,7 +2802,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/decentralized-autonomous-cooperative",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": "Arguably, a DAO is, or often ends up being, simply 'an online cooperative with some smart contracts, maybe'."
     },
@@ -2868,7 +2868,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/decentralized-indexes",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -2896,7 +2896,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/decryption",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -2910,7 +2910,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/deep-web",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -2952,7 +2952,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/delisting",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -2980,7 +2980,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/depeg",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -3008,7 +3008,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/depression",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -3036,7 +3036,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/design-flaw-attack",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -3106,7 +3106,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/diamond-hands",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -3219,7 +3219,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/direct-market-access-dma",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -3247,7 +3247,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/divergence",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -3261,7 +3261,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/diversification",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -3289,7 +3289,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/do-your-own-research",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -3303,7 +3303,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/dollar-cost-averaging",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -3317,7 +3317,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/dot-plot",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -3350,7 +3350,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/eclipse-attack",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -3406,7 +3406,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/efficient-market-hypothesis-emh",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -3420,7 +3420,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/eigenlayer",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -3448,7 +3448,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/eip-3074",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -3462,7 +3462,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/eip-4844",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -3476,7 +3476,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/eip-7251",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -3490,7 +3490,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/eip-7702",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -3504,7 +3504,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/elasticity",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -3551,7 +3551,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/endogenous-variable",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -3664,7 +3664,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/erc-404",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -3697,7 +3697,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/etf",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -3767,7 +3767,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/ethereum-classic",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -3781,7 +3781,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/ethereum-foundation",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -3950,7 +3950,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/exogenous-variable",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -3964,7 +3964,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/exponential-moving-average-ema",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -3978,7 +3978,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/externally-owned-account-eoa",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -3992,7 +3992,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/fakeout",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -4006,7 +4006,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/falling-knife",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -4020,7 +4020,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/fan-tokens",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -4076,7 +4076,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/fear-of-missing-out",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -4090,7 +4090,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/fear-uncertainty-and-doubt",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -4104,7 +4104,7 @@
       "sampleSentence": "",
       "extended": "While it is often referred to simply as 'fiat', the full phrase is 'fiat currency'. The word 'fiat' refers, in Latin, to 'trusting'; hence, a fiat currency is one that trusts in something else to provide it value. For example, we are trusting that a government will maintain the value of a currency, rather than it having some sort of inherent value, or value derived from the things for which it can be exchanged.",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/fiat",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -4132,7 +4132,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/fibonacci-retracement",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -4146,7 +4146,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/fill-or-kill-order",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -4281,7 +4281,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/first-mover-advantage",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -4295,7 +4295,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/fiscal-policy",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -4309,7 +4309,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/flappening",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -4323,7 +4323,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/flashbots",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -4337,7 +4337,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/flippening",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -4351,7 +4351,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/flow-variable",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -4365,7 +4365,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/forced-liquidation",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -4379,7 +4379,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/forex-fx",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -4416,7 +4416,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/formal-verification",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -4463,7 +4463,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/fren",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -4510,7 +4510,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/fully-diluted-valuation-fdv",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -4524,7 +4524,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/fundamental-analysis",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -4538,7 +4538,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/funding-fees",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -4552,7 +4552,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/fungibility",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -4566,7 +4566,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/futures-contract",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -4580,7 +4580,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/gamefi",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -4702,7 +4702,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/gdp-deflator",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -4716,7 +4716,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/general-public-license",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -4800,7 +4800,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/gm-good-morning",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -4828,7 +4828,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/golden-cross",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -4842,7 +4842,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/golden-ratio",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -4856,7 +4856,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/goldilocks",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -4870,7 +4870,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/gossip-protocol",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -4898,7 +4898,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/gross-domestic-product-gdp",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -4945,7 +4945,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/hackathon",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -4959,7 +4959,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/hacker",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -4973,7 +4973,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/haha-money-printer-go-brrrrr",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -5006,7 +5006,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/hard-cap",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -5034,7 +5034,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/hard-landing",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -5099,7 +5099,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/hash-rate",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -5113,7 +5113,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/hashed-timelock-contract",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -5141,7 +5141,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/herd-instinct",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -5169,7 +5169,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/high-frequency-trading-hft",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -5183,7 +5183,7 @@
       "sampleSentence": "",
       "extended": "See also 'BUIDL'.",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/hodl",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -5197,7 +5197,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/honeypot",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -5281,7 +5281,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/iceberg-order",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -5342,7 +5342,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/index-funds",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -5370,7 +5370,7 @@
       "sampleSentence": "",
       "extended": "Often referred to by its initialism, 'ICO'.",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/initial-coin-offering",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -5384,7 +5384,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/initial-dex-offering-ido",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -5398,7 +5398,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/initial-exchange-offering",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -5412,7 +5412,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/inscription",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -5440,7 +5440,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/integrated-circuit",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -5454,7 +5454,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/interest-rates",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -5520,7 +5520,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/iou",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -5581,7 +5581,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/isolated-margin",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -5595,7 +5595,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/issuance",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -5637,7 +5637,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/keccak",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -5740,7 +5740,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/laspeyres-index",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -5801,7 +5801,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/law-of-demand",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -5909,7 +5909,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/leveraged-tokens",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -5994,7 +5994,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/limit-order",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -6022,7 +6022,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/linux",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -6050,7 +6050,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/liquid-staking",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -6064,7 +6064,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/liquid-staking-token-lst",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -6111,7 +6111,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/liquidity-crisis",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -6139,7 +6139,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/liquidity-provider",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -6153,7 +6153,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/liquidity-ratios",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -6181,7 +6181,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/listing",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -6214,7 +6214,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/mainnet-swap",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -6228,7 +6228,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/maker",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -6275,7 +6275,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/margin-trading",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -6308,7 +6308,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/market-momentum",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -6322,7 +6322,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/market-order",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -6336,7 +6336,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/masternode",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -6350,7 +6350,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/matching-engine",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -6392,7 +6392,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/maximum-supply",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -6467,7 +6467,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/merged-mining",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -6495,7 +6495,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/merkle-tree",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -6659,7 +6659,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/microtransactions",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -6720,7 +6720,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/mining-farm",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -6795,7 +6795,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/monetary-policy",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -6809,7 +6809,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/money-markets",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -6823,7 +6823,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/monitoring-tag",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -6837,7 +6837,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/moon",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -6865,7 +6865,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/moving-average-envelopes",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -6879,7 +6879,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/moving-average-ribbon",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -6893,7 +6893,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/mt-gox",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -6940,7 +6940,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/nakamoto-consensus",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -6968,7 +6968,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/net-asset-value-nav",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -7066,7 +7066,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/nft-floor-prices",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -7080,7 +7080,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/nft-mystery-boxes",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -7094,7 +7094,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/ngmi",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -7183,7 +7183,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/oco-order",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -7230,7 +7230,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/offline-signing-orchestrator-oso",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -7244,7 +7244,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/offshore-account",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -7319,7 +7319,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/opbnb",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -7333,7 +7333,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/open-source-software-oss",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -7375,7 +7375,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/opportunity-cost",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -7436,7 +7436,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/orc-20-tokens",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -7450,7 +7450,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/order-book",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -7464,7 +7464,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/ordinals",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -7478,7 +7478,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/orphan-block",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -7520,7 +7520,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/pancakeswap",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -7534,7 +7534,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/paper-wallet",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -7548,7 +7548,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/parallelization",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -7590,7 +7590,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/passive-management",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -7660,7 +7660,7 @@
       "sampleSentence": "",
       "extended": "See also, P2P.",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/peer-to-peer",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -7674,7 +7674,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/pegged-currency",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -7716,7 +7716,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/permissionless-blockchain",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -7796,7 +7796,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/polkadot-crowdloan",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -7824,7 +7824,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/ponzi-scheme",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -7880,7 +7880,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/premining",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -7894,7 +7894,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/price-action",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -7922,7 +7922,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/prisoners-dilemma",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -7987,7 +7987,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/private-sale",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -8001,7 +8001,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/progressive-web-application",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -8015,7 +8015,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/proof-of-attendance-protocol-poap",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -8029,7 +8029,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/proof-of-reserves-por",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -8062,7 +8062,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/proof-of-staked-authority-posa",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -8095,7 +8095,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/proposer-builder-separation-pbs",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -8109,7 +8109,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/proto-danksharding",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -8137,7 +8137,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/pseudorandom",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -8216,7 +8216,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/pump-and-dump",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -8244,7 +8244,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/quantitative-easing-qe",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -8258,7 +8258,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/quantitative-tightening-qt",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -8272,7 +8272,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/quantum-computing",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -8300,7 +8300,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/race-attack",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -8314,7 +8314,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/ransomware",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -8342,7 +8342,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/real-world-assets-rwas",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -8356,7 +8356,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/recession",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -8370,7 +8370,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/recursive-inscription",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -8384,7 +8384,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/rekt",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -8398,7 +8398,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/relative-strength-index",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -8440,7 +8440,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/resistance",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -8454,7 +8454,7 @@
       "sampleSentence": "",
       "extended": "Generally referred to by its initialism, 'ROI'.",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/return-on-investment",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -8468,7 +8468,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/revenge-trading",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -8496,7 +8496,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/risk-premium",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -8571,7 +8571,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/routing-attack",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -8632,7 +8632,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/sahm-rule",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -8674,7 +8674,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/sandwich-trading",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -8702,7 +8702,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/satoshi",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -8833,7 +8833,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/secure-asset-fund-for-users",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -8847,7 +8847,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/securities-and-exchange-commission",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -8861,7 +8861,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/security-audit",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -8927,7 +8927,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/seed-tag",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -8941,7 +8941,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/segregated-witness",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -8983,7 +8983,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/selfish-mining",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -8997,7 +8997,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/sell-wall",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -9011,7 +9011,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/sentiment",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -9100,7 +9100,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/sharpe-ratio",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -9166,7 +9166,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/simple-moving-average-sma",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -9180,7 +9180,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/slashing",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -9255,7 +9255,7 @@
           "source": "https://solana.com/docs/references/terminology#smart-contract"
         }
       ],
-      "termSource": "https://academy.binance.com/en/glossary/smart-contract",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -9269,7 +9269,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/smart-contract-wallet",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -9283,7 +9283,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/snapshot",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -9297,7 +9297,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/social-recovery-wallet",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -9311,7 +9311,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/social-trading",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -9325,7 +9325,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/socialfi",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -9353,7 +9353,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/soft-landing",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -9372,7 +9372,7 @@
           "source": "https://academy.binance.com/en/glossary/solidity"
         }
       ],
-      "termSource": "https://academy.binance.com/en/glossary/solidity",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -9386,7 +9386,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/source-code",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -9400,7 +9400,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/spl",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -9414,7 +9414,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/src-20-tokens",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -9433,7 +9433,7 @@
           "source": "https://academy.binance.com/en/glossary/stablecoin"
         }
       ],
-      "termSource": "https://academy.binance.com/en/glossary/stablecoin",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -9447,7 +9447,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/stagflation",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -9494,7 +9494,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/staking-pool",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -9541,7 +9541,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/steth",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -9569,7 +9569,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/stock-variable",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -9583,7 +9583,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/store-of-value",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -9611,7 +9611,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/supercomputer",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -9625,7 +9625,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/supply-chain",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -9639,7 +9639,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/support",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -9667,7 +9667,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/sybil-attack",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -9695,7 +9695,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/taker",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -9709,7 +9709,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/tank",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -9756,7 +9756,7 @@
           "source": "https://academy.binance.com/en/glossary/testnet"
         }
       ],
-      "termSource": "https://academy.binance.com/en/glossary/testnet",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -9812,7 +9812,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/ticker",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -9826,7 +9826,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/ticker-symbol",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -9849,7 +9849,7 @@
           "source": "https://solana.com/docs/references/terminology#token"
         }
       ],
-      "termSource": "https://academy.binance.com/en/glossary/token",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -9863,7 +9863,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/token-generation-event-tge",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -9882,7 +9882,7 @@
           "source": "https://academy.binance.com/en/glossary/token-lockup"
         }
       ],
-      "termSource": "https://academy.binance.com/en/glossary/token-lockup",
+      "termSource": "S",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -9896,7 +9896,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/token-merge",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -9910,7 +9910,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/token-sale",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -9943,7 +9943,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/tokenization",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -9957,7 +9957,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/tokenomics",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -9971,7 +9971,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/total-supply",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -9985,7 +9985,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/total-value-locked-tvl",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -9999,7 +9999,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/tradfi",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -10069,7 +10069,7 @@
           "source": "https://solana.com/docs/references/terminology#transaction-id"
         }
       ],
-      "termSource": "https://academy.binance.com/en/glossary/transaction-id",
+      "termSource": "S",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -10102,7 +10102,7 @@
           "source": "https://solana.com/docs/references/terminology#tps"
         }
       ],
-      "termSource": "https://academy.binance.com/en/glossary/transactions-per-second-tps",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -10130,7 +10130,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/treasury-bills-t-bills",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -10158,7 +10158,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/trueusd-tusd",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -10191,7 +10191,7 @@
           "source": "https://academy.binance.com/en/glossary/trustless"
         }
       ],
-      "termSource": "https://academy.binance.com/en/glossary/trustless",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -10210,7 +10210,7 @@
           "source": "https://academy.binance.com/en/glossary/turing-complete"
         }
       ],
-      "termSource": "https://academy.binance.com/en/glossary/turing-complete",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -10266,7 +10266,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/understanding-cz-s-number-4",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -10308,7 +10308,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/unit-of-account",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -10397,7 +10397,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/user-interface",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -10411,7 +10411,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/utility-token",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -10486,7 +10486,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/verification-code",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -10528,7 +10528,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/virtual-machine",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -10542,7 +10542,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/vladimir-club",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -10556,7 +10556,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/volatility",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -10570,7 +10570,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/volume",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -10584,7 +10584,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/wagmi",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -10607,7 +10607,7 @@
           "source": "https://solana.com/docs/references/terminology#wallet"
         }
       ],
-      "termSource": "https://academy.binance.com/en/glossary/wallet",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -10649,7 +10649,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/wash-trading",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -10663,7 +10663,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/weak-hands",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -10677,7 +10677,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/weak-subjectivity",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -10691,7 +10691,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/web-1",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -10794,7 +10794,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/weighted-moving-average-wma",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -10808,7 +10808,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/whale",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -10822,7 +10822,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/whiskers",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -10836,7 +10836,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/whitelist",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -10864,7 +10864,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/wick",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -10878,7 +10878,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/win-rate",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -10892,7 +10892,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/wrapped-ether",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -10920,7 +10920,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/wyckoff",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -10995,7 +10995,7 @@
           "source": "https://academy.binance.com/en/glossary/yield-farming"
         }
       ],
-      "termSource": "https://academy.binance.com/en/glossary/yield-farming",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -11066,7 +11066,7 @@
           "source": "https://academy.binance.com/en/glossary/zk-snarks"
         }
       ],
-      "termSource": "https://academy.binance.com/en/glossary/zk-snarks",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -11080,7 +11080,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/zk-starks",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },

--- a/locales/en-US/en-US.json
+++ b/locales/en-US/en-US.json
@@ -118,7 +118,7 @@
       "termCategory": "",
       "phonetic": "/əˈkaʊnt/",
       "definition": "An account, in web1 and web2 terms, refers to some sort of identity on some sort of digital platform. It is usually tied to an authentication method, e.g., username and password, which is granted, managed, and secured by the platform or service in question.   By contrast, a web3 or crypto account consists of what is known as a public-private key pair; the public half is generally safe to be shared publicly, and in the case of Ethereum, is further processed to create what is known as the 'public address' of the account, always beginning with '0x'. The private half, meanwhile, gives total control over the account; *total*.",
-      "definitionSource": "",
+      "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "These public-private key pairs can be generated one at a time, or they can be *derived* from what is known as a **seed phrase** or **secret recovery phrase**; for more on this, see HD wallet.",
       "additional": [
@@ -254,7 +254,7 @@
       "termCategory": "",
       "phonetic": "/ˈɛrˌdrɑp/",
       "definition": "A token distribution method in which cryptocurrency or tokens are sent to a predeterimened set of wallet addresses.",
-      "definitionSource": "https://academy.binance.com/en/glossary/airdrop",
+      "definitionSource": "Consensys Software Inc., A Blockchain Glossary for Beginners",
       "sampleSentence": "",
       "extended": "Sometimes airdrops are used for marketing purposes in exchange for simple tasks like reshares, referrals, or app downloads. The timing, recipient sourcing and inclusion methods, tokenomics and, if applicable, potential market value of tokens received through an airdrop are the subject of extensive debate and discussion.",
       "additional": [
@@ -263,7 +263,7 @@
           "source": "https://academy.binance.com/en/glossary/airdrop"
         }
       ],
-      "termSource": "https://academy.binance.com/en/glossary/airdrop",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -301,7 +301,7 @@
       "termCategory": "",
       "phonetic": "/ˈælɡəˌrɪðəm/",
       "definition": "An algorithm is a finite sequence of rigorous instructions, typically used to solve a class of specific problems or to perform a computation.",
-      "definitionSource": "https://academy.binance.com/en/glossary/algorithm",
+      "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
       "additional": [
@@ -310,7 +310,7 @@
           "source": "https://academy.binance.com/en/glossary/algorithm"
         }
       ],
-      "termSource": "https://academy.binance.com/en/glossary/algorithm",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -852,7 +852,7 @@
           "source": "https://academy.binance.com/en/glossary/beacon-chain"
         }
       ],
-      "termSource": "https://academy.binance.com/en/glossary/beacon-chain",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -1081,7 +1081,7 @@
           "source": "https://academy.binance.com/en/glossary/bitcoin"
         }
       ],
-      "termSource": "https://academy.binance.com/en/glossary/bitcoin",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -1174,7 +1174,7 @@
           "source": "https://solana.com/docs/references/terminology#block"
         }
       ],
-      "termSource": "https://academy.binance.com/en/glossary/block",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -1225,7 +1225,7 @@
           "source": "https://solana.com/docs/references/terminology#block-height"
         }
       ],
-      "termSource": "https://academy.binance.com/en/glossary/block-height",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -1235,7 +1235,7 @@
       "termCategory": "",
       "phonetic": "/blɑk rɪˈwɔrd/",
       "definition": "The reward given to a miner or validator after it has successfully built a block of transactions and added them to the chain.",
-      "definitionSource": "https://academy.binance.com/en/glossary/block-reward",
+      "definitionSource": "Consensys Software Inc., A Blockchain Glossary for Beginners",
       "sampleSentence": "",
       "extended": "Block rewards can be a mixture of coins and transaction fees. The composition depends on the policy used by the cryptocurrency in question, and whether all of the coins have already been successfully mined. The current block reward for the Bitcoin network is 12.5 bitcoins per block.",
       "additional": [
@@ -1244,7 +1244,7 @@
           "source": "https://academy.binance.com/en/glossary/block-reward"
         }
       ],
-      "termSource": "https://academy.binance.com/en/glossary/block-reward",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -1291,7 +1291,7 @@
           "source": "https://academy.binance.com/en/glossary/blockchain"
         }
       ],
-      "termSource": "https://academy.binance.com/en/glossary/blockchain",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -1436,7 +1436,7 @@
           "source": "https://academy.binance.com/en/glossary/bounty"
         }
       ],
-      "termSource": "https://academy.binance.com/en/glossary/bounty",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -1815,7 +1815,7 @@
       "termCategory": "",
       "phonetic": "/ˌsɛntrəˈlaɪzd ɪkˈstʃeɪndʒ/, /ˈsiːˈɛks/",
       "definition": "A centralized exchange (CEX) is a cryptocurrency exchange that is operated and controlled by a centralized entity. In a CEX, the exchange company or organization acts as an intermediary between buyers and sellers, holding and managing the assets on behalf of its users.",
-      "definitionSource": "https://academy.binance.com/en/glossary/centralized-exchange",
+      "definitionSource": "Consensys Software Inc., A Blockchain Glossary for Beginners",
       "sampleSentence": "",
       "extended": "Centralized exchanges typically offer a wide range of trading pairs, with many popular cryptocurrencies available for trade. They also usually have high liquidity and offer advanced trading features such as margin trading, order types, and charting tools.\nHowever, centralized exchanges also have several drawbacks. They are often targeted by hackers, as the centralized nature of the exchange makes them a single point of failure. They also require users to trust the exchange to hold their funds securely and execute trades fairly, which can be a source of concern for some users.",
       "additional": [
@@ -1824,7 +1824,7 @@
           "source": "https://academy.binance.com/en/glossary/centralized-exchange"
         }
       ],
-      "termSource": "https://academy.binance.com/en/glossary/centralized-exchange",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -1965,7 +1965,7 @@
       "termCategory": "",
       "phonetic": "/kɔɪn/",
       "definition": "The term 'coin' has some nuances. Strictly speaking, a 'coin' could be defined as: A fungible token (all of them identical) issued on a blockchain, either as the network's transactional token, or through a smart contract deployed to that network. Some people may use 'coins' as shorthand for 'bitcoin'; the immortal aphorism 'not your keys, not your coins' refers to bitcoins. Another thing to keep in mind is that, while coins are put forward as some sort of representation of value, that value can vary wildly from one 'coin' to another. A coin may represent the value of the computational resources of the network, or it may be 'pegged' to represent fiat currency value, or it may float according to the value placed on immaterial resources like NFTs, membership, or digital goods, to name a few.",
-      "definitionSource": "https://academy.binance.com/en/glossary/coin",
+      "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
       "additional": [
@@ -1974,7 +1974,7 @@
           "source": "https://academy.binance.com/en/glossary/coin"
         }
       ],
-      "termSource": "https://academy.binance.com/en/glossary/coin",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -2012,7 +2012,7 @@
       "termCategory": "",
       "phonetic": "/koʊld ˈstɔrɪdʒ/",
       "definition": "A phrasing borrowed from traditional data security; specifically in crypto, 'keeping assets in cold storage' refers to keeping the private keys that control them in a way that is never connected to the internet. This can refer to technological solutions like hardware wallets, as well as more low-tech methods, like writing down an SRP and keeping it in a safe.",
-      "definitionSource": "https://academy.binance.com/en/glossary/cold-storage",
+      "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "See also: airgapping",
       "additional": [
@@ -2021,7 +2021,7 @@
           "source": "https://academy.binance.com/en/glossary/cold-storage"
         }
       ],
-      "termSource": "https://academy.binance.com/en/glossary/cold-storage",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -2152,7 +2152,7 @@
           "source": "https://solana.com/docs/references/terminology#confirmation-time"
         }
       ],
-      "termSource": "https://academy.binance.com/en/glossary/confirmation-time",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -2278,7 +2278,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "https://academy.binance.com/en/glossary/consumer-price-index-(cpi)",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -2554,7 +2554,7 @@
       "termCategory": "",
       "phonetic": "/ˌkrɪptəˈkɜrənsi/",
       "definition": "Digital currency that is based on mathematics and uses encryption techniques to regulate the creation of units of currency as well as verifying the transfer of funds. Cryptocurrencies operate independently of a central bank, and are kept track of through distributed ledger technology.",
-      "definitionSource": "https://academy.binance.com/en/glossary/cryptocurrency",
+      "definitionSource": "Consensys Software Inc., A Blockchain Glossary for Beginners",
       "sampleSentence": "",
       "extended": "",
       "additional": [
@@ -2563,7 +2563,7 @@
           "source": "https://academy.binance.com/en/glossary/cryptocurrency"
         }
       ],
-      "termSource": "https://academy.binance.com/en/glossary/cryptocurrency",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -2596,7 +2596,7 @@
           "source": "https://academy.binance.com/en/glossary/cryptography"
         }
       ],
-      "termSource": "https://academy.binance.com/en/glossary/cryptography",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -2620,7 +2620,7 @@
       "termCategory": "",
       "phonetic": "/ˈkʌstədi/",
       "definition": "In the context of cryptocurrencies, custody refers to the safekeeping and management of digital assets on behalf of a client by a third-party service provider. Custody services are an important aspect of the cryptocurrency industry because cryptocurrencies are digital assets that require secure storage and management to prevent loss, theft, or unauthorized access.\n\nCrypto custody services are typically offered by specialized companies that provide secure storage solutions for cryptocurrencies. These companies use various security measures such as multi-signature authentication, cold storage, and insurance to protect their clients' assets.",
-      "definitionSource": "https://academy.binance.com/en/glossary/custody",
+      "definitionSource": "Education DAO - mapachurro",
       "sampleSentence": "",
       "extended": "",
       "additional": [
@@ -2629,7 +2629,7 @@
           "source": "https://academy.binance.com/en/glossary/custody"
         }
       ],
-      "termSource": "https://academy.binance.com/en/glossary/custody",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -2788,7 +2788,7 @@
           "source": "https://academy.binance.com/en/glossary/decentralized-application"
         }
       ],
-      "termSource": "https://academy.binance.com/en/glossary/decentralized-application",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -2821,7 +2821,7 @@
           "source": "https://academy.binance.com/en/glossary/decentralized-autonomous-organization"
         }
       ],
-      "termSource": "https://academy.binance.com/en/glossary/decentralized-autonomous-organization",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -2831,7 +2831,7 @@
       "termCategory": "",
       "phonetic": "/diːˈsɛntrəˌlaɪzd ɪksˈtʃeɪndʒ/",
       "definition": "A decentralized exchange (DEX) is a platform for exchanging cryptocurrencies based on functionality programmed on the blockchain (i.e., in smart contracts). If cryptocurrency is web3’s monetary system, its financial system is DeFi.",
-      "definitionSource": "https://academy.binance.com/en/glossary/decentralized-exchange",
+      "definitionSource": "Consensys Software Inc., A Blockchain Glossary for Beginners",
       "sampleSentence": "",
       "extended": "This includes familiar concepts like loans and interest-bearing financial instruments, as well as so-called “DeFi primitives”, novel solutions like token swapping and liquidity pools. The trading is peer-to-peer, or between pools of liquidity. This is in contrast with a centralized exchange, which is more akin to a bank or investment firm that specializes in cryptocurrencies. Additionally, there are so-called on-ramp providers, who could be compared to currency brokers, exchanging traditional “fiat” money for cryptocurrencies, and do not hold customer’s funds “on deposit” the way a centralized exchange does. There are important technical and regulatory differences between these, which are constantly evolving.",
       "additional": [
@@ -2840,7 +2840,7 @@
           "source": "https://academy.binance.com/en/glossary/decentralized-exchange"
         }
       ],
-      "termSource": "https://academy.binance.com/en/glossary/decentralized-exchange",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -3125,7 +3125,7 @@
           "source": "https://academy.binance.com/en/glossary/difficulty"
         }
       ],
-      "termSource": "https://academy.binance.com/en/glossary/difficulty",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -3144,7 +3144,7 @@
           "source": "https://academy.binance.com/en/glossary/difficulty-bomb"
         }
       ],
-      "termSource": "https://academy.binance.com/en/glossary/difficulty-bomb",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -3191,7 +3191,7 @@
           "source": "https://academy.binance.com/en/glossary/digital-signature"
         }
       ],
-      "termSource": "https://academy.binance.com/en/glossary/digital-signature",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -3537,7 +3537,7 @@
           "source": "https://academy.binance.com/en/glossary/encryption"
         }
       ],
-      "termSource": "https://academy.binance.com/en/glossary/encryption",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -3631,7 +3631,7 @@
           "source": "https://academy.binance.com/en/glossary/erc-1155"
         }
       ],
-      "termSource": "https://academy.binance.com/en/glossary/erc-1155",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -3650,7 +3650,7 @@
           "source": "https://academy.binance.com/en/glossary/erc-20"
         }
       ],
-      "termSource": "https://academy.binance.com/en/glossary/erc-20",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -3683,7 +3683,7 @@
           "source": "https://academy.binance.com/en/glossary/erc-721"
         }
       ],
-      "termSource": "https://academy.binance.com/en/glossary/erc-721",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -3908,7 +3908,7 @@
           "source": "https://academy.binance.com/en/glossary/exchange"
         }
       ],
-      "termSource": "https://academy.binance.com/en/glossary/exchange",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -4169,7 +4169,7 @@
           "source": "https://solana.com/docs/references/terminology#finality"
         }
       ],
-      "termSource": "https://academy.binance.com/en/glossary/finality",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -4402,7 +4402,7 @@
           "source": "https://solana.com/docs/references/terminology#fork"
         }
       ],
-      "termSource": "https://academy.binance.com/en/glossary/fork",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -4449,7 +4449,7 @@
           "source": "https://academy.binance.com/en/glossary/fraud-proof"
         }
       ],
-      "termSource": "https://academy.binance.com/en/glossary/fraud-proof",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -4496,7 +4496,7 @@
           "source": "https://academy.binance.com/en/glossary/full-node"
         }
       ],
-      "termSource": "https://academy.binance.com/en/glossary/full-node",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -4613,7 +4613,7 @@
           "source": "https://academy.binance.com/en/glossary/gas"
         }
       ],
-      "termSource": "https://academy.binance.com/en/glossary/gas",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -4646,7 +4646,7 @@
           "source": "https://academy.binance.com/en/glossary/gas-limit"
         }
       ],
-      "termSource": "https://academy.binance.com/en/glossary/gas-limit",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -4786,7 +4786,7 @@
           "source": "https://academy.binance.com/en/glossary/github"
         }
       ],
-      "termSource": "https://academy.binance.com/en/glossary/github",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -4931,7 +4931,7 @@
           "source": "https://academy.binance.com/en/glossary/gwei"
         }
       ],
-      "termSource": "https://academy.binance.com/en/glossary/gwei",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -4992,7 +4992,7 @@
           "source": "https://academy.binance.com/en/glossary/halving"
         }
       ],
-      "termSource": "https://academy.binance.com/en/glossary/halving",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -5328,7 +5328,7 @@
           "source": "https://academy.binance.com/en/glossary/immutability"
         }
       ],
-      "termSource": "https://academy.binance.com/en/glossary/immutability",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -5487,7 +5487,7 @@
           "source": "https://academy.binance.com/en/glossary/interoperability"
         }
       ],
-      "termSource": "https://academy.binance.com/en/glossary/interoperability",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -5670,7 +5670,7 @@
           "source": "https://academy.binance.com/en/glossary/know-your-customer"
         }
       ],
-      "termSource": "https://academy.binance.com/en/glossary/know-your-customer",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -5759,7 +5759,7 @@
           "source": "https://academy.binance.com/en/glossary/latency"
         }
       ],
-      "termSource": "https://academy.binance.com/en/glossary/latency",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -5848,7 +5848,7 @@
           "source": "https://academy.binance.com/en/glossary/layer-2"
         }
       ],
-      "termSource": "https://academy.binance.com/en/glossary/layer-2",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -5867,7 +5867,7 @@
           "source": "https://solana.com/docs/references/terminology#ledger"
         }
       ],
-      "termSource": "https://academy.binance.com/en/glossary/ledger",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -5928,7 +5928,7 @@
           "source": "https://academy.binance.com/en/glossary/library"
         }
       ],
-      "termSource": "https://academy.binance.com/en/glossary/library",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -5980,7 +5980,7 @@
           "source": "https://academy.binance.com/en/glossary/lightning-network"
         }
       ],
-      "termSource": "https://academy.binance.com/en/glossary/lightning-network",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -6097,7 +6097,7 @@
           "source": "https://academy.binance.com/en/glossary/liquidity"
         }
       ],
-      "termSource": "https://academy.binance.com/en/glossary/liquidity",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -6200,7 +6200,7 @@
           "source": "https://academy.binance.com/en/glossary/mainnet"
         }
       ],
-      "termSource": "https://academy.binance.com/en/glossary/mainnet",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -6261,7 +6261,7 @@
           "source": "https://academy.binance.com/en/glossary/malware"
         }
       ],
-      "termSource": "https://academy.binance.com/en/glossary/malware",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -6425,7 +6425,7 @@
           "source": "https://academy.binance.com/en/glossary/mempool"
         }
       ],
-      "termSource": "https://academy.binance.com/en/glossary/mempool",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -6528,7 +6528,7 @@
           "source": "https://academy.binance.com/en/glossary/metadata"
         }
       ],
-      "termSource": "https://academy.binance.com/en/glossary/metadata",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -6617,7 +6617,7 @@
           "source": "https://academy.binance.com/en/glossary/metaverse"
         }
       ],
-      "termSource": "https://academy.binance.com/en/glossary/metaverse",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -6706,7 +6706,7 @@
           "source": "https://academy.binance.com/en/glossary/mining"
         }
       ],
-      "termSource": "https://academy.binance.com/en/glossary/mining",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -6739,7 +6739,7 @@
           "source": "https://academy.binance.com/en/glossary/mint"
         }
       ],
-      "termSource": "https://academy.binance.com/en/glossary/mint",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -7131,7 +7131,7 @@
           "source": "https://solana.com/docs/references/terminology#node"
         }
       ],
-      "termSource": "https://academy.binance.com/en/glossary/node",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -7169,7 +7169,7 @@
           "source": "https://academy.binance.com/en/glossary/nonce"
         }
       ],
-      "termSource": "https://academy.binance.com/en/glossary/nonce",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -7202,7 +7202,7 @@
           "source": "https://academy.binance.com/en/glossary/off-chain"
         }
       ],
-      "termSource": "https://academy.binance.com/en/glossary/off-chain",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -7277,7 +7277,7 @@
           "source": "https://academy.binance.com/en/glossary/on-chain"
         }
       ],
-      "termSource": "https://academy.binance.com/en/glossary/on-chain",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -7422,7 +7422,7 @@
           "source": "https://academy.binance.com/en/glossary/oracle"
         }
       ],
-      "termSource": "https://academy.binance.com/en/glossary/oracle",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -7735,7 +7735,7 @@
           "source": "https://academy.binance.com/en/glossary/phishing"
         }
       ],
-      "termSource": "https://academy.binance.com/en/glossary/phishing",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -7768,7 +7768,7 @@
           "source": "https://academy.binance.com/en/glossary/plasma"
         }
       ],
-      "termSource": "https://academy.binance.com/en/glossary/plasma",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -7973,7 +7973,7 @@
           "source": "https://solana.com/docs/references/terminology#private-key"
         }
       ],
-      "termSource": "https://academy.binance.com/en/glossary/private-key",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -8048,7 +8048,7 @@
           "source": "https://academy.binance.com/en/glossary/proof-of-stake"
         }
       ],
-      "termSource": "https://academy.binance.com/en/glossary/proof-of-stake",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -8081,7 +8081,7 @@
           "source": "https://academy.binance.com/en/glossary/proof-of-work"
         }
       ],
-      "termSource": "https://academy.binance.com/en/glossary/proof-of-work",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -8188,7 +8188,7 @@
           "source": "https://solana.com/docs/references/terminology#public-key-pubkey"
         }
       ],
-      "termSource": "https://academy.binance.com/en/glossary/public-key",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -8515,7 +8515,7 @@
           "source": "https://academy.binance.com/en/glossary/roadmap"
         }
       ],
-      "termSource": "https://academy.binance.com/en/glossary/roadmap",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -8604,7 +8604,7 @@
           "source": "https://academy.binance.com/en/glossary/rug-pull"
         }
       ],
-      "termSource": "https://academy.binance.com/en/glossary/rug-pull",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -8721,7 +8721,7 @@
           "source": "https://academy.binance.com/en/glossary/satoshi-nakamoto"
         }
       ],
-      "termSource": "https://academy.binance.com/en/glossary/satoshi-nakamoto",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -8913,7 +8913,7 @@
           "source": "https://academy.binance.com/en/glossary/seed-phrase"
         }
       ],
-      "termSource": "https://academy.binance.com/en/glossary/seed-phrase",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -9086,7 +9086,7 @@
           "source": "https://academy.binance.com/en/glossary/sharding"
         }
       ],
-      "termSource": "https://academy.binance.com/en/glossary/sharding",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -9213,7 +9213,7 @@
           "source": "https://academy.binance.com/en/glossary/slippage"
         }
       ],
-      "termSource": "https://academy.binance.com/en/glossary/slippage",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },
@@ -10780,7 +10780,7 @@
           "source": "https://academy.binance.com/en/glossary/wei"
         }
       ],
-      "termSource": "https://academy.binance.com/en/glossary/wei",
+      "termSource": "",
       "dateFirstRecorded": "2025-01-31",
       "commentary": ""
     },

--- a/locales/en-US/en-US.json
+++ b/locales/en-US/en-US.json
@@ -3743,7 +3743,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "ethereum-2.0": {
+    "ethereum-2": {
       "term": "Ethereum 2.0",
       "partOfSpeech": "noun",
       "termCategory": "",

--- a/locales/en-US/en-US.json
+++ b/locales/en-US/en-US.json
@@ -11094,7 +11094,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "Solana Glossary",
+      "termSource": "",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
     },
@@ -11108,7 +11108,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "Solana Glossary",
+      "termSource": "",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
     },
@@ -11122,7 +11122,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "Solana Glossary",
+      "termSource": "",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
     },
@@ -11136,7 +11136,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "Solana Glossary",
+      "termSource": "",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
     },
@@ -11150,7 +11150,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "Solana Glossary",
+      "termSource": "",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
     },
@@ -11164,7 +11164,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "Solana Glossary",
+      "termSource": "",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
     },
@@ -11178,7 +11178,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "Solana Glossary",
+      "termSource": "",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
     },
@@ -11192,7 +11192,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "Solana Glossary",
+      "termSource": "",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
     },
@@ -11206,7 +11206,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "Solana Glossary",
+      "termSource": "",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
     },
@@ -11220,7 +11220,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "Solana Glossary",
+      "termSource": "",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
     },
@@ -11234,7 +11234,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "Solana Glossary",
+      "termSource": "",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
     },
@@ -11248,7 +11248,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "Solana Glossary",
+      "termSource": "",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
     },
@@ -11262,7 +11262,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "Solana Glossary",
+      "termSource": "",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
     },
@@ -11276,7 +11276,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "Solana Glossary",
+      "termSource": "",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
     },
@@ -11290,7 +11290,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "Solana Glossary",
+      "termSource": "",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
     },
@@ -11304,7 +11304,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "Solana Glossary",
+      "termSource": "",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
     },
@@ -11318,7 +11318,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "Solana Glossary",
+      "termSource": "",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
     },
@@ -11332,7 +11332,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "Solana Glossary",
+      "termSource": "",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
     },
@@ -11346,7 +11346,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "Solana Glossary",
+      "termSource": "",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
     },
@@ -11360,7 +11360,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "Solana Glossary",
+      "termSource": "",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
     },
@@ -11374,7 +11374,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "Solana Glossary",
+      "termSource": "",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
     },
@@ -11388,7 +11388,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "Solana Glossary",
+      "termSource": "",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
     },
@@ -11402,7 +11402,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "Solana Glossary",
+      "termSource": "",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
     },
@@ -11416,7 +11416,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "Solana Glossary",
+      "termSource": "",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
     },
@@ -11430,7 +11430,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "Solana Glossary",
+      "termSource": "",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
     },
@@ -11444,7 +11444,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "Solana Glossary",
+      "termSource": "",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
     },
@@ -11458,7 +11458,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "Solana Glossary",
+      "termSource": "",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
     },
@@ -11472,7 +11472,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "Solana Glossary",
+      "termSource": "",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
     },
@@ -11486,7 +11486,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "Solana Glossary",
+      "termSource": "",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
     },
@@ -11500,7 +11500,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "Solana Glossary",
+      "termSource": "",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
     },
@@ -11514,7 +11514,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "Solana Glossary",
+      "termSource": "",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
     },
@@ -11528,7 +11528,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "Solana Glossary",
+      "termSource": "",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
     },
@@ -11542,7 +11542,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "Solana Glossary",
+      "termSource": "",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
     },
@@ -11556,7 +11556,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "Solana Glossary",
+      "termSource": "",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
     },
@@ -11570,7 +11570,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "Solana Glossary",
+      "termSource": "",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
     },
@@ -11584,7 +11584,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "Solana Glossary",
+      "termSource": "",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
     },
@@ -11598,7 +11598,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "Solana Glossary",
+      "termSource": "",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
     },
@@ -11612,7 +11612,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "Solana Glossary",
+      "termSource": "",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
     },
@@ -11626,7 +11626,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "Solana Glossary",
+      "termSource": "",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
     },
@@ -11640,7 +11640,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "Solana Glossary",
+      "termSource": "",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
     },
@@ -11654,7 +11654,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "Solana Glossary",
+      "termSource": "",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
     },
@@ -11668,7 +11668,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "Solana Glossary",
+      "termSource": "",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
     },
@@ -11682,7 +11682,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "Solana Glossary",
+      "termSource": "",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
     },
@@ -11696,7 +11696,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "Solana Glossary",
+      "termSource": "",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
     },
@@ -11710,7 +11710,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "Solana Glossary",
+      "termSource": "",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
     },
@@ -11724,7 +11724,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "Solana Glossary",
+      "termSource": "",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
     },
@@ -11738,7 +11738,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "Solana Glossary",
+      "termSource": "",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
     },
@@ -11752,7 +11752,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "Solana Glossary",
+      "termSource": "",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
     },
@@ -11766,7 +11766,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "Solana Glossary",
+      "termSource": "",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
     },
@@ -11780,7 +11780,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "Solana Glossary",
+      "termSource": "",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
     },
@@ -11794,7 +11794,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "Solana Glossary",
+      "termSource": "",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
     },
@@ -11808,7 +11808,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "Solana Glossary",
+      "termSource": "",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
     },
@@ -11822,7 +11822,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "Solana Glossary",
+      "termSource": "",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
     },
@@ -11836,7 +11836,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "Solana Glossary",
+      "termSource": "",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
     },
@@ -11850,7 +11850,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "Solana Glossary",
+      "termSource": "",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
     },
@@ -11864,7 +11864,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "Solana Glossary",
+      "termSource": "",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
     },
@@ -11878,7 +11878,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "Solana Glossary",
+      "termSource": "",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
     },
@@ -11892,7 +11892,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "Solana Glossary",
+      "termSource": "",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
     },
@@ -11906,7 +11906,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "Solana Glossary",
+      "termSource": "",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
     },
@@ -11920,7 +11920,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "Solana Glossary",
+      "termSource": "",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
     },
@@ -11934,7 +11934,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "Solana Glossary",
+      "termSource": "",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
     },
@@ -11948,7 +11948,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "Solana Glossary",
+      "termSource": "",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
     },
@@ -11962,7 +11962,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "Solana Glossary",
+      "termSource": "",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
     },
@@ -11976,7 +11976,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "Solana Glossary",
+      "termSource": "",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
     },
@@ -11990,7 +11990,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "Solana Glossary",
+      "termSource": "",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
     },
@@ -12004,7 +12004,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "Solana Glossary",
+      "termSource": "",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
     },
@@ -12018,7 +12018,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "Solana Glossary",
+      "termSource": "",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
     },
@@ -12032,7 +12032,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "Solana Glossary",
+      "termSource": "",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
     },
@@ -12046,7 +12046,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "Solana Glossary",
+      "termSource": "",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
     },
@@ -12060,7 +12060,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "Solana Glossary",
+      "termSource": "",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
     },
@@ -12074,7 +12074,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "Solana Glossary",
+      "termSource": "",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
     },
@@ -12088,7 +12088,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "Solana Glossary",
+      "termSource": "",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
     },
@@ -12102,7 +12102,7 @@
       "sampleSentence": "",
       "extended": "",
       "additional": [],
-      "termSource": "Solana Glossary",
+      "termSource": "",
       "dateFirstRecorded": "2025-02-14",
       "commentary": ""
     }

--- a/locales/en-US/en-US.json
+++ b/locales/en-US/en-US.json
@@ -2268,7 +2268,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "consumer-price-index-(cpi)": {
+    "consumer-price-index": {
       "term": "Consumer Price Index (CPI)",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/en-US/en-US.json
+++ b/locales/en-US/en-US.json
@@ -2928,7 +2928,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "delegated-proof-of-stake-(dpos)": {
+    "delegated-proof-of-stake": {
       "term": "Delegated proof of stake (DPoS)",
       "partOfSpeech": "noun",
       "termCategory": "",

--- a/locales/es-419/es-419.json
+++ b/locales/es-419/es-419.json
@@ -2156,7 +2156,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "consumer-price-index-(cpi)": {
+    "consumer-price-index": {
       "term": "Consumer Price Index (CPI)",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/es-419/es-419.json
+++ b/locales/es-419/es-419.json
@@ -3570,7 +3570,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "ethereum-2.0": {
+    "ethereum-2": {
       "term": "Ethereum 2.0",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/es-419/es-419.json
+++ b/locales/es-419/es-419.json
@@ -2786,7 +2786,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "delegated-proof-of-stake-(dpos)": {
+    "delegated-proof-of-stake": {
       "term": "DPoS",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/fa-AF/fa-AF.json
+++ b/locales/fa-AF/fa-AF.json
@@ -1414,7 +1414,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "delegated-proof-of-stake-(dpos)": {
+    "delegated-proof-of-stake": {
       "term": "الگوریتم گواه اثبات سهام نیابتی(DPoS)",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/fa-AF/fa-AF.json
+++ b/locales/fa-AF/fa-AF.json
@@ -1862,7 +1862,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "ethereum-2.0": {
+    "ethereum-2": {
       "term": "Ethereum 2.0",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/fr-FR/fr-FR.json
+++ b/locales/fr-FR/fr-FR.json
@@ -2156,7 +2156,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "consumer-price-index-(cpi)": {
+    "consumer-price-index": {
       "term": "Consumer Price Index (CPI)",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/fr-FR/fr-FR.json
+++ b/locales/fr-FR/fr-FR.json
@@ -3570,7 +3570,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "ethereum-2.0": {
+    "ethereum-2": {
       "term": "Ethereum 2.0",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/fr-FR/fr-FR.json
+++ b/locales/fr-FR/fr-FR.json
@@ -2786,7 +2786,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "delegated-proof-of-stake-(dpos)": {
+    "delegated-proof-of-stake": {
       "term": "DPoS",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/ha-NG/ha-NG.json
+++ b/locales/ha-NG/ha-NG.json
@@ -1414,7 +1414,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "delegated-proof-of-stake-(dpos)": {
+    "delegated-proof-of-stake": {
       "term": "Tabbatarwa ta Hanyar Mallaka wanda aka wakilta",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/ha-NG/ha-NG.json
+++ b/locales/ha-NG/ha-NG.json
@@ -1862,7 +1862,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "ethereum-2.0": {
+    "ethereum-2": {
       "term": "Ethereum 2.0",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/hi-IN/hi-IN.json
+++ b/locales/hi-IN/hi-IN.json
@@ -1414,7 +1414,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "delegated-proof-of-stake-(dpos)": {
+    "delegated-proof-of-stake": {
       "term": "डेलिगेटेड प्रूफ ऑफ़ स्टेक (DPoS)",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/hi-IN/hi-IN.json
+++ b/locales/hi-IN/hi-IN.json
@@ -1862,7 +1862,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "ethereum-2.0": {
+    "ethereum-2": {
       "term": "Ethereum 2.0",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/hu-HU/hu-HU.json
+++ b/locales/hu-HU/hu-HU.json
@@ -2156,7 +2156,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "consumer-price-index-(cpi)": {
+    "consumer-price-index": {
       "term": "Consumer Price Index (CPI)",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/hu-HU/hu-HU.json
+++ b/locales/hu-HU/hu-HU.json
@@ -3570,7 +3570,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "ethereum-2.0": {
+    "ethereum-2": {
       "term": "Ethereum 2.0",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/hu-HU/hu-HU.json
+++ b/locales/hu-HU/hu-HU.json
@@ -2786,7 +2786,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "delegated-proof-of-stake-(dpos)": {
+    "delegated-proof-of-stake": {
       "term": "DPoS",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/id-ID/id-ID.json
+++ b/locales/id-ID/id-ID.json
@@ -2156,7 +2156,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "consumer-price-index-(cpi)": {
+    "consumer-price-index": {
       "term": "Consumer Price Index (CPI)",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/id-ID/id-ID.json
+++ b/locales/id-ID/id-ID.json
@@ -3570,7 +3570,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "ethereum-2.0": {
+    "ethereum-2": {
       "term": "Ethereum 2.0",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/id-ID/id-ID.json
+++ b/locales/id-ID/id-ID.json
@@ -2786,7 +2786,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "delegated-proof-of-stake-(dpos)": {
+    "delegated-proof-of-stake": {
       "term": "Bukti staking terdelgasi (DPoS)",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/it-IT/it-IT.json
+++ b/locales/it-IT/it-IT.json
@@ -2786,7 +2786,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "delegated-proof-of-stake-(dpos)": {
+    "delegated-proof-of-stake": {
       "term": "Delegated proof of stake (DPoS)",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/it-IT/it-IT.json
+++ b/locales/it-IT/it-IT.json
@@ -2156,7 +2156,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "consumer-price-index-(cpi)": {
+    "consumer-price-index": {
       "term": "Consumer Price Index (CPI)",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/it-IT/it-IT.json
+++ b/locales/it-IT/it-IT.json
@@ -3570,7 +3570,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "ethereum-2.0": {
+    "ethereum-2": {
       "term": "Ethereum 2.0",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/ja-JP/ja-JP.json
+++ b/locales/ja-JP/ja-JP.json
@@ -1414,7 +1414,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "delegated-proof-of-stake-(dpos)": {
+    "delegated-proof-of-stake": {
       "term": "デリゲート・プルーフ・オブ・ステーク (DPoS)",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/ja-JP/ja-JP.json
+++ b/locales/ja-JP/ja-JP.json
@@ -1862,7 +1862,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "ethereum-2.0": {
+    "ethereum-2": {
       "term": "Ethereum 2.0",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/ko-KR/ko-KR.json
+++ b/locales/ko-KR/ko-KR.json
@@ -1414,7 +1414,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "delegated-proof-of-stake-(dpos)": {
+    "delegated-proof-of-stake": {
       "term": "DPoS",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/ko-KR/ko-KR.json
+++ b/locales/ko-KR/ko-KR.json
@@ -1862,7 +1862,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "ethereum-2.0": {
+    "ethereum-2": {
       "term": "Ethereum 2.0",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/ms-MY/ms-MY.json
+++ b/locales/ms-MY/ms-MY.json
@@ -1414,7 +1414,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "delegated-proof-of-stake-(dpos)": {
+    "delegated-proof-of-stake": {
       "term": "Bukti pegangan yang terdelegasi (DPoS)",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/ms-MY/ms-MY.json
+++ b/locales/ms-MY/ms-MY.json
@@ -1862,7 +1862,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "ethereum-2.0": {
+    "ethereum-2": {
       "term": "Ethereum 2.0",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/nl-NL/nl-NL.json
+++ b/locales/nl-NL/nl-NL.json
@@ -1414,7 +1414,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "delegated-proof-of-stake-(dpos)": {
+    "delegated-proof-of-stake": {
       "term": "DPoS (delegated proof-of-stake)",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/nl-NL/nl-NL.json
+++ b/locales/nl-NL/nl-NL.json
@@ -1862,7 +1862,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "ethereum-2.0": {
+    "ethereum-2": {
       "term": "Ethereum 2.0",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/pcm-NG/pcm-NG.json
+++ b/locales/pcm-NG/pcm-NG.json
@@ -1414,7 +1414,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "delegated-proof-of-stake-(dpos)": {
+    "delegated-proof-of-stake": {
       "term": "How dem dey protect blockchain by you holding crypto wey dem delegate",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/pcm-NG/pcm-NG.json
+++ b/locales/pcm-NG/pcm-NG.json
@@ -1862,7 +1862,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "ethereum-2.0": {
+    "ethereum-2": {
       "term": "Ethereum 2.0",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/pl-PL/pl-PL.json
+++ b/locales/pl-PL/pl-PL.json
@@ -1414,7 +1414,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "delegated-proof-of-stake-(dpos)": {
+    "delegated-proof-of-stake": {
       "term": "DPoS",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/pl-PL/pl-PL.json
+++ b/locales/pl-PL/pl-PL.json
@@ -1862,7 +1862,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "ethereum-2.0": {
+    "ethereum-2": {
       "term": "Ethereum 2.0",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/pt-BR/pt-BR.json
+++ b/locales/pt-BR/pt-BR.json
@@ -1862,7 +1862,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "ethereum-2.0": {
+    "ethereum-2": {
       "term": "Ethereum 2.0",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/pt-BR/pt-BR.json
+++ b/locales/pt-BR/pt-BR.json
@@ -1414,7 +1414,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "delegated-proof-of-stake-(dpos)": {
+    "delegated-proof-of-stake": {
       "term": "Prova de participação delegada (DPoS)",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/ro-RO/ro-RO.json
+++ b/locales/ro-RO/ro-RO.json
@@ -2156,7 +2156,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "consumer-price-index-(cpi)": {
+    "consumer-price-index": {
       "term": "Consumer Price Index (CPI)",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/ro-RO/ro-RO.json
+++ b/locales/ro-RO/ro-RO.json
@@ -3570,7 +3570,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "ethereum-2.0": {
+    "ethereum-2": {
       "term": "Ethereum 2.0",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/ro-RO/ro-RO.json
+++ b/locales/ro-RO/ro-RO.json
@@ -2786,7 +2786,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "delegated-proof-of-stake-(dpos)": {
+    "delegated-proof-of-stake": {
       "term": "Proof of stake delegat (DPoS)",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/ru-RU/ru-RU.json
+++ b/locales/ru-RU/ru-RU.json
@@ -1414,7 +1414,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "delegated-proof-of-stake-(dpos)": {
+    "delegated-proof-of-stake": {
       "term": "DPoS",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/ru-RU/ru-RU.json
+++ b/locales/ru-RU/ru-RU.json
@@ -1862,7 +1862,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "ethereum-2.0": {
+    "ethereum-2": {
       "term": "Ethereum 2.0",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/th-TH/th-TH.json
+++ b/locales/th-TH/th-TH.json
@@ -1414,7 +1414,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "delegated-proof-of-stake-(dpos)": {
+    "delegated-proof-of-stake": {
       "term": "DPoS",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/th-TH/th-TH.json
+++ b/locales/th-TH/th-TH.json
@@ -1862,7 +1862,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "ethereum-2.0": {
+    "ethereum-2": {
       "term": "Ethereum 2.0",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/tl-PH/tl-PH.json
+++ b/locales/tl-PH/tl-PH.json
@@ -1414,7 +1414,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "delegated-proof-of-stake-(dpos)": {
+    "delegated-proof-of-stake": {
       "term": "Delegated proof of stake (DPoS)",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/tl-PH/tl-PH.json
+++ b/locales/tl-PH/tl-PH.json
@@ -1862,7 +1862,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "ethereum-2.0": {
+    "ethereum-2": {
       "term": "Ethereum 2.0",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/tr-TR/tr-TR.json
+++ b/locales/tr-TR/tr-TR.json
@@ -1414,7 +1414,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "delegated-proof-of-stake-(dpos)": {
+    "delegated-proof-of-stake": {
       "term": "DPoS",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/tr-TR/tr-TR.json
+++ b/locales/tr-TR/tr-TR.json
@@ -1862,7 +1862,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "ethereum-2.0": {
+    "ethereum-2": {
       "term": "Ethereum 2.0",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/uk-UA/uk-UA.json
+++ b/locales/uk-UA/uk-UA.json
@@ -2156,7 +2156,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "consumer-price-index-(cpi)": {
+    "consumer-price-index": {
       "term": "Consumer Price Index (CPI)",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/uk-UA/uk-UA.json
+++ b/locales/uk-UA/uk-UA.json
@@ -3570,7 +3570,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "ethereum-2.0": {
+    "ethereum-2": {
       "term": "Ethereum 2.0",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/uk-UA/uk-UA.json
+++ b/locales/uk-UA/uk-UA.json
@@ -2786,7 +2786,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "delegated-proof-of-stake-(dpos)": {
+    "delegated-proof-of-stake": {
       "term": "DPoS",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/vi-VN/vi-VN.json
+++ b/locales/vi-VN/vi-VN.json
@@ -2156,7 +2156,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "consumer-price-index-(cpi)": {
+    "consumer-price-index": {
       "term": "Consumer Price Index (CPI)",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/vi-VN/vi-VN.json
+++ b/locales/vi-VN/vi-VN.json
@@ -3570,7 +3570,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "ethereum-2.0": {
+    "ethereum-2": {
       "term": "Ethereum 2.0",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/vi-VN/vi-VN.json
+++ b/locales/vi-VN/vi-VN.json
@@ -2786,7 +2786,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "delegated-proof-of-stake-(dpos)": {
+    "delegated-proof-of-stake": {
       "term": "Bằng chứng cổ phần được ủy quyền (DPoS)",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/zh-CN/zh-CN.json
+++ b/locales/zh-CN/zh-CN.json
@@ -2786,7 +2786,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "delegated-proof-of-stake-(dpos)": {
+    "delegated-proof-of-stake": {
       "term": "权益授权证明（DPoS）",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/zh-CN/zh-CN.json
+++ b/locales/zh-CN/zh-CN.json
@@ -3570,7 +3570,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "ethereum-2.0": {
+    "ethereum-2": {
       "term": "以太坊 2.0",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/zh-CN/zh-CN.json
+++ b/locales/zh-CN/zh-CN.json
@@ -2156,7 +2156,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "consumer-price-index-(cpi)": {
+    "consumer-price-index": {
       "term": "Consumer Price Index (CPI)",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/zh-TW/zh-TW.json
+++ b/locales/zh-TW/zh-TW.json
@@ -2156,7 +2156,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "consumer-price-index-(cpi)": {
+    "consumer-price-index": {
       "term": "Consumer Price Index (CPI)",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/zh-TW/zh-TW.json
+++ b/locales/zh-TW/zh-TW.json
@@ -3570,7 +3570,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "ethereum-2.0": {
+    "ethereum-2": {
       "term": "Ethereum 2.0",
       "partOfSpeech": "",
       "termCategory": "",

--- a/locales/zh-TW/zh-TW.json
+++ b/locales/zh-TW/zh-TW.json
@@ -2786,7 +2786,7 @@
       "dateFirstRecorded": "",
       "commentary": ""
     },
-    "delegated-proof-of-stake-(dpos)": {
+    "delegated-proof-of-stake": {
       "term": "DPoS",
       "partOfSpeech": "",
       "termCategory": "",

--- a/utils/additional-pages/resources.json
+++ b/utils/additional-pages/resources.json
@@ -82,7 +82,7 @@
           {
             "text": "Ethereum Improvement Proposals",
             "url": "https://eips.ethereum.org/",
-            "description": "The canonical source of truth regarding what's happened to the Ethereum network protocols. If you're confused about what this even means, see <a href='./english-us/ethereum-improvement-proposals.html'>here</a>."
+            "description": "The canonical source of truth regarding what's happened to the Ethereum network protocols. If you're confused about what this even means, see <a href='./english-us/ethereum-improvement-proposal.html'>here</a>."
           },
           {
             "text": "Ethereum Rollup Improvement Proposals",


### PR DESCRIPTION
Some Binance term keys ended up with parentheses in them. This can screw things up. Removing them.